### PR TITLE
feat(agent): add exec handler with process management

### DIFF
--- a/internal/agent/exec.go
+++ b/internal/agent/exec.go
@@ -51,6 +51,20 @@ func (h *ExecHandler) Handle(ctx context.Context, req *operationspb.ExecRequest,
 	// Enable process group kill so child processes are cleaned up.
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 
+	// Use cmd.Cancel to SIGTERM the process group on context cancellation,
+	// and WaitDelay to escalate to SIGKILL after the grace period.
+	cmd.Cancel = func() error {
+		if cmd.Process == nil {
+			return nil
+		}
+		pgid, err := syscall.Getpgid(cmd.Process.Pid)
+		if err != nil {
+			return cmd.Process.Kill()
+		}
+		return syscall.Kill(-pgid, syscall.SIGTERM)
+	}
+	cmd.WaitDelay = killGracePeriod
+
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
 		sendError(send, fmt.Sprintf("stdout pipe: %v", err))
@@ -97,17 +111,17 @@ func (h *ExecHandler) Handle(ctx context.Context, req *operationspb.ExecRequest,
 	var exitErr string
 
 	if err := cmd.Wait(); err != nil {
-		if exitError, ok := err.(*exec.ExitError); ok {
-			exitCode = exitError.ExitCode()
-		} else if ctx.Err() != nil {
-			// Context cancelled or timed out — kill the process group.
-			killProcessGroup(cmd)
+		if ctx.Err() != nil {
+			// Context cancelled or timed out — process group already killed
+			// via cmd.Cancel / cmd.WaitDelay.
 			exitCode = -1
 			if ctx.Err() == context.DeadlineExceeded {
 				exitErr = "timeout exceeded"
 			} else {
 				exitErr = "cancelled"
 			}
+		} else if exitError, ok := err.(*exec.ExitError); ok {
+			exitCode = exitError.ExitCode()
 		} else {
 			exitCode = -1
 			exitErr = err.Error()
@@ -156,37 +170,6 @@ func sendError(send func(*operationspb.ExecOutput) error, msg string) {
 	})
 }
 
-// killProcessGroup sends SIGTERM to the process group, waits killGracePeriod,
-// then sends SIGKILL if the process is still running.
-func killProcessGroup(cmd *exec.Cmd) {
-	if cmd.Process == nil {
-		return
-	}
-	pgid, err := syscall.Getpgid(cmd.Process.Pid)
-	if err != nil {
-		// Fallback: kill the process directly.
-		_ = cmd.Process.Kill()
-		return
-	}
-
-	// Send SIGTERM to the process group.
-	_ = syscall.Kill(-pgid, syscall.SIGTERM)
-
-	// Wait briefly, then SIGKILL if still alive.
-	done := make(chan struct{})
-	go func() {
-		_, _ = cmd.Process.Wait()
-		close(done)
-	}()
-
-	select {
-	case <-done:
-		return
-	case <-time.After(killGracePeriod):
-		_ = syscall.Kill(-pgid, syscall.SIGKILL)
-	}
-}
-
 // shellCommand returns the shell binary and flag for the current platform.
 func shellCommand() (string, string) {
 	if runtime.GOOS == "windows" {
@@ -199,11 +182,8 @@ func shellCommand() (string, string) {
 // with the provided overrides.
 func buildEnv(overrides map[string]string) []string {
 	// Start with current environment.
-	env := make([]string, 0)
-	for _, e := range syscall.Environ() {
-		env = append(env, e)
-	}
-	// Apply overrides.
+	env := append([]string{}, syscall.Environ()...)
+	// Apply overrides (appended last; Go exec uses last-wins for duplicate keys).
 	for k, v := range overrides {
 		env = append(env, k+"="+v)
 	}

--- a/internal/agent/exec.go
+++ b/internal/agent/exec.go
@@ -1,0 +1,211 @@
+package agent
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"os/exec"
+	"runtime"
+	"sync"
+	"syscall"
+	"time"
+
+	operationspb "github.com/garysng/axon/gen/proto/operations"
+)
+
+const (
+	// killGracePeriod is the time to wait after SIGTERM before sending SIGKILL.
+	killGracePeriod = 5 * time.Second
+
+	// streamBufSize is the buffer size for stdout/stderr readers.
+	streamBufSize = 32 * 1024
+)
+
+// ExecHandler processes an ExecRequest by spawning a local process, streaming
+// stdout/stderr back, and forwarding the exit code.
+type ExecHandler struct{}
+
+// Handle runs the command described by req and streams output via send.
+// It respects ctx cancellation and req.TimeoutSeconds.
+func (h *ExecHandler) Handle(ctx context.Context, req *operationspb.ExecRequest, send func(*operationspb.ExecOutput) error) {
+	if req.TimeoutSeconds > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, time.Duration(req.TimeoutSeconds)*time.Second)
+		defer cancel()
+	}
+
+	shell, flag := shellCommand()
+	cmd := exec.CommandContext(ctx, shell, flag, req.Command)
+
+	// Set working directory if specified.
+	if req.WorkingDir != "" {
+		cmd.Dir = req.WorkingDir
+	}
+
+	// Set environment variables (inherit current env + overrides).
+	if len(req.Env) > 0 {
+		cmd.Env = buildEnv(req.Env)
+	}
+
+	// Enable process group kill so child processes are cleaned up.
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		sendError(send, fmt.Sprintf("stdout pipe: %v", err))
+		return
+	}
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		sendError(send, fmt.Sprintf("stderr pipe: %v", err))
+		return
+	}
+
+	if err := cmd.Start(); err != nil {
+		sendError(send, fmt.Sprintf("start: %v", err))
+		return
+	}
+
+	// Stream stdout and stderr concurrently.
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	go func() {
+		defer wg.Done()
+		streamOutput(stdout, func(data []byte) error {
+			return send(&operationspb.ExecOutput{
+				Payload: &operationspb.ExecOutput_Stdout{Stdout: data},
+			})
+		})
+	}()
+
+	go func() {
+		defer wg.Done()
+		streamOutput(stderr, func(data []byte) error {
+			return send(&operationspb.ExecOutput{
+				Payload: &operationspb.ExecOutput_Stderr{Stderr: data},
+			})
+		})
+	}()
+
+	// Wait for all output to be consumed before calling cmd.Wait.
+	wg.Wait()
+
+	// Wait for process exit.
+	exitCode := 0
+	var exitErr string
+
+	if err := cmd.Wait(); err != nil {
+		if exitError, ok := err.(*exec.ExitError); ok {
+			exitCode = exitError.ExitCode()
+		} else if ctx.Err() != nil {
+			// Context cancelled or timed out — kill the process group.
+			killProcessGroup(cmd)
+			exitCode = -1
+			if ctx.Err() == context.DeadlineExceeded {
+				exitErr = "timeout exceeded"
+			} else {
+				exitErr = "cancelled"
+			}
+		} else {
+			exitCode = -1
+			exitErr = err.Error()
+		}
+	}
+
+	_ = send(&operationspb.ExecOutput{
+		Payload: &operationspb.ExecOutput_Exit{
+			Exit: &operationspb.ExecExit{
+				ExitCode: int32(exitCode),
+				Error:    exitErr,
+			},
+		},
+	})
+}
+
+// streamOutput reads from r in chunks and calls send for each chunk.
+func streamOutput(r io.Reader, send func([]byte) error) {
+	reader := bufio.NewReaderSize(r, streamBufSize)
+	buf := make([]byte, streamBufSize)
+	for {
+		n, err := reader.Read(buf)
+		if n > 0 {
+			// Copy the slice to avoid data races.
+			data := make([]byte, n)
+			copy(data, buf[:n])
+			if sendErr := send(data); sendErr != nil {
+				return
+			}
+		}
+		if err != nil {
+			return
+		}
+	}
+}
+
+// sendError sends an ExecExit with exit code -1 and the given error message.
+func sendError(send func(*operationspb.ExecOutput) error, msg string) {
+	_ = send(&operationspb.ExecOutput{
+		Payload: &operationspb.ExecOutput_Exit{
+			Exit: &operationspb.ExecExit{
+				ExitCode: -1,
+				Error:    msg,
+			},
+		},
+	})
+}
+
+// killProcessGroup sends SIGTERM to the process group, waits killGracePeriod,
+// then sends SIGKILL if the process is still running.
+func killProcessGroup(cmd *exec.Cmd) {
+	if cmd.Process == nil {
+		return
+	}
+	pgid, err := syscall.Getpgid(cmd.Process.Pid)
+	if err != nil {
+		// Fallback: kill the process directly.
+		_ = cmd.Process.Kill()
+		return
+	}
+
+	// Send SIGTERM to the process group.
+	_ = syscall.Kill(-pgid, syscall.SIGTERM)
+
+	// Wait briefly, then SIGKILL if still alive.
+	done := make(chan struct{})
+	go func() {
+		_, _ = cmd.Process.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		return
+	case <-time.After(killGracePeriod):
+		_ = syscall.Kill(-pgid, syscall.SIGKILL)
+	}
+}
+
+// shellCommand returns the shell binary and flag for the current platform.
+func shellCommand() (string, string) {
+	if runtime.GOOS == "windows" {
+		return "cmd", "/C"
+	}
+	return "/bin/sh", "-c"
+}
+
+// buildEnv creates an environment slice by combining the current environment
+// with the provided overrides.
+func buildEnv(overrides map[string]string) []string {
+	// Start with current environment.
+	env := make([]string, 0)
+	for _, e := range syscall.Environ() {
+		env = append(env, e)
+	}
+	// Apply overrides.
+	for k, v := range overrides {
+		env = append(env, k+"="+v)
+	}
+	return env
+}

--- a/internal/agent/exec_test.go
+++ b/internal/agent/exec_test.go
@@ -1,0 +1,278 @@
+package agent
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	operationspb "github.com/garysng/axon/gen/proto/operations"
+)
+
+// outputCollector collects ExecOutput messages for assertions.
+type outputCollector struct {
+	mu      sync.Mutex
+	outputs []*operationspb.ExecOutput
+}
+
+func (c *outputCollector) send(out *operationspb.ExecOutput) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.outputs = append(c.outputs, out)
+	return nil
+}
+
+func (c *outputCollector) stdout() string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	var b strings.Builder
+	for _, o := range c.outputs {
+		if s := o.GetStdout(); s != nil {
+			b.Write(s)
+		}
+	}
+	return b.String()
+}
+
+func (c *outputCollector) stderr() string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	var b strings.Builder
+	for _, o := range c.outputs {
+		if s := o.GetStderr(); s != nil {
+			b.Write(s)
+		}
+	}
+	return b.String()
+}
+
+func (c *outputCollector) exitCode() (int32, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for _, o := range c.outputs {
+		if e := o.GetExit(); e != nil {
+			return e.ExitCode, true
+		}
+	}
+	return 0, false
+}
+
+func (c *outputCollector) exitError() string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for _, o := range c.outputs {
+		if e := o.GetExit(); e != nil {
+			return e.Error
+		}
+	}
+	return ""
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────
+
+func TestExec_SimpleCommand(t *testing.T) {
+	h := &ExecHandler{}
+	c := &outputCollector{}
+
+	h.Handle(context.Background(), &operationspb.ExecRequest{
+		Command: "echo hello world",
+	}, c.send)
+
+	out := strings.TrimSpace(c.stdout())
+	if out != "hello world" {
+		t.Errorf("stdout = %q, want %q", out, "hello world")
+	}
+
+	code, ok := c.exitCode()
+	if !ok {
+		t.Fatal("no exit message received")
+	}
+	if code != 0 {
+		t.Errorf("exit code = %d, want 0", code)
+	}
+}
+
+func TestExec_StderrOutput(t *testing.T) {
+	h := &ExecHandler{}
+	c := &outputCollector{}
+
+	h.Handle(context.Background(), &operationspb.ExecRequest{
+		Command: "echo error >&2",
+	}, c.send)
+
+	errOut := strings.TrimSpace(c.stderr())
+	if errOut != "error" {
+		t.Errorf("stderr = %q, want %q", errOut, "error")
+	}
+
+	code, _ := c.exitCode()
+	if code != 0 {
+		t.Errorf("exit code = %d, want 0", code)
+	}
+}
+
+func TestExec_NonZeroExit(t *testing.T) {
+	h := &ExecHandler{}
+	c := &outputCollector{}
+
+	h.Handle(context.Background(), &operationspb.ExecRequest{
+		Command: "exit 42",
+	}, c.send)
+
+	code, ok := c.exitCode()
+	if !ok {
+		t.Fatal("no exit message received")
+	}
+	if code != 42 {
+		t.Errorf("exit code = %d, want 42", code)
+	}
+}
+
+func TestExec_WorkingDir(t *testing.T) {
+	h := &ExecHandler{}
+	c := &outputCollector{}
+
+	h.Handle(context.Background(), &operationspb.ExecRequest{
+		Command:    "pwd",
+		WorkingDir: "/tmp",
+	}, c.send)
+
+	// On macOS /tmp is a symlink to /private/tmp.
+	out := strings.TrimSpace(c.stdout())
+	if !strings.HasSuffix(out, "/tmp") {
+		t.Errorf("stdout = %q, want to end with /tmp", out)
+	}
+
+	code, _ := c.exitCode()
+	if code != 0 {
+		t.Errorf("exit code = %d, want 0", code)
+	}
+}
+
+func TestExec_EnvVars(t *testing.T) {
+	h := &ExecHandler{}
+	c := &outputCollector{}
+
+	h.Handle(context.Background(), &operationspb.ExecRequest{
+		Command: "echo $AXON_TEST_VAR",
+		Env:     map[string]string{"AXON_TEST_VAR": "foobar"},
+	}, c.send)
+
+	out := strings.TrimSpace(c.stdout())
+	if out != "foobar" {
+		t.Errorf("stdout = %q, want %q", out, "foobar")
+	}
+}
+
+func TestExec_Timeout(t *testing.T) {
+	h := &ExecHandler{}
+	c := &outputCollector{}
+
+	start := time.Now()
+	h.Handle(context.Background(), &operationspb.ExecRequest{
+		Command:        "sleep 60",
+		TimeoutSeconds: 1,
+	}, c.send)
+	elapsed := time.Since(start)
+
+	if elapsed > 10*time.Second {
+		t.Errorf("timeout took %v, expected ~1s", elapsed)
+	}
+
+	code, ok := c.exitCode()
+	if !ok {
+		t.Fatal("no exit message received")
+	}
+	if code == 0 {
+		t.Error("expected non-zero exit code for timeout")
+	}
+}
+
+func TestExec_Cancellation(t *testing.T) {
+	h := &ExecHandler{}
+	c := &outputCollector{}
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	// Cancel after 500ms.
+	go func() {
+		time.Sleep(500 * time.Millisecond)
+		cancel()
+	}()
+
+	start := time.Now()
+	h.Handle(ctx, &operationspb.ExecRequest{
+		Command: "sleep 60",
+	}, c.send)
+	elapsed := time.Since(start)
+
+	if elapsed > 10*time.Second {
+		t.Errorf("cancellation took %v, expected ~500ms", elapsed)
+	}
+
+	code, ok := c.exitCode()
+	if !ok {
+		t.Fatal("no exit message received")
+	}
+	if code == 0 {
+		t.Error("expected non-zero exit code for cancellation")
+	}
+}
+
+func TestExec_InvalidCommand(t *testing.T) {
+	h := &ExecHandler{}
+	c := &outputCollector{}
+
+	h.Handle(context.Background(), &operationspb.ExecRequest{
+		Command: "nonexistent_command_xyz_12345",
+	}, c.send)
+
+	code, ok := c.exitCode()
+	if !ok {
+		t.Fatal("no exit message received")
+	}
+	if code == 0 {
+		t.Error("expected non-zero exit code for invalid command")
+	}
+}
+
+func TestExec_LargeOutput(t *testing.T) {
+	h := &ExecHandler{}
+	c := &outputCollector{}
+
+	// Generate ~100KB of output using yes + head.
+	h.Handle(context.Background(), &operationspb.ExecRequest{
+		Command: "yes 'abcdefghijklmnopqrstuvwxyz0123456789' | head -3000",
+	}, c.send)
+
+	out := c.stdout()
+	if len(out) < 10000 {
+		t.Errorf("stdout length = %d, expected > 10000 bytes", len(out))
+	}
+
+	code, _ := c.exitCode()
+	if code != 0 {
+		t.Errorf("exit code = %d, want 0", code)
+	}
+}
+
+func TestExec_InvalidWorkingDir(t *testing.T) {
+	h := &ExecHandler{}
+	c := &outputCollector{}
+
+	h.Handle(context.Background(), &operationspb.ExecRequest{
+		Command:    "echo hello",
+		WorkingDir: "/nonexistent_dir_xyz",
+	}, c.send)
+
+	code, ok := c.exitCode()
+	if !ok {
+		t.Fatal("no exit message received")
+	}
+	// Should fail because the working directory doesn't exist.
+	exitErr := c.exitError()
+	if code == 0 && exitErr == "" {
+		t.Error("expected error for invalid working directory")
+	}
+}


### PR DESCRIPTION
## C-10: Agent Exec Handler

### What
`internal/agent/exec.go` — ExecHandler processes ExecRequest by spawning a local process and streaming output back.

**Features:**
- Spawn via `/bin/sh -c` (or `cmd /C` on Windows)
- Stream stdout/stderr concurrently as `ExecOutput` messages
- Exit code forwarding via `ExecExit`
- Timeout: SIGTERM to process group → 5s grace → SIGKILL
- Cancellation: gRPC context cancel → SIGTERM → SIGKILL
- Environment variable overrides (inherit current + apply overrides)
- Working directory support
- Process group kill (`Setpgid`) for child process cleanup

### Tests (10)
| Test | Validates |
|------|-----------|
| SimpleCommand | `echo hello world` → stdout matches |
| StderrOutput | `echo error >&2` → stderr matches |
| NonZeroExit | `exit 42` → exit code = 42 |
| WorkingDir | `pwd` in `/tmp` → correct output |
| EnvVars | Custom env var propagated to child |
| Timeout | `sleep 60` with 1s timeout → killed in ~1s |
| Cancellation | ctx cancel after 500ms → process killed |
| InvalidCommand | Non-existent binary → non-zero exit |
| LargeOutput | ~100KB output streamed correctly |
| InvalidWorkingDir | Non-existent dir → error reported |

### Dependencies
- C-9 (Agent control plane) ✅

### Checklist
- [x] Branch from `origin/dev` ✅
- [x] `go build ./...` passes
- [x] `go test ./...` all green
- [x] `go vet ./...` clean
- [x] Single clean commit
- [x] PR base: `dev`