### PR TITLE
fix(makefile): add LDFLAGS, per-component targets, release target, fix lint path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,45 @@
-.PHONY: build test lint proto clean
+VERSION ?= $(shell git describe --tags --always --dirty)
+LDFLAGS := -ldflags "-X main.version=$(VERSION)"
 
-build:
-	go build -o bin/axon ./cmd/axon
-	go build -o bin/axon-server ./cmd/axon-server
-	go build -o bin/axon-agent ./cmd/axon-agent
+PLATFORMS := linux/amd64 linux/arm64 darwin/amd64 darwin/arm64
+BINARIES := axon axon-server axon-agent
+
+.PHONY: build build-cli build-server build-agent test lint proto clean release
+
+build: build-cli build-server build-agent
+
+build-cli:
+	go build $(LDFLAGS) -o bin/axon ./cmd/axon
+
+build-server:
+	go build $(LDFLAGS) -o bin/axon-server ./cmd/axon-server
+
+build-agent:
+	go build $(LDFLAGS) -o bin/axon-agent ./cmd/axon-agent
 
 test:
 	go test ./... -race -cover
 
 lint:
-	golangci-lint run
+	golangci-lint run ./...
 
 proto:
-	@echo "proto generation not yet implemented"
+	bash scripts/proto-gen.sh
 
 clean:
-	rm -rf bin/
+	rm -rf bin/ dist/
+
+release:
+	@mkdir -p dist
+	@for platform in $(PLATFORMS); do \
+		os=$${platform%%/*}; \
+		arch=$${platform##*/}; \
+		for bin in $(BINARIES); do \
+			cmd_dir=cmd/$${bin}; \
+			output=dist/$${bin}-$${os}-$${arch}; \
+			if [ "$${os}" = "windows" ]; then output=$${output}.exe; fi; \
+			echo "Building $${output}..."; \
+			GOOS=$${os} GOARCH=$${arch} go build $(LDFLAGS) -o $${output} ./$${cmd_dir}; \
+		done; \
+	done
+	@echo "Release binaries in dist/"


### PR DESCRIPTION
## Fix: Makefile improvements per Planner review on PR #2

Addresses all 4 review comments:

1. ✅ **LDFLAGS version injection** — `-X main.version=$(VERSION)` via `git describe`
2. ✅ **Per-component build targets** — `build-cli`, `build-server`, `build-agent`
3. ✅ **Release target** — cross-compile linux/darwin × amd64/arm64, output to `dist/`
4. ✅ **Lint path fix** — `golangci-lint run ./...`

Also updated `proto` target to call `scripts/proto-gen.sh` instead of placeholder echo.