### PR TITLE
feat(server): add gRPC server and ControlService implementation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.25.0
 
 require (
 	github.com/golang-jwt/jwt/v5 v5.2.1
+	github.com/google/uuid v1.6.0
 	google.golang.org/grpc v1.79.3
 	google.golang.org/protobuf v1.36.11
 	gopkg.in/yaml.v3 v3.0.1
@@ -12,7 +13,6 @@ require (
 
 require (
 	github.com/dustin/go-humanize v1.0.1 // indirect
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/ncruces/go-strftime v1.0.0 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect

--- a/internal/server/bufconn_test.go
+++ b/internal/server/bufconn_test.go
@@ -1,0 +1,22 @@
+package server
+
+import (
+	"net"
+
+	"google.golang.org/grpc/test/bufconn"
+)
+
+// bufListener wraps a bufconn.Listener and exposes a Dial method that returns
+// an in-memory net.Conn. This avoids any real network usage in tests.
+type bufListener struct {
+	*bufconn.Listener
+}
+
+func newBufListener(size int) *bufListener {
+	return &bufListener{bufconn.Listen(size)}
+}
+
+// Dial returns a new in-memory connection to the listener.
+func (b *bufListener) Dial() (net.Conn, error) {
+	return b.Listener.Dial()
+}

--- a/internal/server/control.go
+++ b/internal/server/control.go
@@ -1,0 +1,195 @@
+package server
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"time"
+
+	"github.com/google/uuid"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	controlpb "github.com/garysng/axon/gen/proto/control"
+	"github.com/garysng/axon/internal/server/registry"
+	"github.com/garysng/axon/pkg/auth"
+)
+
+// ControlService implements controlpb.ControlServiceServer.
+type ControlService struct {
+	controlpb.UnimplementedControlServiceServer
+	reg *registry.Registry
+	cfg ServerConfig
+}
+
+var _ controlpb.ControlServiceServer = (*ControlService)(nil)
+
+func newControlService(reg *registry.Registry, cfg ServerConfig) *ControlService {
+	return &ControlService{reg: reg, cfg: cfg}
+}
+
+// Connect handles the bidirectional streaming control channel between the
+// server and an agent. The protocol is:
+//
+//  1. First message must be a RegisterRequest with a valid agent token.
+//  2. Subsequent messages may be Heartbeat or NodeInfo.
+//  3. On disconnect the node is marked offline.
+func (cs *ControlService) Connect(stream controlpb.ControlService_ConnectServer) error {
+	// ── Step 1: expect RegisterRequest ────────────────────────────────────────
+	first, err := stream.Recv()
+	if err != nil {
+		return status.Errorf(codes.Internal, "control: read first message: %v", err)
+	}
+
+	reg, ok := first.Payload.(*controlpb.AgentMessage_Register)
+	if !ok || reg.Register == nil {
+		return status.Error(codes.InvalidArgument, "control: first message must be RegisterRequest")
+	}
+	req := reg.Register
+
+	// Validate agent token.
+	claims, err := auth.ValidateToken(cs.cfg.JWTSecret, req.Token)
+	if err != nil {
+		_ = stream.Send(&controlpb.ServerMessage{
+			Payload: &controlpb.ServerMessage_RegisterResponse{
+				RegisterResponse: &controlpb.RegisterResponse{
+					Success: false,
+					Error:   "invalid token",
+				},
+			},
+		})
+		return status.Errorf(codes.Unauthenticated, "control: invalid agent token: %v", err)
+	}
+	_ = claims // claims available for future use (e.g. ACLs)
+
+	// Assign a node ID and register.
+	nodeID := uuid.NewString()
+	info := protoNodeInfoToRegistry(req.Info)
+	if err := cs.reg.Register(nodeID, req.NodeName, info); err != nil {
+		return status.Errorf(codes.Internal, "control: register node: %v", err)
+	}
+
+	// Persist the stream so task signals can be dispatched later.
+	if err := cs.reg.SetStream(nodeID, stream); err != nil {
+		return status.Errorf(codes.Internal, "control: set stream: %v", err)
+	}
+
+	// Mark node offline on disconnect (regardless of reason).
+	defer func() {
+		if err := cs.reg.MarkOffline(nodeID); err != nil {
+			log.Printf("control: mark offline %s: %v", nodeID, err)
+		}
+	}()
+
+	// Send RegisterResponse.
+	intervalSec := int32(cs.cfg.HeartbeatInterval / time.Second)
+	if intervalSec == 0 {
+		intervalSec = 30
+	}
+	if err := stream.Send(&controlpb.ServerMessage{
+		Payload: &controlpb.ServerMessage_RegisterResponse{
+			RegisterResponse: &controlpb.RegisterResponse{
+				Success:                  true,
+				NodeId:                   nodeID,
+				HeartbeatIntervalSeconds: intervalSec,
+			},
+		},
+	}); err != nil {
+		return status.Errorf(codes.Internal, "control: send register response: %v", err)
+	}
+
+	// ── Step 2: message loop ───────────────────────────────────────────────────
+	for {
+		msg, err := stream.Recv()
+		if err == io.EOF {
+			return nil
+		}
+		if err != nil {
+			// Connection closed by client or network error.
+			return nil //nolint:nilerr // disconnect is expected
+		}
+
+		switch p := msg.Payload.(type) {
+		case *controlpb.AgentMessage_Heartbeat:
+			_ = p
+			if err := cs.reg.UpdateHeartbeat(nodeID); err != nil {
+				log.Printf("control: update heartbeat %s: %v", nodeID, err)
+			}
+			if err := stream.Send(&controlpb.ServerMessage{
+				Payload: &controlpb.ServerMessage_HeartbeatAck{
+					HeartbeatAck: &controlpb.HeartbeatAck{
+						ServerTimestamp: time.Now().UnixMilli(),
+					},
+				},
+			}); err != nil {
+				return nil // client gone
+			}
+
+		case *controlpb.AgentMessage_NodeInfo:
+			if p.NodeInfo != nil {
+				info := protoNodeInfoToRegistry(p.NodeInfo)
+				// Re-register to update node info while preserving node ID.
+				// UpdateInfo is not yet in the registry API, so we use Register
+				// which updates fields on an existing entry.
+				nodeName := ""
+				if entry, ok := cs.reg.Lookup(nodeID); ok {
+					nodeName = entry.NodeName
+				}
+				if err := cs.reg.Register(nodeID, nodeName, info); err != nil {
+					log.Printf("control: update node info %s: %v", nodeID, err)
+				}
+				// Restore stream reference (Register clears it on re-register).
+				if err := cs.reg.SetStream(nodeID, stream); err != nil {
+					log.Printf("control: restore stream %s: %v", nodeID, err)
+				}
+			}
+
+		default:
+			// Unknown payload type; ignore.
+		}
+	}
+}
+
+// SendTaskSignal dispatches a TaskSignal to the agent identified by nodeID.
+func (cs *ControlService) SendTaskSignal(nodeID, taskID string, taskType controlpb.TaskType) error {
+	raw, ok := cs.reg.GetStream(nodeID)
+	if !ok {
+		return fmt.Errorf("control: send task signal: node %q has no active stream", nodeID)
+	}
+	stream, ok := raw.(controlpb.ControlService_ConnectServer)
+	if !ok {
+		return fmt.Errorf("control: send task signal: invalid stream type for node %q", nodeID)
+	}
+	return stream.Send(&controlpb.ServerMessage{
+		Payload: &controlpb.ServerMessage_TaskSignal{
+			TaskSignal: &controlpb.TaskSignal{
+				TaskId: taskID,
+				Type:   taskType,
+			},
+		},
+	})
+}
+
+// protoNodeInfoToRegistry converts a protobuf NodeInfo to the registry type.
+func protoNodeInfoToRegistry(info *controlpb.NodeInfo) registry.NodeInfo {
+	if info == nil {
+		return registry.NodeInfo{}
+	}
+	ri := registry.NodeInfo{
+		Hostname:      info.Hostname,
+		Arch:          info.Arch,
+		IP:            info.Ip,
+		UptimeSeconds: info.UptimeSeconds,
+		AgentVersion:  info.AgentVersion,
+	}
+	if info.OsInfo != nil {
+		ri.OSInfo = registry.OSInfo{
+			OS:              info.OsInfo.Os,
+			OSVersion:       info.OsInfo.OsVersion,
+			Platform:        info.OsInfo.Platform,
+			PlatformVersion: info.OsInfo.PlatformVersion,
+			PrettyName:      info.OsInfo.PrettyName,
+		}
+	}
+	return ri
+}

--- a/internal/server/control_test.go
+++ b/internal/server/control_test.go
@@ -1,0 +1,342 @@
+package server
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+
+	controlpb "github.com/garysng/axon/gen/proto/control"
+	"github.com/garysng/axon/internal/server/registry"
+	"github.com/garysng/axon/pkg/auth"
+)
+
+const (
+	testSecret    = "test-jwt-secret"
+	testNodeName  = "test-node"
+	bufSize       = 1024 * 1024
+)
+
+// testEnv holds all the pieces needed by a single test case.
+type testEnv struct {
+	server *Server
+	client controlpb.ControlServiceClient
+	cancel context.CancelFunc
+}
+
+// newTestEnv spins up a gRPC server backed by an in-process bufconn listener.
+// The server stops when the returned cancel function is called.
+func newTestEnv(t *testing.T) *testEnv {
+	t.Helper()
+
+	cfg := ServerConfig{
+		JWTSecret:         testSecret,
+		HeartbeatInterval: 30 * time.Second,
+		HeartbeatTimeout:  5 * time.Minute,
+	}
+
+	srv := NewServer(cfg)
+
+	// Build the internal components manually so we can use a custom listener.
+	srv.registry = registry.NewRegistry(cfg.HeartbeatTimeout)
+	srv.control = newControlService(srv.registry, cfg)
+
+	opts, err := srv.buildServerOptions()
+	if err != nil {
+		t.Fatalf("buildServerOptions: %v", err)
+	}
+	srv.grpc = grpc.NewServer(opts...)
+	controlpb.RegisterControlServiceServer(srv.grpc, srv.control)
+
+	// In-memory listener.
+	lis := newBufListener(bufSize)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	srv.registry.StartMonitor(ctx)
+
+	go func() {
+		_ = srv.grpc.Serve(lis)
+	}()
+
+	// Dial using the bufconn dialer.
+	conn, err := grpc.NewClient(
+		"passthrough://bufnet",
+		grpc.WithContextDialer(func(ctx context.Context, _ string) (net.Conn, error) {
+			return lis.Dial()
+		}),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	if err != nil {
+		cancel()
+		t.Fatalf("grpc.NewClient: %v", err)
+	}
+
+	t.Cleanup(func() {
+		cancel()
+		srv.grpc.Stop()
+		conn.Close()
+	})
+
+	return &testEnv{
+		server: srv,
+		client: controlpb.NewControlServiceClient(conn),
+		cancel: cancel,
+	}
+}
+
+// validAgentToken generates a short-lived agent token for testing.
+func validAgentToken(t *testing.T) string {
+	t.Helper()
+	tok, err := auth.SignAgentToken(testSecret, "pre-node", time.Hour)
+	if err != nil {
+		t.Fatalf("SignAgentToken: %v", err)
+	}
+	return tok
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────
+
+func TestConnect_RegisterSuccess(t *testing.T) {
+	env := newTestEnv(t)
+
+	stream, err := env.client.Connect(context.Background())
+	if err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+
+	// Send RegisterRequest.
+	err = stream.Send(&controlpb.AgentMessage{
+		Payload: &controlpb.AgentMessage_Register{
+			Register: &controlpb.RegisterRequest{
+				Token:    validAgentToken(t),
+				NodeName: testNodeName,
+				Info: &controlpb.NodeInfo{
+					Hostname: "host-1",
+					Arch:     "amd64",
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Send RegisterRequest: %v", err)
+	}
+
+	// Receive RegisterResponse.
+	resp, err := stream.Recv()
+	if err != nil {
+		t.Fatalf("Recv RegisterResponse: %v", err)
+	}
+
+	rr := resp.GetRegisterResponse()
+	if rr == nil {
+		t.Fatal("expected RegisterResponse, got nil")
+	}
+	if !rr.Success {
+		t.Fatalf("expected success=true, got error: %s", rr.Error)
+	}
+	if rr.NodeId == "" {
+		t.Error("expected non-empty NodeId")
+	}
+	if rr.HeartbeatIntervalSeconds <= 0 {
+		t.Error("expected positive HeartbeatIntervalSeconds")
+	}
+
+	// Verify node is in registry.
+	nodeID := rr.NodeId
+	entry, ok := env.server.Registry().Lookup(nodeID)
+	if !ok {
+		t.Fatalf("node %s not found in registry", nodeID)
+	}
+	if entry.Status != registry.StatusOnline {
+		t.Errorf("status = %q, want %q", entry.Status, registry.StatusOnline)
+	}
+	if entry.NodeName != testNodeName {
+		t.Errorf("NodeName = %q, want %q", entry.NodeName, testNodeName)
+	}
+}
+
+func TestConnect_HeartbeatAck(t *testing.T) {
+	env := newTestEnv(t)
+
+	stream, err := env.client.Connect(context.Background())
+	if err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+
+	// Register first.
+	if err := stream.Send(&controlpb.AgentMessage{
+		Payload: &controlpb.AgentMessage_Register{
+			Register: &controlpb.RegisterRequest{
+				Token:    validAgentToken(t),
+				NodeName: "hb-node",
+			},
+		},
+	}); err != nil {
+		t.Fatalf("Send register: %v", err)
+	}
+	regResp, err := stream.Recv()
+	if err != nil {
+		t.Fatalf("Recv register resp: %v", err)
+	}
+	if !regResp.GetRegisterResponse().Success {
+		t.Fatal("registration failed")
+	}
+
+	// Send Heartbeat.
+	before := time.Now().UnixMilli()
+	if err := stream.Send(&controlpb.AgentMessage{
+		Payload: &controlpb.AgentMessage_Heartbeat{
+			Heartbeat: &controlpb.Heartbeat{Timestamp: before},
+		},
+	}); err != nil {
+		t.Fatalf("Send Heartbeat: %v", err)
+	}
+
+	// Receive HeartbeatAck.
+	ack, err := stream.Recv()
+	if err != nil {
+		t.Fatalf("Recv HeartbeatAck: %v", err)
+	}
+	ha := ack.GetHeartbeatAck()
+	if ha == nil {
+		t.Fatal("expected HeartbeatAck, got nil")
+	}
+	if ha.ServerTimestamp < before {
+		t.Errorf("server_timestamp %d < before %d", ha.ServerTimestamp, before)
+	}
+}
+
+func TestConnect_InvalidToken(t *testing.T) {
+	env := newTestEnv(t)
+
+	stream, err := env.client.Connect(context.Background())
+	if err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+
+	// Send RegisterRequest with a bad token.
+	if err := stream.Send(&controlpb.AgentMessage{
+		Payload: &controlpb.AgentMessage_Register{
+			Register: &controlpb.RegisterRequest{
+				Token:    "this.is.invalid",
+				NodeName: "bad-node",
+			},
+		},
+	}); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+
+	// The server should either send a failure response or close the stream with
+	// an Unauthenticated error.
+	resp, err := stream.Recv()
+	if err == nil {
+		// Server may send a failure RegisterResponse before closing.
+		rr := resp.GetRegisterResponse()
+		if rr != nil && rr.Success {
+			t.Fatal("expected registration to fail but got success=true")
+		}
+		// Next recv should return an error.
+		_, err = stream.Recv()
+	}
+	if err == nil {
+		t.Fatal("expected error for invalid token, got nil")
+	}
+}
+
+func TestConnect_NodeOfflineOnDisconnect(t *testing.T) {
+	env := newTestEnv(t)
+
+	stream, err := env.client.Connect(context.Background())
+	if err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+
+	// Register.
+	if err := stream.Send(&controlpb.AgentMessage{
+		Payload: &controlpb.AgentMessage_Register{
+			Register: &controlpb.RegisterRequest{
+				Token:    validAgentToken(t),
+				NodeName: "disc-node",
+			},
+		},
+	}); err != nil {
+		t.Fatalf("Send register: %v", err)
+	}
+	resp, err := stream.Recv()
+	if err != nil {
+		t.Fatalf("Recv register: %v", err)
+	}
+	nodeID := resp.GetRegisterResponse().NodeId
+	if nodeID == "" {
+		t.Fatal("empty NodeId")
+	}
+
+	// Close the client side of the stream.
+	_ = stream.CloseSend()
+
+	// Give the server goroutine time to handle the EOF.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		entry, ok := env.server.Registry().Lookup(nodeID)
+		if ok && entry.Status == registry.StatusOffline {
+			return // success
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	entry, _ := env.server.Registry().Lookup(nodeID)
+	t.Errorf("node status = %q after disconnect, want %q", entry.Status, registry.StatusOffline)
+}
+
+func TestConnect_NodeInfoUpdate(t *testing.T) {
+	env := newTestEnv(t)
+
+	stream, err := env.client.Connect(context.Background())
+	if err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+
+	// Register.
+	if err := stream.Send(&controlpb.AgentMessage{
+		Payload: &controlpb.AgentMessage_Register{
+			Register: &controlpb.RegisterRequest{
+				Token:    validAgentToken(t),
+				NodeName: "info-node",
+				Info:     &controlpb.NodeInfo{Hostname: "old-host"},
+			},
+		},
+	}); err != nil {
+		t.Fatalf("Send register: %v", err)
+	}
+	resp, err := stream.Recv()
+	if err != nil {
+		t.Fatalf("Recv register: %v", err)
+	}
+	nodeID := resp.GetRegisterResponse().NodeId
+
+	// Send NodeInfo update.
+	if err := stream.Send(&controlpb.AgentMessage{
+		Payload: &controlpb.AgentMessage_NodeInfo{
+			NodeInfo: &controlpb.NodeInfo{
+				Hostname: "new-host",
+				Arch:     "arm64",
+			},
+		},
+	}); err != nil {
+		t.Fatalf("Send NodeInfo: %v", err)
+	}
+
+	// Wait for registry to reflect update.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		entry, ok := env.server.Registry().Lookup(nodeID)
+		if ok && entry.Info.Hostname == "new-host" {
+			return // success
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	entry, _ := env.server.Registry().Lookup(nodeID)
+	t.Errorf("Hostname = %q after NodeInfo update, want %q", entry.Info.Hostname, "new-host")
+}

--- a/internal/server/registry/registry.go
+++ b/internal/server/registry/registry.go
@@ -1,0 +1,234 @@
+// Package registry provides an in-memory node registry with heartbeat monitoring.
+package registry
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+)
+
+// OSInfo holds detailed operating system information for a node.
+type OSInfo struct {
+	OS              string // Kernel name: "linux", "darwin", "windows"
+	OSVersion       string // Kernel version: "6.8.0-45-generic", "24.3.0"
+	Platform        string // Distribution/platform: "ubuntu", "centos", "macOS"
+	PlatformVersion string // Distribution version: "24.04", "9", "14.4"
+	PrettyName      string // Human-readable: "Ubuntu 24.04 LTS", "macOS 14.4 Sonoma"
+}
+
+// NodeInfo holds hardware and OS information reported by an agent.
+type NodeInfo struct {
+	Hostname     string
+	Arch         string // e.g. "amd64", "arm64"
+	IP           string // Primary IP
+	UptimeSeconds int64
+	AgentVersion  string
+	OSInfo       OSInfo
+}
+
+// NodeEntry represents a registered node in the registry.
+type NodeEntry struct {
+	NodeID        string
+	NodeName      string
+	Info          NodeInfo
+	Status        string // "online" | "offline"
+	ConnectedAt   time.Time
+	LastHeartbeat time.Time
+	RegisteredAt  time.Time
+	Labels        map[string]string
+	stream        interface{} // control stream reference, protected by Registry mutex
+}
+
+const (
+	StatusOnline  = "online"
+	StatusOffline = "offline"
+)
+
+// Registry is a thread-safe in-memory store of node entries.
+type Registry struct {
+	mu               sync.RWMutex
+	nodes            map[string]*NodeEntry // keyed by NodeID
+	heartbeatTimeout time.Duration
+}
+
+// NewRegistry creates a new Registry with the given heartbeat timeout.
+func NewRegistry(heartbeatTimeout time.Duration) *Registry {
+	return &Registry{
+		nodes:            make(map[string]*NodeEntry),
+		heartbeatTimeout: heartbeatTimeout,
+	}
+}
+
+// Register adds or updates a node entry, setting its status to online.
+func (r *Registry) Register(nodeID, nodeName string, info NodeInfo) error {
+	if nodeID == "" {
+		return fmt.Errorf("registry: register: nodeID must not be empty")
+	}
+	now := time.Now()
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if existing, ok := r.nodes[nodeID]; ok {
+		// Re-registration: update fields but preserve RegisteredAt.
+		existing.NodeName = nodeName
+		existing.Info = info
+		existing.Status = StatusOnline
+		existing.ConnectedAt = now
+		existing.LastHeartbeat = now
+		existing.stream = nil
+		return nil
+	}
+
+	r.nodes[nodeID] = &NodeEntry{
+		NodeID:        nodeID,
+		NodeName:      nodeName,
+		Info:          info,
+		Status:        StatusOnline,
+		ConnectedAt:   now,
+		LastHeartbeat: now,
+		RegisteredAt:  now,
+		Labels:        make(map[string]string),
+	}
+	return nil
+}
+
+// UpdateHeartbeat updates the LastHeartbeat timestamp for the given node.
+func (r *Registry) UpdateHeartbeat(nodeID string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	entry, ok := r.nodes[nodeID]
+	if !ok {
+		return fmt.Errorf("registry: update heartbeat: node %q not found", nodeID)
+	}
+	entry.LastHeartbeat = time.Now()
+	return nil
+}
+
+// MarkOffline sets the node's status to offline and clears its control stream.
+func (r *Registry) MarkOffline(nodeID string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	entry, ok := r.nodes[nodeID]
+	if !ok {
+		return fmt.Errorf("registry: mark offline: node %q not found", nodeID)
+	}
+	entry.Status = StatusOffline
+	entry.stream = nil
+	return nil
+}
+
+// Remove deletes a node entry entirely.
+func (r *Registry) Remove(nodeID string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if _, ok := r.nodes[nodeID]; !ok {
+		return fmt.Errorf("registry: remove: node %q not found", nodeID)
+	}
+	delete(r.nodes, nodeID)
+	return nil
+}
+
+// List returns a snapshot of all node entries.
+func (r *Registry) List() []NodeEntry {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	out := make([]NodeEntry, 0, len(r.nodes))
+	for _, e := range r.nodes {
+		out = append(out, *e)
+	}
+	return out
+}
+
+// Lookup returns a copy of the node entry for the given ID, if it exists.
+func (r *Registry) Lookup(nodeID string) (*NodeEntry, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	entry, ok := r.nodes[nodeID]
+	if !ok {
+		return nil, false
+	}
+	cp := *entry
+	return &cp, true
+}
+
+// LookupByName returns a copy of the first node entry matching the given name.
+func (r *Registry) LookupByName(nodeName string) (*NodeEntry, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	for _, e := range r.nodes {
+		if e.NodeName == nodeName {
+			cp := *e
+			return &cp, true
+		}
+	}
+	return nil, false
+}
+
+// SetStream associates a control stream with the given node.
+func (r *Registry) SetStream(nodeID string, stream interface{}) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	entry, ok := r.nodes[nodeID]
+	if !ok {
+		return fmt.Errorf("registry: set stream: node %q not found", nodeID)
+	}
+	entry.stream = stream
+	return nil
+}
+
+// GetStream returns the control stream associated with the given node.
+func (r *Registry) GetStream(nodeID string) (interface{}, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	entry, ok := r.nodes[nodeID]
+	if !ok {
+		return nil, false
+	}
+	return entry.stream, entry.stream != nil
+}
+
+// StartMonitor starts a background goroutine that periodically marks nodes
+// as offline when their LastHeartbeat exceeds the heartbeatTimeout. It stops
+// when ctx is cancelled.
+func (r *Registry) StartMonitor(ctx context.Context) {
+	go func() {
+		ticker := time.NewTicker(r.heartbeatTimeout / 2)
+		if r.heartbeatTimeout < 2*time.Millisecond {
+			// For very short timeouts (tests), poll more frequently.
+			ticker = time.NewTicker(r.heartbeatTimeout / 2)
+		}
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				r.sweepExpired()
+			}
+		}
+	}()
+}
+
+// sweepExpired marks all online nodes whose heartbeat has expired as offline.
+func (r *Registry) sweepExpired() {
+	now := time.Now()
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	for _, e := range r.nodes {
+		if e.Status == StatusOnline && now.Sub(e.LastHeartbeat) > r.heartbeatTimeout {
+			e.Status = StatusOffline
+			e.stream = nil
+		}
+	}
+}

--- a/internal/server/registry/registry_test.go
+++ b/internal/server/registry/registry_test.go
@@ -1,0 +1,392 @@
+package registry
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+)
+
+func sampleInfo() NodeInfo {
+	return NodeInfo{
+		Hostname:      "host-1",
+		Arch:          "amd64",
+		IP:            "10.0.0.1",
+		UptimeSeconds: 3600,
+		AgentVersion:  "0.1.0",
+		OSInfo: OSInfo{
+			OS:              "linux",
+			OSVersion:       "6.8.0",
+			Platform:        "ubuntu",
+			PlatformVersion: "24.04",
+			PrettyName:      "Ubuntu 24.04 LTS",
+		},
+	}
+}
+
+func TestRegisterAndLookup(t *testing.T) {
+	r := NewRegistry(30 * time.Second)
+
+	if err := r.Register("node-1", "web-1", sampleInfo()); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	entry, ok := r.Lookup("node-1")
+	if !ok {
+		t.Fatal("expected to find node-1")
+	}
+	if entry.NodeID != "node-1" {
+		t.Errorf("NodeID = %q, want %q", entry.NodeID, "node-1")
+	}
+	if entry.NodeName != "web-1" {
+		t.Errorf("NodeName = %q, want %q", entry.NodeName, "web-1")
+	}
+	if entry.Status != StatusOnline {
+		t.Errorf("Status = %q, want %q", entry.Status, StatusOnline)
+	}
+	if entry.Info.Hostname != "host-1" {
+		t.Errorf("Info.Hostname = %q, want %q", entry.Info.Hostname, "host-1")
+	}
+}
+
+func TestRegisterEmptyIDError(t *testing.T) {
+	r := NewRegistry(30 * time.Second)
+	if err := r.Register("", "web-1", sampleInfo()); err == nil {
+		t.Fatal("expected error for empty nodeID")
+	}
+}
+
+func TestLookupNotFound(t *testing.T) {
+	r := NewRegistry(30 * time.Second)
+	_, ok := r.Lookup("nonexistent")
+	if ok {
+		t.Fatal("expected not found")
+	}
+}
+
+func TestLookupByName(t *testing.T) {
+	r := NewRegistry(30 * time.Second)
+	if err := r.Register("node-1", "web-1", sampleInfo()); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	entry, ok := r.LookupByName("web-1")
+	if !ok {
+		t.Fatal("expected to find node by name web-1")
+	}
+	if entry.NodeID != "node-1" {
+		t.Errorf("NodeID = %q, want %q", entry.NodeID, "node-1")
+	}
+}
+
+func TestLookupByNameNotFound(t *testing.T) {
+	r := NewRegistry(30 * time.Second)
+	_, ok := r.LookupByName("unknown")
+	if ok {
+		t.Fatal("expected not found for unknown name")
+	}
+}
+
+func TestUpdateHeartbeat(t *testing.T) {
+	r := NewRegistry(30 * time.Second)
+	if err := r.Register("node-1", "web-1", sampleInfo()); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	before, _ := r.Lookup("node-1")
+	time.Sleep(5 * time.Millisecond)
+
+	if err := r.UpdateHeartbeat("node-1"); err != nil {
+		t.Fatalf("UpdateHeartbeat: %v", err)
+	}
+
+	after, _ := r.Lookup("node-1")
+	if !after.LastHeartbeat.After(before.LastHeartbeat) {
+		t.Error("expected LastHeartbeat to be updated")
+	}
+}
+
+func TestUpdateHeartbeatNotFound(t *testing.T) {
+	r := NewRegistry(30 * time.Second)
+	if err := r.UpdateHeartbeat("nonexistent"); err == nil {
+		t.Fatal("expected error for nonexistent node")
+	}
+}
+
+func TestMarkOffline(t *testing.T) {
+	r := NewRegistry(30 * time.Second)
+	if err := r.Register("node-1", "web-1", sampleInfo()); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	// Set a stream so we can verify it gets cleared.
+	if err := r.SetStream("node-1", "mock-stream"); err != nil {
+		t.Fatalf("SetStream: %v", err)
+	}
+
+	if err := r.MarkOffline("node-1"); err != nil {
+		t.Fatalf("MarkOffline: %v", err)
+	}
+
+	entry, _ := r.Lookup("node-1")
+	if entry.Status != StatusOffline {
+		t.Errorf("Status = %q, want %q", entry.Status, StatusOffline)
+	}
+
+	_, hasStream := r.GetStream("node-1")
+	if hasStream {
+		t.Error("expected stream to be cleared after MarkOffline")
+	}
+}
+
+func TestMarkOfflineNotFound(t *testing.T) {
+	r := NewRegistry(30 * time.Second)
+	if err := r.MarkOffline("nonexistent"); err == nil {
+		t.Fatal("expected error for nonexistent node")
+	}
+}
+
+func TestRemove(t *testing.T) {
+	r := NewRegistry(30 * time.Second)
+	if err := r.Register("node-1", "web-1", sampleInfo()); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	if err := r.Remove("node-1"); err != nil {
+		t.Fatalf("Remove: %v", err)
+	}
+
+	_, ok := r.Lookup("node-1")
+	if ok {
+		t.Fatal("expected node-1 to be removed")
+	}
+}
+
+func TestRemoveNotFound(t *testing.T) {
+	r := NewRegistry(30 * time.Second)
+	if err := r.Remove("nonexistent"); err == nil {
+		t.Fatal("expected error for nonexistent node")
+	}
+}
+
+func TestList(t *testing.T) {
+	r := NewRegistry(30 * time.Second)
+
+	for i := 1; i <= 3; i++ {
+		id := fmt.Sprintf("node-%d", i)
+		name := fmt.Sprintf("web-%d", i)
+		if err := r.Register(id, name, sampleInfo()); err != nil {
+			t.Fatalf("Register %s: %v", id, err)
+		}
+	}
+
+	entries := r.List()
+	if len(entries) != 3 {
+		t.Errorf("List returned %d entries, want 3", len(entries))
+	}
+}
+
+func TestListEmpty(t *testing.T) {
+	r := NewRegistry(30 * time.Second)
+	entries := r.List()
+	if len(entries) != 0 {
+		t.Errorf("expected empty list, got %d entries", len(entries))
+	}
+}
+
+func TestHeartbeatTimeout(t *testing.T) {
+	timeout := 50 * time.Millisecond
+	r := NewRegistry(timeout)
+
+	if err := r.Register("node-1", "web-1", sampleInfo()); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	r.StartMonitor(ctx)
+
+	// Wait long enough for the heartbeat to expire and the monitor to sweep.
+	time.Sleep(timeout*3 + 10*time.Millisecond)
+
+	entry, ok := r.Lookup("node-1")
+	if !ok {
+		t.Fatal("expected node-1 to still exist")
+	}
+	if entry.Status != StatusOffline {
+		t.Errorf("Status = %q, want %q after heartbeat timeout", entry.Status, StatusOffline)
+	}
+}
+
+func TestHeartbeatNotExpiredWhenUpdated(t *testing.T) {
+	timeout := 100 * time.Millisecond
+	r := NewRegistry(timeout)
+
+	if err := r.Register("node-1", "web-1", sampleInfo()); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	r.StartMonitor(ctx)
+
+	// Keep heartbeating every 20ms — well within the 100ms timeout.
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		ticker := time.NewTicker(20 * time.Millisecond)
+		defer ticker.Stop()
+		deadline := time.After(timeout * 2)
+		for {
+			select {
+			case <-ticker.C:
+				_ = r.UpdateHeartbeat("node-1")
+			case <-deadline:
+				return
+			}
+		}
+	}()
+	<-done
+
+	entry, _ := r.Lookup("node-1")
+	if entry.Status != StatusOnline {
+		t.Errorf("Status = %q, want %q — node should still be online", entry.Status, StatusOnline)
+	}
+}
+
+func TestMonitorStopsOnContextCancel(t *testing.T) {
+	timeout := 20 * time.Millisecond
+	r := NewRegistry(timeout)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	r.StartMonitor(ctx)
+
+	// Cancel immediately; this should not panic or deadlock.
+	cancel()
+	time.Sleep(50 * time.Millisecond) // give goroutine time to exit cleanly
+}
+
+func TestSetAndGetStream(t *testing.T) {
+	r := NewRegistry(30 * time.Second)
+	if err := r.Register("node-1", "web-1", sampleInfo()); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	// Initially no stream.
+	_, ok := r.GetStream("node-1")
+	if ok {
+		t.Error("expected no stream before SetStream")
+	}
+
+	mockStream := "mock-grpc-stream"
+	if err := r.SetStream("node-1", mockStream); err != nil {
+		t.Fatalf("SetStream: %v", err)
+	}
+
+	got, ok := r.GetStream("node-1")
+	if !ok {
+		t.Fatal("expected stream after SetStream")
+	}
+	if got != mockStream {
+		t.Errorf("GetStream = %v, want %v", got, mockStream)
+	}
+}
+
+func TestSetStreamNotFound(t *testing.T) {
+	r := NewRegistry(30 * time.Second)
+	if err := r.SetStream("nonexistent", "stream"); err == nil {
+		t.Fatal("expected error for nonexistent node")
+	}
+}
+
+func TestGetStreamNotFound(t *testing.T) {
+	r := NewRegistry(30 * time.Second)
+	_, ok := r.GetStream("nonexistent")
+	if ok {
+		t.Fatal("expected not found for nonexistent node")
+	}
+}
+
+func TestReRegister(t *testing.T) {
+	r := NewRegistry(30 * time.Second)
+	if err := r.Register("node-1", "web-1", sampleInfo()); err != nil {
+		t.Fatalf("first Register: %v", err)
+	}
+	if err := r.MarkOffline("node-1"); err != nil {
+		t.Fatalf("MarkOffline: %v", err)
+	}
+
+	// Re-register same node — should come back online.
+	newInfo := sampleInfo()
+	newInfo.AgentVersion = "0.2.0"
+	if err := r.Register("node-1", "web-1", newInfo); err != nil {
+		t.Fatalf("second Register: %v", err)
+	}
+
+	entry, _ := r.Lookup("node-1")
+	if entry.Status != StatusOnline {
+		t.Errorf("Status = %q, want %q after re-register", entry.Status, StatusOnline)
+	}
+	if entry.Info.AgentVersion != "0.2.0" {
+		t.Errorf("AgentVersion = %q, want %q", entry.Info.AgentVersion, "0.2.0")
+	}
+}
+
+func TestConcurrentSafety(t *testing.T) {
+	r := NewRegistry(30 * time.Second)
+
+	const numNodes = 20
+	const numWorkers = 10
+
+	// Pre-register nodes.
+	for i := 0; i < numNodes; i++ {
+		id := fmt.Sprintf("node-%d", i)
+		name := fmt.Sprintf("web-%d", i)
+		if err := r.Register(id, name, sampleInfo()); err != nil {
+			t.Fatalf("Register %s: %v", id, err)
+		}
+	}
+
+	var wg sync.WaitGroup
+
+	// Concurrent heartbeat updates.
+	for w := 0; w < numWorkers; w++ {
+		wg.Add(1)
+		go func(w int) {
+			defer wg.Done()
+			for i := 0; i < numNodes; i++ {
+				id := fmt.Sprintf("node-%d", i)
+				_ = r.UpdateHeartbeat(id)
+			}
+		}(w)
+	}
+
+	// Concurrent reads.
+	for w := 0; w < numWorkers; w++ {
+		wg.Add(1)
+		go func(w int) {
+			defer wg.Done()
+			for i := 0; i < numNodes; i++ {
+				id := fmt.Sprintf("node-%d", i)
+				_, _ = r.Lookup(id)
+				_ = r.List()
+			}
+		}(w)
+	}
+
+	// Concurrent stream sets.
+	for w := 0; w < numWorkers; w++ {
+		wg.Add(1)
+		go func(w int) {
+			defer wg.Done()
+			for i := 0; i < numNodes; i++ {
+				id := fmt.Sprintf("node-%d", i)
+				_ = r.SetStream(id, "stream")
+				_, _ = r.GetStream(id)
+			}
+		}(w)
+	}
+
+	wg.Wait()
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1,0 +1,141 @@
+// Package server provides the gRPC server and control plane implementation.
+package server
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"net"
+	"time"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+
+	controlpb "github.com/garysng/axon/gen/proto/control"
+	"github.com/garysng/axon/internal/server/registry"
+	"github.com/garysng/axon/pkg/auth"
+)
+
+// ServerConfig holds configuration for the gRPC server.
+type ServerConfig struct {
+	ListenAddr         string
+	TLSCertPath        string
+	TLSKeyPath         string
+	JWTSecret          string
+	HeartbeatInterval  time.Duration
+	HeartbeatTimeout   time.Duration
+}
+
+// Server wraps a gRPC server with its dependencies.
+type Server struct {
+	cfg      ServerConfig
+	grpc     *grpc.Server
+	registry *registry.Registry
+	control  *ControlService
+}
+
+// NewServer creates a new Server with the given configuration.
+func NewServer(cfg ServerConfig) *Server {
+	return &Server{cfg: cfg}
+}
+
+// Start initialises and starts the gRPC server, blocking until ctx is
+// cancelled or the listener fails. It registers all services before
+// accepting connections.
+func (s *Server) Start(ctx context.Context) error {
+	lis, err := net.Listen("tcp", s.cfg.ListenAddr)
+	if err != nil {
+		return fmt.Errorf("server: listen %s: %w", s.cfg.ListenAddr, err)
+	}
+	return s.serve(ctx, lis)
+}
+
+// serve is the internal implementation shared by Start and test helpers
+// that supply their own net.Listener (e.g. bufconn).
+func (s *Server) serve(ctx context.Context, lis net.Listener) error {
+	opts, err := s.buildServerOptions()
+	if err != nil {
+		return err
+	}
+
+	s.grpc = grpc.NewServer(opts...)
+
+	// Build registry and control service.
+	s.registry = registry.NewRegistry(s.cfg.HeartbeatTimeout)
+	s.control = newControlService(s.registry, s.cfg)
+
+	controlpb.RegisterControlServiceServer(s.grpc, s.control)
+
+	// Start heartbeat monitor; it stops when ctx is cancelled.
+	s.registry.StartMonitor(ctx)
+
+	// Stop the gRPC server when the context is cancelled.
+	go func() {
+		<-ctx.Done()
+		s.grpc.GracefulStop()
+	}()
+
+	if err := s.grpc.Serve(lis); err != nil {
+		// GracefulStop causes Serve to return nil; any other error is real.
+		return fmt.Errorf("server: serve: %w", err)
+	}
+	return nil
+}
+
+// GracefulStop shuts down the gRPC server gracefully.
+func (s *Server) GracefulStop() {
+	if s.grpc != nil {
+		s.grpc.GracefulStop()
+	}
+}
+
+// Registry returns the node registry used by this server.
+func (s *Server) Registry() *registry.Registry {
+	return s.registry
+}
+
+// buildServerOptions constructs the gRPC server options, including TLS and auth
+// interceptors.
+func (s *Server) buildServerOptions() ([]grpc.ServerOption, error) {
+	var opts []grpc.ServerOption
+
+	// TLS is optional; only enabled when both cert and key paths are provided.
+	if s.cfg.TLSCertPath != "" && s.cfg.TLSKeyPath != "" {
+		cert, err := tls.LoadX509KeyPair(s.cfg.TLSCertPath, s.cfg.TLSKeyPath)
+		if err != nil {
+			return nil, fmt.Errorf("server: load TLS keypair: %w", err)
+		}
+		creds := credentials.NewTLS(&tls.Config{
+			Certificates: []tls.Certificate{cert},
+			MinVersion:   tls.VersionTLS12,
+		})
+		opts = append(opts, grpc.Creds(creds))
+	}
+
+	// The ControlService/Connect stream handles its own token validation, so the
+	// generic auth interceptors protect all other methods.
+	opts = append(opts,
+		grpc.ChainUnaryInterceptor(auth.UnaryInterceptor(s.cfg.JWTSecret)),
+		grpc.ChainStreamInterceptor(skipConnectStreamInterceptor(s.cfg.JWTSecret)),
+	)
+
+	return opts, nil
+}
+
+// skipConnectStreamInterceptor wraps auth.StreamInterceptor but bypasses JWT
+// auth for the ControlService/Connect method (which validates its own token
+// inside the handler).
+func skipConnectStreamInterceptor(secret string) grpc.StreamServerInterceptor {
+	inner := auth.StreamInterceptor(secret)
+	return func(
+		srv interface{},
+		ss grpc.ServerStream,
+		info *grpc.StreamServerInfo,
+		handler grpc.StreamHandler,
+	) error {
+		if info.FullMethod == controlpb.ControlService_Connect_FullMethodName {
+			return handler(srv, ss)
+		}
+		return inner(srv, ss, info, handler)
+	}
+}


### PR DESCRIPTION
## Task C-7: Server gRPC + Control Plane

### What
- `internal/server/server.go`: gRPC server with optional TLS, auth interceptors, graceful shutdown
- `internal/server/control.go`: ControlService.Connect() bidirectional stream handler
  - Agent registration flow (validate token → UUID node_id → register → respond)
  - Heartbeat handling (update registry → ack)
  - NodeInfo updates
  - Auto mark-offline on disconnect
  - SendTaskSignal() for future task dispatch
- Custom stream interceptor that skips auth for Connect() (agent uses own token in RegisterRequest)

### Tests
5 integration tests using bufconn (in-memory gRPC, no real network), all pass with `-race` ✅
- Register success + registry state
- Heartbeat ack
- Invalid token rejection
- Node offline on disconnect
- NodeInfo update

### Depends on
- C-2 Proto (in dev) ✅
- C-3 Auth (in dev) ✅
- C-6 Registry — PR #9 (included in this branch)

### Next
C-8: Server router + Operations bridge