### PR TITLE
test(integration): add integration test framework with 15 end-to-end tests

### DIFF
--- a/internal/agent/testing.go
+++ b/internal/agent/testing.go
@@ -1,0 +1,9 @@
+package agent
+
+import "google.golang.org/grpc"
+
+// SetDialOverride sets a gRPC dial option that replaces the network transport.
+// This is intended for testing only (e.g. using bufconn).
+func (a *Agent) SetDialOverride(opt grpc.DialOption) {
+	a.dialOverride = opt
+}

--- a/internal/server/testing.go
+++ b/internal/server/testing.go
@@ -1,0 +1,13 @@
+package server
+
+import (
+	"context"
+	"net"
+)
+
+// ServeListener is a test-friendly wrapper around serve() that accepts an
+// external net.Listener (e.g. bufconn). It initialises the server in the same
+// way as Start but uses the provided listener instead of binding a TCP port.
+func (s *Server) ServeListener(ctx context.Context, lis net.Listener) error {
+	return s.serve(ctx, lis)
+}

--- a/internal/server/testing.go
+++ b/internal/server/testing.go
@@ -2,12 +2,65 @@ package server
 
 import (
 	"context"
+	"fmt"
 	"net"
+
+	"google.golang.org/grpc"
+
+	controlpb "github.com/garysng/axon/gen/proto/control"
+	managementpb "github.com/garysng/axon/gen/proto/management"
+	operationspb "github.com/garysng/axon/gen/proto/operations"
+	"github.com/garysng/axon/internal/server/registry"
+	"github.com/garysng/axon/pkg/audit"
 )
 
-// ServeListener is a test-friendly wrapper around serve() that accepts an
-// external net.Listener (e.g. bufconn). It initialises the server in the same
-// way as Start but uses the provided listener instead of binding a TCP port.
-func (s *Server) ServeListener(ctx context.Context, lis net.Listener) error {
-	return s.serve(ctx, lis)
+// ServeListenerReady starts the server on lis and closes the ready channel
+// once all internal components are initialised. This avoids the data race
+// between serve() writing s.registry and test code reading it via Registry().
+func (s *Server) ServeListenerReady(ctx context.Context, lis net.Listener, ready chan<- struct{}) error {
+	// Pre-initialise the components that serve() would create, so they are
+	// visible to callers *before* the goroutine starts gRPC serving.
+	opts, err := s.buildServerOptions()
+	if err != nil {
+		return err
+	}
+
+	s.grpc = grpc.NewServer(opts...)
+
+	s.registry = registry.NewRegistry(s.cfg.HeartbeatTimeout)
+	s.control = newControlService(s.registry, s.cfg)
+
+	auditDBPath := s.cfg.AuditDBPath
+	if auditDBPath == "" {
+		auditDBPath = ":memory:"
+	}
+	auditStore, err := audit.NewStore(auditDBPath)
+	if err != nil {
+		return fmt.Errorf("server: init audit store: %w", err)
+	}
+	s.auditWriter = audit.NewWriter(auditStore, 256)
+
+	router := newRouter(s.registry)
+	ops := newOperationsService(router, s.control, s.auditWriter)
+	mgmt := newManagementService(s.registry, s.cfg.Users, s.cfg.JWTSecret)
+
+	controlpb.RegisterControlServiceServer(s.grpc, s.control)
+	operationspb.RegisterOperationsServiceServer(s.grpc, ops)
+	managementpb.RegisterManagementServiceServer(s.grpc, mgmt)
+
+	s.registry.StartMonitor(ctx)
+
+	// Signal that initialisation is complete — callers can now safely
+	// access Registry() and other server state without a data race.
+	close(ready)
+
+	go func() {
+		<-ctx.Done()
+		s.grpc.GracefulStop()
+	}()
+
+	if err := s.grpc.Serve(lis); err != nil {
+		return fmt.Errorf("server: serve: %w", err)
+	}
+	return nil
 }

--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -1,0 +1,545 @@
+package integration_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"golang.org/x/crypto/bcrypt"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	controlpb "github.com/garysng/axon/gen/proto/control"
+	managementpb "github.com/garysng/axon/gen/proto/management"
+	operationspb "github.com/garysng/axon/gen/proto/operations"
+	"github.com/garysng/axon/internal/server"
+	"github.com/garysng/axon/internal/server/registry"
+	"github.com/garysng/axon/test/integration/testharness"
+)
+
+// ── Agent lifecycle tests ──────────────────────────────────────────────────
+
+func TestIntegration_AgentConnectAndRegister(t *testing.T) {
+	h := testharness.NewHarness(t)
+
+	nodeID := h.AgentNodeID()
+	if nodeID == "" {
+		t.Fatal("expected non-empty node ID")
+	}
+
+	entry, ok := h.Registry().Lookup(nodeID)
+	if !ok {
+		t.Fatalf("node %s not found in registry", nodeID)
+	}
+	if entry.Status != registry.StatusOnline {
+		t.Errorf("status = %q, want %q", entry.Status, registry.StatusOnline)
+	}
+	if entry.NodeName != "integration-agent" {
+		t.Errorf("NodeName = %q, want %q", entry.NodeName, "integration-agent")
+	}
+}
+
+func TestIntegration_AgentHeartbeat(t *testing.T) {
+	// The server protocol communicates heartbeat intervals in whole seconds,
+	// so the minimum testable interval is 1s.
+	h := testharness.NewHarness(t,
+		testharness.WithHeartbeatInterval(1*time.Second),
+		testharness.WithHeartbeatTimeout(10*time.Second),
+	)
+
+	nodeID := h.AgentNodeID()
+
+	// Record the initial heartbeat time.
+	entry, ok := h.Registry().Lookup(nodeID)
+	if !ok {
+		t.Fatalf("node %s not found in registry", nodeID)
+	}
+	initialHB := entry.LastHeartbeat
+
+	// Wait for at least one heartbeat cycle (1s interval + margin).
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		entry, ok = h.Registry().Lookup(nodeID)
+		if ok && entry.LastHeartbeat.After(initialHB) {
+			return // success: heartbeat was updated
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	t.Error("heartbeat was not updated within 5s")
+}
+
+func TestIntegration_AgentDisconnectReconnect(t *testing.T) {
+	h := testharness.NewHarness(t,
+		testharness.WithAgentNodeName("disc-reconnect-agent"),
+	)
+
+	nodeID := h.AgentNodeID()
+
+	// Verify online.
+	entry, ok := h.Registry().Lookup(nodeID)
+	if !ok || entry.Status != registry.StatusOnline {
+		t.Fatalf("expected node online, got status=%q ok=%v", entry.Status, ok)
+	}
+
+	// Stop the agent to simulate disconnect.
+	h.StopAgent()
+
+	// Wait for node to go offline.
+	h.WaitForNodeStatus(nodeID, registry.StatusOffline)
+
+	// Connect a new agent with the same name — it gets a new node ID.
+	_, newNodeID := h.ConnectAgent("disc-reconnect-agent")
+	if newNodeID == "" {
+		t.Fatal("expected non-empty node ID after reconnect")
+	}
+
+	newEntry, ok := h.Registry().Lookup(newNodeID)
+	if !ok {
+		t.Fatalf("reconnected node %s not found", newNodeID)
+	}
+	if newEntry.Status != registry.StatusOnline {
+		t.Errorf("reconnected status = %q, want %q", newEntry.Status, registry.StatusOnline)
+	}
+}
+
+// ── Management service tests ───────────────────────────────────────────────
+
+func TestIntegration_ListNodes(t *testing.T) {
+	h := testharness.NewHarness(t)
+
+	conn := h.CLIConn()
+	client := managementpb.NewManagementServiceClient(conn)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	resp, err := client.ListNodes(ctx, &managementpb.ListNodesRequest{})
+	if err != nil {
+		t.Fatalf("ListNodes: %v", err)
+	}
+
+	if len(resp.GetNodes()) == 0 {
+		t.Fatal("expected at least one node in ListNodes response")
+	}
+
+	found := false
+	for _, n := range resp.GetNodes() {
+		if n.GetNodeId() == h.AgentNodeID() {
+			found = true
+			if n.GetStatus() != registry.StatusOnline {
+				t.Errorf("node status = %q, want %q", n.GetStatus(), registry.StatusOnline)
+			}
+			if n.GetNodeName() != "integration-agent" {
+				t.Errorf("node name = %q, want %q", n.GetNodeName(), "integration-agent")
+			}
+		}
+	}
+	if !found {
+		t.Errorf("agent node %s not found in ListNodes response", h.AgentNodeID())
+	}
+}
+
+func TestIntegration_GetNode(t *testing.T) {
+	h := testharness.NewHarness(t)
+
+	conn := h.CLIConn()
+	client := managementpb.NewManagementServiceClient(conn)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	resp, err := client.GetNode(ctx, &managementpb.GetNodeRequest{
+		NodeId: h.AgentNodeID(),
+	})
+	if err != nil {
+		t.Fatalf("GetNode: %v", err)
+	}
+
+	summary := resp.GetSummary()
+	if summary == nil {
+		t.Fatal("expected non-nil summary")
+	}
+	if summary.GetNodeId() != h.AgentNodeID() {
+		t.Errorf("NodeId = %q, want %q", summary.GetNodeId(), h.AgentNodeID())
+	}
+	if summary.GetNodeName() != "integration-agent" {
+		t.Errorf("NodeName = %q, want %q", summary.GetNodeName(), "integration-agent")
+	}
+	if summary.GetStatus() != registry.StatusOnline {
+		t.Errorf("Status = %q, want %q", summary.GetStatus(), registry.StatusOnline)
+	}
+}
+
+func TestIntegration_RemoveNode(t *testing.T) {
+	h := testharness.NewHarness(t)
+
+	conn := h.CLIConn()
+	client := managementpb.NewManagementServiceClient(conn)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	resp, err := client.RemoveNode(ctx, &managementpb.RemoveNodeRequest{
+		NodeId: h.AgentNodeID(),
+	})
+	if err != nil {
+		t.Fatalf("RemoveNode: %v", err)
+	}
+	if !resp.GetSuccess() {
+		t.Errorf("RemoveNode success = false, error = %q", resp.GetError())
+	}
+
+	// Verify node is gone.
+	_, ok := h.Registry().Lookup(h.AgentNodeID())
+	if ok {
+		t.Error("node still in registry after RemoveNode")
+	}
+}
+
+// ── Login tests ────────────────────────────────────────────────────────────
+
+func hashPassword(t *testing.T, password string) string {
+	t.Helper()
+	hash, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.MinCost)
+	if err != nil {
+		t.Fatalf("bcrypt hash: %v", err)
+	}
+	return string(hash)
+}
+
+func TestIntegration_Login(t *testing.T) {
+	users := []server.UserEntry{
+		{
+			Username:     "admin",
+			PasswordHash: hashPassword(t, "secret123"),
+			NodeIDs:      []string{"*"},
+		},
+	}
+
+	h := testharness.NewHarnessServerOnly(t, testharness.WithUsers(users))
+
+	conn := h.UnauthConn()
+	client := managementpb.NewManagementServiceClient(conn)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	resp, err := client.Login(ctx, &managementpb.LoginRequest{
+		Username: "admin",
+		Password: "secret123",
+	})
+	if err != nil {
+		t.Fatalf("Login: %v", err)
+	}
+	if resp.GetToken() == "" {
+		t.Errorf("expected non-empty token, got error: %s", resp.GetError())
+	}
+	if resp.GetExpiresAt() == 0 {
+		t.Error("expected non-zero ExpiresAt")
+	}
+}
+
+func TestIntegration_LoginInvalidCredentials(t *testing.T) {
+	users := []server.UserEntry{
+		{
+			Username:     "admin",
+			PasswordHash: hashPassword(t, "secret123"),
+			NodeIDs:      []string{"*"},
+		},
+	}
+
+	h := testharness.NewHarnessServerOnly(t, testharness.WithUsers(users))
+
+	conn := h.UnauthConn()
+	client := managementpb.NewManagementServiceClient(conn)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	resp, err := client.Login(ctx, &managementpb.LoginRequest{
+		Username: "admin",
+		Password: "wrongpassword",
+	})
+	if err != nil {
+		t.Fatalf("Login: %v", err)
+	}
+	if resp.GetToken() != "" {
+		t.Error("expected empty token for invalid credentials")
+	}
+	if resp.GetError() == "" {
+		t.Error("expected non-empty error message for invalid credentials")
+	}
+}
+
+// ── Task signal tests ──────────────────────────────────────────────────────
+
+func TestIntegration_ExecTaskSignal(t *testing.T) {
+	taskCh := make(chan testharness.TaskSignal, 1)
+	h := testharness.NewHarnessServerOnly(t)
+	_, nodeID := h.ConnectAgentWithHandler("exec-agent", func(taskID string, taskType controlpb.TaskType) {
+		taskCh <- testharness.TaskSignal{TaskID: taskID, TaskType: taskType}
+	})
+
+	conn := h.CLIConn()
+	client := operationspb.NewOperationsServiceClient(conn)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	stream, err := client.Exec(ctx, &operationspb.ExecRequest{
+		NodeId:  nodeID,
+		Command: "echo hello",
+	})
+	if err != nil {
+		t.Fatalf("Exec: %v", err)
+	}
+	// Drain the response stream.
+	for {
+		_, err := stream.Recv()
+		if err != nil {
+			break
+		}
+	}
+
+	select {
+	case sig := <-taskCh:
+		if sig.TaskType != controlpb.TaskType_TASK_EXEC {
+			t.Errorf("task type = %v, want TASK_EXEC", sig.TaskType)
+		}
+		if sig.TaskID == "" {
+			t.Error("expected non-empty task ID")
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for task signal")
+	}
+}
+
+func TestIntegration_ReadTaskSignal(t *testing.T) {
+	taskCh := make(chan testharness.TaskSignal, 1)
+	h := testharness.NewHarnessServerOnly(t)
+	_, nodeID := h.ConnectAgentWithHandler("read-agent", func(taskID string, taskType controlpb.TaskType) {
+		taskCh <- testharness.TaskSignal{TaskID: taskID, TaskType: taskType}
+	})
+
+	conn := h.CLIConn()
+	client := operationspb.NewOperationsServiceClient(conn)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	stream, err := client.Read(ctx, &operationspb.ReadRequest{
+		NodeId: nodeID,
+		Path:   "/tmp/testfile",
+	})
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	for {
+		_, err := stream.Recv()
+		if err != nil {
+			break
+		}
+	}
+
+	select {
+	case sig := <-taskCh:
+		if sig.TaskType != controlpb.TaskType_TASK_READ {
+			t.Errorf("task type = %v, want TASK_READ", sig.TaskType)
+		}
+		if sig.TaskID == "" {
+			t.Error("expected non-empty task ID")
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for task signal")
+	}
+}
+
+func TestIntegration_WriteTaskSignal(t *testing.T) {
+	taskCh := make(chan testharness.TaskSignal, 1)
+	h := testharness.NewHarnessServerOnly(t)
+	_, nodeID := h.ConnectAgentWithHandler("write-agent", func(taskID string, taskType controlpb.TaskType) {
+		taskCh <- testharness.TaskSignal{TaskID: taskID, TaskType: taskType}
+	})
+
+	conn := h.CLIConn()
+	client := operationspb.NewOperationsServiceClient(conn)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	stream, err := client.Write(ctx)
+	if err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	// Send WriteHeader as first message.
+	if err := stream.Send(&operationspb.WriteInput{
+		Payload: &operationspb.WriteInput_Header{
+			Header: &operationspb.WriteHeader{
+				NodeId: nodeID,
+				Path:   "/tmp/testfile",
+			},
+		},
+	}); err != nil {
+		t.Fatalf("Send WriteHeader: %v", err)
+	}
+
+	// Close and receive response.
+	_, _ = stream.CloseAndRecv()
+
+	select {
+	case sig := <-taskCh:
+		if sig.TaskType != controlpb.TaskType_TASK_WRITE {
+			t.Errorf("task type = %v, want TASK_WRITE", sig.TaskType)
+		}
+		if sig.TaskID == "" {
+			t.Error("expected non-empty task ID")
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for task signal")
+	}
+}
+
+func TestIntegration_ForwardTaskSignal(t *testing.T) {
+	taskCh := make(chan testharness.TaskSignal, 1)
+	h := testharness.NewHarnessServerOnly(t)
+	_, nodeID := h.ConnectAgentWithHandler("forward-agent", func(taskID string, taskType controlpb.TaskType) {
+		taskCh <- testharness.TaskSignal{TaskID: taskID, TaskType: taskType}
+	})
+
+	conn := h.CLIConn()
+	client := operationspb.NewOperationsServiceClient(conn)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	stream, err := client.Forward(ctx)
+	if err != nil {
+		t.Fatalf("Forward: %v", err)
+	}
+
+	// Send TunnelOpen as first message.
+	if err := stream.Send(&operationspb.TunnelData{
+		Open: &operationspb.TunnelOpen{
+			NodeId:     nodeID,
+			RemotePort: 8080,
+		},
+	}); err != nil {
+		t.Fatalf("Send TunnelOpen: %v", err)
+	}
+
+	// Read response (server sends a close signal).
+	_, _ = stream.Recv()
+
+	select {
+	case sig := <-taskCh:
+		if sig.TaskType != controlpb.TaskType_TASK_FORWARD {
+			t.Errorf("task type = %v, want TASK_FORWARD", sig.TaskType)
+		}
+		if sig.TaskID == "" {
+			t.Error("expected non-empty task ID")
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for task signal")
+	}
+}
+
+// ── Router error tests ─────────────────────────────────────────────────────
+
+func TestIntegration_RouterNodeNotFound(t *testing.T) {
+	h := testharness.NewHarnessServerOnly(t)
+
+	conn := h.CLIConn()
+	client := operationspb.NewOperationsServiceClient(conn)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	stream, err := client.Exec(ctx, &operationspb.ExecRequest{
+		NodeId:  "non-existent-node-id",
+		Command: "echo hello",
+	})
+	if err != nil {
+		t.Fatalf("Exec: %v", err)
+	}
+
+	_, err = stream.Recv()
+	if err == nil {
+		t.Fatal("expected error for non-existent node")
+	}
+
+	st, ok := status.FromError(err)
+	if !ok {
+		t.Fatalf("expected gRPC status error, got: %v", err)
+	}
+	if st.Code() != codes.NotFound {
+		t.Errorf("status code = %v, want NotFound", st.Code())
+	}
+}
+
+func TestIntegration_RouterNodeOffline(t *testing.T) {
+	h := testharness.NewHarnessServerOnly(t)
+
+	// Connect an agent, then stop it.
+	_, nodeID := h.ConnectAgent("offline-agent")
+	h.Registry().MarkOffline(nodeID)
+
+	conn := h.CLIConn()
+	client := operationspb.NewOperationsServiceClient(conn)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	stream, err := client.Exec(ctx, &operationspb.ExecRequest{
+		NodeId:  nodeID,
+		Command: "echo hello",
+	})
+	if err != nil {
+		t.Fatalf("Exec: %v", err)
+	}
+
+	_, err = stream.Recv()
+	if err == nil {
+		t.Fatal("expected error for offline node")
+	}
+
+	st, ok := status.FromError(err)
+	if !ok {
+		t.Fatalf("expected gRPC status error, got: %v", err)
+	}
+	if st.Code() != codes.Unavailable {
+		t.Errorf("status code = %v, want Unavailable", st.Code())
+	}
+}
+
+func TestIntegration_UnauthorizedAccess(t *testing.T) {
+	h := testharness.NewHarness(t)
+
+	// Create a CLI connection that only has access to a different node.
+	conn := h.CLIConnWithAccess("some-other-node-id")
+	client := operationspb.NewOperationsServiceClient(conn)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	stream, err := client.Exec(ctx, &operationspb.ExecRequest{
+		NodeId:  h.AgentNodeID(),
+		Command: "echo hello",
+	})
+	if err != nil {
+		t.Fatalf("Exec: %v", err)
+	}
+
+	_, err = stream.Recv()
+	if err == nil {
+		t.Fatal("expected error for unauthorized access")
+	}
+
+	st, ok := status.FromError(err)
+	if !ok {
+		t.Fatalf("expected gRPC status error, got: %v", err)
+	}
+	if st.Code() != codes.PermissionDenied {
+		t.Errorf("status code = %v, want PermissionDenied", st.Code())
+	}
+}

--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -482,7 +482,9 @@ func TestIntegration_RouterNodeOffline(t *testing.T) {
 
 	// Connect an agent, then stop it.
 	_, nodeID := h.ConnectAgent("offline-agent")
-	h.Registry().MarkOffline(nodeID)
+	if err := h.Registry().MarkOffline(nodeID); err != nil {
+		t.Fatalf("MarkOffline: %v", err)
+	}
 
 	conn := h.CLIConn()
 	client := operationspb.NewOperationsServiceClient(conn)

--- a/test/integration/testharness/harness.go
+++ b/test/integration/testharness/harness.go
@@ -1,0 +1,425 @@
+// Package testharness provides a reusable integration test harness that
+// spins up an axon-server and axon-agent in-process using bufconn.
+package testharness
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/test/bufconn"
+
+	controlpb "github.com/garysng/axon/gen/proto/control"
+	"github.com/garysng/axon/internal/agent"
+	"github.com/garysng/axon/internal/server"
+	"github.com/garysng/axon/internal/server/registry"
+	"github.com/garysng/axon/pkg/auth"
+	"github.com/garysng/axon/pkg/config"
+)
+
+const bufSize = 1024 * 1024
+
+// Harness holds a running server and agent connected via bufconn.
+type Harness struct {
+	t      *testing.T
+	srv    *server.Server
+	agt    *agent.Agent
+	lis    *bufconn.Listener
+	cancel context.CancelFunc
+
+	opts harnessOpts
+
+	agentNodeID string
+	agentCancel context.CancelFunc
+}
+
+type harnessOpts struct {
+	jwtSecret         string
+	heartbeatInterval time.Duration
+	heartbeatTimeout  time.Duration
+	agentNodeName     string
+	users             []server.UserEntry
+}
+
+func defaultOpts() harnessOpts {
+	return harnessOpts{
+		jwtSecret:         "integration-test-secret",
+		heartbeatInterval: 30 * time.Second,
+		heartbeatTimeout:  5 * time.Minute,
+		agentNodeName:     "integration-agent",
+	}
+}
+
+// HarnessOption configures the test harness.
+type HarnessOption func(*harnessOpts)
+
+// WithJWTSecret sets the JWT secret used by the server.
+func WithJWTSecret(secret string) HarnessOption {
+	return func(o *harnessOpts) { o.jwtSecret = secret }
+}
+
+// WithHeartbeatInterval sets the heartbeat interval advertised to agents.
+func WithHeartbeatInterval(d time.Duration) HarnessOption {
+	return func(o *harnessOpts) { o.heartbeatInterval = d }
+}
+
+// WithHeartbeatTimeout sets the heartbeat timeout for the registry monitor.
+func WithHeartbeatTimeout(d time.Duration) HarnessOption {
+	return func(o *harnessOpts) { o.heartbeatTimeout = d }
+}
+
+// WithAgentNodeName sets the node name used by the agent.
+func WithAgentNodeName(name string) HarnessOption {
+	return func(o *harnessOpts) { o.agentNodeName = name }
+}
+
+// WithUsers sets the CLI user credentials for Login tests.
+func WithUsers(users []server.UserEntry) HarnessOption {
+	return func(o *harnessOpts) { o.users = users }
+}
+
+// NewHarness creates a new integration test harness. It starts the server and
+// connects an agent, blocking until the agent appears in the registry.
+func NewHarness(t *testing.T, options ...HarnessOption) *Harness {
+	t.Helper()
+
+	opts := defaultOpts()
+	for _, o := range options {
+		o(&opts)
+	}
+
+	lis := bufconn.Listen(bufSize)
+
+	srvCfg := server.ServerConfig{
+		JWTSecret:         opts.jwtSecret,
+		HeartbeatInterval: opts.heartbeatInterval,
+		HeartbeatTimeout:  opts.heartbeatTimeout,
+		Users:             opts.users,
+	}
+	srv := server.NewServer(srvCfg)
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	// Start server in background.
+	srvErrCh := make(chan error, 1)
+	go func() {
+		srvErrCh <- srv.ServeListener(ctx, lis)
+	}()
+
+	// Build agent config.
+	agentToken, err := auth.SignAgentToken(opts.jwtSecret, "integration-node", time.Hour)
+	if err != nil {
+		cancel()
+		t.Fatalf("harness: sign agent token: %v", err)
+	}
+
+	agentCfg := config.AgentConfig{
+		ServerAddr:  "passthrough://bufnet",
+		Token:       agentToken,
+		NodeName:    opts.agentNodeName,
+		TLSInsecure: true,
+	}
+
+	agt := agent.NewAgent(agentCfg, "")
+	agt.SetDialOverride(grpc.WithContextDialer(func(ctx context.Context, _ string) (net.Conn, error) {
+		return lis.DialContext(ctx)
+	}))
+
+	// Start agent in background.
+	agentCtx, agentCancel := context.WithCancel(ctx)
+	go func() {
+		_ = agt.Run(agentCtx)
+	}()
+
+	h := &Harness{
+		t:           t,
+		srv:         srv,
+		agt:         agt,
+		lis:         lis,
+		cancel:      cancel,
+		opts:        opts,
+		agentCancel: agentCancel,
+	}
+
+	// Wait for agent to appear in registry.
+	h.agentNodeID = h.waitForAgent()
+
+	t.Cleanup(h.Close)
+	return h
+}
+
+// NewHarnessServerOnly creates a harness with only the server (no agent).
+func NewHarnessServerOnly(t *testing.T, options ...HarnessOption) *Harness {
+	t.Helper()
+
+	opts := defaultOpts()
+	for _, o := range options {
+		o(&opts)
+	}
+
+	lis := bufconn.Listen(bufSize)
+
+	srvCfg := server.ServerConfig{
+		JWTSecret:         opts.jwtSecret,
+		HeartbeatInterval: opts.heartbeatInterval,
+		HeartbeatTimeout:  opts.heartbeatTimeout,
+		Users:             opts.users,
+	}
+	srv := server.NewServer(srvCfg)
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	srvErrCh := make(chan error, 1)
+	go func() {
+		srvErrCh <- srv.ServeListener(ctx, lis)
+	}()
+
+	// Give the server a moment to start serving.
+	time.Sleep(50 * time.Millisecond)
+
+	h := &Harness{
+		t:      t,
+		srv:    srv,
+		lis:    lis,
+		cancel: cancel,
+		opts:   opts,
+	}
+
+	t.Cleanup(h.Close)
+	return h
+}
+
+// Server returns the server instance.
+func (h *Harness) Server() *server.Server { return h.srv }
+
+// Registry returns the server's node registry.
+func (h *Harness) Registry() *registry.Registry { return h.srv.Registry() }
+
+// AgentNodeID returns the node ID assigned to the agent.
+func (h *Harness) AgentNodeID() string { return h.agentNodeID }
+
+// CLIConn returns a gRPC client connection authenticated with a CLI JWT token
+// that has wildcard ("*") node access.
+func (h *Harness) CLIConn() *grpc.ClientConn {
+	h.t.Helper()
+	return h.CLIConnWithAccess("*")
+}
+
+// CLIConnWithAccess returns a gRPC client connection authenticated with a CLI
+// JWT token that grants access to the specified node IDs.
+func (h *Harness) CLIConnWithAccess(nodeIDs ...string) *grpc.ClientConn {
+	h.t.Helper()
+
+	token, err := auth.SignCLIToken(h.opts.jwtSecret, "test-user", nodeIDs, time.Hour)
+	if err != nil {
+		h.t.Fatalf("harness: sign CLI token: %v", err)
+	}
+
+	conn, err := grpc.NewClient(
+		"passthrough://bufnet",
+		grpc.WithContextDialer(func(ctx context.Context, _ string) (net.Conn, error) {
+			return h.lis.DialContext(ctx)
+		}),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithUnaryInterceptor(authUnaryInterceptor(token)),
+		grpc.WithStreamInterceptor(authStreamInterceptor(token)),
+	)
+	if err != nil {
+		h.t.Fatalf("harness: dial CLI conn: %v", err)
+	}
+
+	h.t.Cleanup(func() { _ = conn.Close() })
+	return conn
+}
+
+// UnauthConn returns a gRPC client connection with no authentication.
+// Useful for Login tests that don't require a pre-existing token.
+func (h *Harness) UnauthConn() *grpc.ClientConn {
+	h.t.Helper()
+
+	conn, err := grpc.NewClient(
+		"passthrough://bufnet",
+		grpc.WithContextDialer(func(ctx context.Context, _ string) (net.Conn, error) {
+			return h.lis.DialContext(ctx)
+		}),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	if err != nil {
+		h.t.Fatalf("harness: dial unauth conn: %v", err)
+	}
+
+	h.t.Cleanup(func() { _ = conn.Close() })
+	return conn
+}
+
+// ConnectAgent connects a new agent instance and waits for it to register.
+// Returns the agent and its node ID. The agent is stopped when the harness
+// is closed.
+func (h *Harness) ConnectAgent(name string) (*agent.Agent, string) {
+	h.t.Helper()
+
+	agentToken, err := auth.SignAgentToken(h.opts.jwtSecret, "extra-node", time.Hour)
+	if err != nil {
+		h.t.Fatalf("harness: sign agent token: %v", err)
+	}
+
+	agentCfg := config.AgentConfig{
+		ServerAddr:  "passthrough://bufnet",
+		Token:       agentToken,
+		NodeName:    name,
+		TLSInsecure: true,
+	}
+
+	agt := agent.NewAgent(agentCfg, "")
+	agt.SetDialOverride(grpc.WithContextDialer(func(ctx context.Context, _ string) (net.Conn, error) {
+		return h.lis.DialContext(ctx)
+	}))
+
+	agentCtx, agentCancel := context.WithCancel(context.Background())
+	go func() {
+		_ = agt.Run(agentCtx)
+	}()
+
+	h.t.Cleanup(agentCancel)
+
+	// Wait for agent to register.
+	nodeID := h.waitForNodeByName(name)
+	return agt, nodeID
+}
+
+// ConnectAgentWithHandler connects a new agent with a custom TaskHandler.
+func (h *Harness) ConnectAgentWithHandler(name string, handler agent.TaskHandler) (*agent.Agent, string) {
+	h.t.Helper()
+
+	agentToken, err := auth.SignAgentToken(h.opts.jwtSecret, "task-node", time.Hour)
+	if err != nil {
+		h.t.Fatalf("harness: sign agent token: %v", err)
+	}
+
+	agentCfg := config.AgentConfig{
+		ServerAddr:  "passthrough://bufnet",
+		Token:       agentToken,
+		NodeName:    name,
+		TLSInsecure: true,
+	}
+
+	agt := agent.NewAgent(agentCfg, "")
+	agt.SetTaskHandler(handler)
+	agt.SetDialOverride(grpc.WithContextDialer(func(ctx context.Context, _ string) (net.Conn, error) {
+		return h.lis.DialContext(ctx)
+	}))
+
+	agentCtx, agentCancel := context.WithCancel(context.Background())
+	go func() {
+		_ = agt.Run(agentCtx)
+	}()
+
+	h.t.Cleanup(agentCancel)
+
+	nodeID := h.waitForNodeByName(name)
+	return agt, nodeID
+}
+
+// StopAgent cancels the primary agent's context, causing it to disconnect.
+func (h *Harness) StopAgent() {
+	if h.agentCancel != nil {
+		h.agentCancel()
+	}
+}
+
+// Close stops the server and agent.
+func (h *Harness) Close() {
+	if h.agentCancel != nil {
+		h.agentCancel()
+	}
+	h.cancel()
+	h.srv.GracefulStop()
+}
+
+// waitForAgent polls the registry until a node with the agent's name appears.
+func (h *Harness) waitForAgent() string {
+	h.t.Helper()
+	return h.waitForNodeByName(h.opts.agentNodeName)
+}
+
+// waitForNodeByName polls the registry until a node with the given name appears.
+func (h *Harness) waitForNodeByName(name string) string {
+	h.t.Helper()
+
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		reg := h.srv.Registry()
+		if reg == nil {
+			time.Sleep(10 * time.Millisecond)
+			continue
+		}
+		entry, ok := reg.LookupByName(name)
+		if ok && entry.Status == registry.StatusOnline {
+			return entry.NodeID
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	h.t.Fatalf("harness: agent %q did not appear in registry within 5s", name)
+	return ""
+}
+
+// WaitForNodeStatus polls until the given node reaches the expected status.
+func (h *Harness) WaitForNodeStatus(nodeID, status string) {
+	h.t.Helper()
+
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		entry, ok := h.Registry().Lookup(nodeID)
+		if ok && entry.Status == status {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	entry, ok := h.Registry().Lookup(nodeID)
+	if !ok {
+		h.t.Fatalf("harness: node %q not found in registry", nodeID)
+	}
+	h.t.Fatalf("harness: node %q status = %q, want %q", nodeID, entry.Status, status)
+}
+
+// authUnaryInterceptor returns a gRPC unary client interceptor that injects
+// the authorization metadata on every call.
+func authUnaryInterceptor(token string) grpc.UnaryClientInterceptor {
+	return func(
+		ctx context.Context,
+		method string,
+		req, reply interface{},
+		cc *grpc.ClientConn,
+		invoker grpc.UnaryInvoker,
+		opts ...grpc.CallOption,
+	) error {
+		ctx = metadata.AppendToOutgoingContext(ctx, "authorization", "Bearer "+token)
+		return invoker(ctx, method, req, reply, cc, opts...)
+	}
+}
+
+// authStreamInterceptor returns a gRPC stream client interceptor that injects
+// the authorization metadata on every stream.
+func authStreamInterceptor(token string) grpc.StreamClientInterceptor {
+	return func(
+		ctx context.Context,
+		desc *grpc.StreamDesc,
+		cc *grpc.ClientConn,
+		method string,
+		streamer grpc.Streamer,
+		opts ...grpc.CallOption,
+	) (grpc.ClientStream, error) {
+		ctx = metadata.AppendToOutgoingContext(ctx, "authorization", "Bearer "+token)
+		return streamer(ctx, desc, cc, method, opts...)
+	}
+}
+
+// TaskSignal captures a task signal received by an agent.
+type TaskSignal struct {
+	TaskID   string
+	TaskType controlpb.TaskType
+}

--- a/test/integration/testharness/harness.go
+++ b/test/integration/testharness/harness.go
@@ -104,11 +104,16 @@ func NewHarness(t *testing.T, options ...HarnessOption) *Harness {
 
 	ctx, cancel := context.WithCancel(context.Background())
 
-	// Start server in background.
+	// Start server in background, waiting for initialisation to complete
+	// before proceeding. This avoids a data race between serve() writing
+	// s.registry and the test calling Registry().
+	srvReady := make(chan struct{})
 	srvErrCh := make(chan error, 1)
 	go func() {
-		srvErrCh <- srv.ServeListener(ctx, lis)
+		srvErrCh <- srv.ServeListenerReady(ctx, lis, srvReady)
 	}()
+	<-srvReady // wait for server internals to be initialised
+	_ = srvErrCh
 
 	// Build agent config.
 	agentToken, err := auth.SignAgentToken(opts.jwtSecret, "integration-node", time.Hour)
@@ -173,13 +178,13 @@ func NewHarnessServerOnly(t *testing.T, options ...HarnessOption) *Harness {
 
 	ctx, cancel := context.WithCancel(context.Background())
 
+	srvReady := make(chan struct{})
 	srvErrCh := make(chan error, 1)
 	go func() {
-		srvErrCh <- srv.ServeListener(ctx, lis)
+		srvErrCh <- srv.ServeListenerReady(ctx, lis, srvReady)
 	}()
-
-	// Give the server a moment to start serving.
-	time.Sleep(50 * time.Millisecond)
+	<-srvReady // wait for server internals to be initialised
+	_ = srvErrCh
 
 	h := &Harness{
 		t:      t,


### PR DESCRIPTION
## Q-3: Integration Test Framework

### What
Reusable test harness + 15 integration tests covering the full server-agent flow.

### Files
- `internal/server/testing.go` — exported `ServeListener` for test listener injection
- `internal/agent/testing.go` — exported `SetDialOverride` for test dial injection
- `test/integration/testharness/harness.go` — test harness (bufconn, zero network)
- `test/integration/integration_test.go` — 15 integration tests

### Test Coverage
| Category | Tests |
|----------|-------|
| Agent lifecycle | Connect+Register, Heartbeat, Disconnect/Reconnect |
| Management | ListNodes, GetNode, RemoveNode, Login, InvalidCredentials |
| Operations | Exec/Read/Write/Forward task signal dispatch |
| Router errors | NodeNotFound, NodeOffline, UnauthorizedAccess |

### Harness Features
- In-process server + agent via bufconn (no real network)
- `NewHarness(t)` / `NewHarnessServerOnly(t)` — auto cleanup via `t.Cleanup()`
- `CLIConn()` — authenticated gRPC client with wildcard node access
- `CLIConnWithAccess(nodeIDs...)` — scoped access for auth tests
- `ConnectAgent(name)` / `ConnectAgentWithHandler(name, handler)` — multi-agent support
- Configurable: JWT secret, heartbeat interval/timeout, users

### Verification
```
$ go test ./test/integration/... -v -count=1
--- PASS: TestIntegration_AgentConnectAndRegister (0.03s)
--- PASS: TestIntegration_AgentHeartbeat (1.06s)
--- PASS: TestIntegration_AgentDisconnectReconnect (0.20s)
--- PASS: TestIntegration_ListNodes (0.05s)
--- PASS: TestIntegration_GetNode (0.03s)
--- PASS: TestIntegration_RemoveNode (0.02s)
--- PASS: TestIntegration_Login (0.05s)
--- PASS: TestIntegration_LoginInvalidCredentials (0.06s)
--- PASS: TestIntegration_ExecTaskSignal (0.11s)
--- PASS: TestIntegration_ReadTaskSignal (0.09s)
--- PASS: TestIntegration_WriteTaskSignal (0.12s)
--- PASS: TestIntegration_ForwardTaskSignal (0.11s)
--- PASS: TestIntegration_RouterNodeNotFound (0.06s)
--- PASS: TestIntegration_RouterNodeOffline (0.14s)
--- PASS: TestIntegration_UnauthorizedAccess (0.03s)
PASS (2.47s)
```

All existing tests continue to pass: `go test ./... ✅`