### PR TITLE
ci: add CI pipeline with lint, test, build, and proto validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,9 +72,10 @@ jobs:
           go-version-file: go.mod
 
       - name: Install protoc
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y protobuf-compiler
+        uses: arduino/setup-protoc@v3
+        with:
+          version: "29.x"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Go protoc plugins
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,10 +72,13 @@ jobs:
           go-version-file: go.mod
 
       - name: Install protoc
-        uses: arduino/setup-protoc@v3
-        with:
-          version: "29.x"
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+        env:
+          PROTOC_VERSION: "34.0"
+        run: |
+          curl -fsSL "https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-x86_64.zip" -o /tmp/protoc.zip
+          sudo unzip -o /tmp/protoc.zip -d /usr/local bin/protoc
+          sudo chmod +x /usr/local/bin/protoc
+          protoc --version
 
       - name: Install Go protoc plugins
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,92 @@
+name: CI
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+    branches: [dev, main]
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: latest
+
+  test:
+    name: Test (Go ${{ matrix.go-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go-version: ["1.25"]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: ${{ matrix.go-version }}
+
+      - name: Run tests
+        run: go test ./... -race -cover -coverprofile=coverage.out
+
+      - name: Upload coverage
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-go${{ matrix.go-version }}
+          path: coverage.out
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Build all binaries
+        run: make build
+
+  proto-check:
+    name: Proto Validation
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Install protoc
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y protobuf-compiler
+
+      - name: Install Go protoc plugins
+        run: |
+          go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
+          go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest
+
+      - name: Generate proto
+        run: make proto
+
+      - name: Check no diff
+        run: |
+          if ! git diff --exit-code gen/; then
+            echo "::error::Generated proto code is out of date. Run 'make proto' and commit."
+            exit 1
+          fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,9 +21,9 @@ jobs:
           go-version-file: go.mod
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v7
         with:
-          version: latest
+          version: v2.11.3
 
   test:
     name: Test (Go ${{ matrix.go-version }})

--- a/pkg/audit/audit_test.go
+++ b/pkg/audit/audit_test.go
@@ -13,7 +13,7 @@ func newTestStore(t *testing.T) *Store {
 	if err != nil {
 		t.Fatalf("NewStore: %v", err)
 	}
-	t.Cleanup(func() { s.Close() })
+	t.Cleanup(func() { _ = s.Close() })
 	return s
 }
 
@@ -253,7 +253,7 @@ func TestWriter_BufferFullDropsEntries(t *testing.T) {
 func TestWriter_ImplementsAuditor(t *testing.T) {
 	s := newTestStore(t)
 	w := NewWriter(s, 8)
-	defer w.Close()
+	defer func() { _ = w.Close() }()
 	// Compile-time interface check.
 	var _ Auditor = w
 	var _ Auditor = s

--- a/pkg/audit/store.go
+++ b/pkg/audit/store.go
@@ -38,7 +38,7 @@ func NewStore(dbPath string) (*Store, error) {
 		return nil, fmt.Errorf("audit: open db: %w", err)
 	}
 	if _, err := db.Exec(schema); err != nil {
-		db.Close()
+		_ = db.Close()
 		return nil, fmt.Errorf("audit: migrate schema: %w", err)
 	}
 	return &Store{db: db}, nil
@@ -105,7 +105,7 @@ func (s *Store) Query(opts QueryOptions) ([]AuditEntry, error) {
 	if err != nil {
 		return nil, fmt.Errorf("audit: query: %w", err)
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 
 	var entries []AuditEntry
 	for rows.Next() {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -18,7 +18,7 @@ func writeTemp(t *testing.T, content string) string {
 	if _, err := f.WriteString(content); err != nil {
 		t.Fatalf("write temp file: %v", err)
 	}
-	f.Close()
+	_ = f.Close()
 	return f.Name()
 }
 


### PR DESCRIPTION
## What

Add GitHub Actions CI pipeline (`.github/workflows/ci.yml`) covering tasks Q-1 and Q-2.

## Jobs

| Job | Description |
|-----|-------------|
| **lint** | golangci-lint via official action |
| **test** | `go test ./... -race -cover` with coverage artifact upload (Go version matrix) |
| **build** | `make build` — compile all three binaries |
| **proto-check** | Install protoc + plugins → `make proto` → verify no diff in `gen/` |

## Triggers

- **push**: all branches
- **pull_request**: to `dev` and `main`

## Tasks

- [x] Q-1: CI pipeline (lint + test + build)
- [x] Q-2: Proto validation (generated code consistency check)

## Testing

- Local `make build` ✅
- Local `make test` ✅ (all packages pass)