### PR TITLE
feat(agent): add read/write file handlers with atomic write

### DIFF
--- a/internal/agent/fileio.go
+++ b/internal/agent/fileio.go
@@ -1,0 +1,175 @@
+package agent
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+
+	operationspb "github.com/garysng/axon/gen/proto/operations"
+)
+
+const readChunkSize = 32 * 1024 // 32 KB
+
+// FileIOHandler processes Read and Write requests on the local filesystem.
+type FileIOHandler struct{}
+
+// HandleRead stats the file, sends ReadMeta, then streams the content in
+// readChunkSize chunks. Errors are reported as ReadOutput_Error messages.
+func (h *FileIOHandler) HandleRead(req *operationspb.ReadRequest, send func(*operationspb.ReadOutput) error) {
+	info, err := os.Stat(req.Path)
+	if err != nil {
+		send(readError(classifyError(err, req.Path))) //nolint:errcheck
+		return
+	}
+	if info.IsDir() {
+		send(readError(fmt.Sprintf("%s is a directory", req.Path))) //nolint:errcheck
+		return
+	}
+
+	// Send metadata first.
+	if err := send(&operationspb.ReadOutput{
+		Payload: &operationspb.ReadOutput_Meta{
+			Meta: &operationspb.ReadMeta{
+				Size:       info.Size(),
+				Mode:       int32(info.Mode().Perm()),
+				ModifiedAt: info.ModTime().Unix(),
+			},
+		},
+	}); err != nil {
+		return
+	}
+
+	f, err := os.Open(req.Path)
+	if err != nil {
+		send(readError(classifyError(err, req.Path))) //nolint:errcheck
+		return
+	}
+	defer func() { _ = f.Close() }()
+
+	buf := make([]byte, readChunkSize)
+	for {
+		n, err := f.Read(buf)
+		if n > 0 {
+			chunk := make([]byte, n)
+			copy(chunk, buf[:n])
+			if sendErr := send(&operationspb.ReadOutput{
+				Payload: &operationspb.ReadOutput_Data{Data: chunk},
+			}); sendErr != nil {
+				return
+			}
+		}
+		if err != nil {
+			if err != io.EOF {
+				send(readError(fmt.Sprintf("read %s: %v", req.Path, err))) //nolint:errcheck
+			}
+			return
+		}
+	}
+}
+
+// HandleWrite receives a WriteHeader followed by data chunks, writes the
+// content atomically (tmpfile + rename), and returns a WriteResponse.
+func (h *FileIOHandler) HandleWrite(
+	recvHeader func() (*operationspb.WriteHeader, error),
+	recvData func() ([]byte, error),
+) *operationspb.WriteResponse {
+	hdr, err := recvHeader()
+	if err != nil {
+		return writeError(fmt.Sprintf("recv header: %v", err))
+	}
+	if hdr == nil {
+		return writeError("first message must be WriteHeader")
+	}
+
+	path := hdr.Path
+	mode := fs.FileMode(hdr.Mode)
+	if mode == 0 {
+		mode = 0644
+	}
+
+	// Create parent directories if needed.
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return writeError(fmt.Sprintf("mkdir %s: %v", dir, err))
+	}
+
+	// Write to a temp file in the same directory for atomic rename.
+	tmp, err := os.CreateTemp(dir, ".axon-write-*")
+	if err != nil {
+		return writeError(fmt.Sprintf("create temp: %v", err))
+	}
+	tmpPath := tmp.Name()
+	defer func() {
+		_ = tmp.Close()
+		// Clean up temp file on failure.
+		_ = os.Remove(tmpPath)
+	}()
+
+	var totalBytes int64
+	for {
+		data, err := recvData()
+		if err != nil {
+			if err == io.EOF {
+				break
+			}
+			return writeError(fmt.Sprintf("recv data: %v", err))
+		}
+		if len(data) == 0 {
+			// Empty chunk signals end of data (or just skip).
+			break
+		}
+		n, err := tmp.Write(data)
+		if err != nil {
+			return writeError(fmt.Sprintf("write: %v", err))
+		}
+		totalBytes += int64(n)
+	}
+
+	// Set permissions before rename.
+	if err := tmp.Chmod(mode); err != nil {
+		return writeError(fmt.Sprintf("chmod: %v", err))
+	}
+
+	// Close before rename (required on some platforms).
+	if err := tmp.Close(); err != nil {
+		return writeError(fmt.Sprintf("close temp: %v", err))
+	}
+
+	// Atomic rename.
+	if err := os.Rename(tmpPath, path); err != nil {
+		return writeError(fmt.Sprintf("rename: %v", err))
+	}
+
+	return &operationspb.WriteResponse{
+		Success:      true,
+		BytesWritten: totalBytes,
+	}
+}
+
+// classifyError returns a human-readable error message, detecting common
+// filesystem errors like not-found and permission-denied.
+func classifyError(err error, path string) string {
+	if errors.Is(err, os.ErrNotExist) {
+		return fmt.Sprintf("%s: not found", path)
+	}
+	if errors.Is(err, os.ErrPermission) {
+		return fmt.Sprintf("%s: permission denied", path)
+	}
+	return fmt.Sprintf("%s: %v", path, err)
+}
+
+func readError(msg string) *operationspb.ReadOutput {
+	return &operationspb.ReadOutput{
+		Payload: &operationspb.ReadOutput_Error{Error: msg},
+	}
+}
+
+func writeError(msg string) *operationspb.WriteResponse {
+	return &operationspb.WriteResponse{
+		Success: false,
+		Error:   msg,
+	}
+}

--- a/internal/agent/fileio_test.go
+++ b/internal/agent/fileio_test.go
@@ -1,0 +1,346 @@
+package agent
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	operationspb "github.com/garysng/axon/gen/proto/operations"
+)
+
+// readCollector collects ReadOutput messages.
+type readCollector struct {
+	mu      sync.Mutex
+	outputs []*operationspb.ReadOutput
+}
+
+func (c *readCollector) send(out *operationspb.ReadOutput) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.outputs = append(c.outputs, out)
+	return nil
+}
+
+func (c *readCollector) meta() *operationspb.ReadMeta {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for _, o := range c.outputs {
+		if m := o.GetMeta(); m != nil {
+			return m
+		}
+	}
+	return nil
+}
+
+func (c *readCollector) data() []byte {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	var buf bytes.Buffer
+	for _, o := range c.outputs {
+		if d := o.GetData(); d != nil {
+			buf.Write(d)
+		}
+	}
+	return buf.Bytes()
+}
+
+func (c *readCollector) errMsg() string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for _, o := range c.outputs {
+		if e := o.GetError(); e != "" {
+			return e
+		}
+	}
+	return ""
+}
+
+// ── Read Tests ─────────────────────────────────────────────────────────────
+
+func TestRead_SimpleFile(t *testing.T) {
+	content := []byte("hello, axon!\n")
+	path := writeTempFile(t, "read-test-*.txt", content, 0644)
+
+	h := &FileIOHandler{}
+	c := &readCollector{}
+
+	h.HandleRead(&operationspb.ReadRequest{Path: path}, c.send)
+
+	// Check meta.
+	meta := c.meta()
+	if meta == nil {
+		t.Fatal("no ReadMeta received")
+	}
+	if meta.Size != int64(len(content)) {
+		t.Errorf("meta.Size = %d, want %d", meta.Size, len(content))
+	}
+	if meta.Mode != 0644 {
+		t.Errorf("meta.Mode = %04o, want 0644", meta.Mode)
+	}
+
+	// Check data.
+	got := c.data()
+	if !bytes.Equal(got, content) {
+		t.Errorf("data = %q, want %q", got, content)
+	}
+
+	// No error.
+	if e := c.errMsg(); e != "" {
+		t.Errorf("unexpected error: %s", e)
+	}
+}
+
+func TestRead_LargeFile(t *testing.T) {
+	// Create a file larger than readChunkSize (32KB).
+	content := bytes.Repeat([]byte("x"), 100*1024)
+	path := writeTempFile(t, "read-large-*.bin", content, 0644)
+
+	h := &FileIOHandler{}
+	c := &readCollector{}
+
+	h.HandleRead(&operationspb.ReadRequest{Path: path}, c.send)
+
+	got := c.data()
+	if !bytes.Equal(got, content) {
+		t.Errorf("data length = %d, want %d", len(got), len(content))
+	}
+}
+
+func TestRead_NotFound(t *testing.T) {
+	h := &FileIOHandler{}
+	c := &readCollector{}
+
+	h.HandleRead(&operationspb.ReadRequest{Path: "/nonexistent/file.txt"}, c.send)
+
+	e := c.errMsg()
+	if e == "" {
+		t.Fatal("expected error for nonexistent file")
+	}
+	if !contains(e, "not found") {
+		t.Errorf("error = %q, expected to contain 'not found'", e)
+	}
+}
+
+func TestRead_IsDirectory(t *testing.T) {
+	h := &FileIOHandler{}
+	c := &readCollector{}
+
+	h.HandleRead(&operationspb.ReadRequest{Path: os.TempDir()}, c.send)
+
+	e := c.errMsg()
+	if e == "" {
+		t.Fatal("expected error for directory")
+	}
+	if !contains(e, "is a directory") {
+		t.Errorf("error = %q, expected to contain 'is a directory'", e)
+	}
+}
+
+func TestRead_PermissionDenied(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("skipping as root")
+	}
+
+	path := writeTempFile(t, "read-noperm-*.txt", []byte("secret"), 0000)
+
+	h := &FileIOHandler{}
+	c := &readCollector{}
+
+	h.HandleRead(&operationspb.ReadRequest{Path: path}, c.send)
+
+	e := c.errMsg()
+	if e == "" {
+		t.Fatal("expected error for permission denied")
+	}
+	if !contains(e, "permission denied") {
+		t.Errorf("error = %q, expected to contain 'permission denied'", e)
+	}
+}
+
+// ── Write Tests ────────────────────────────────────────────────────────────
+
+func TestWrite_SimpleFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "output.txt")
+	content := []byte("written by axon")
+
+	h := &FileIOHandler{}
+	resp := h.HandleWrite(
+		func() (*operationspb.WriteHeader, error) {
+			return &operationspb.WriteHeader{Path: path, Mode: 0644}, nil
+		},
+		singleChunkRecv(content),
+	)
+
+	if !resp.Success {
+		t.Fatalf("write failed: %s", resp.Error)
+	}
+	if resp.BytesWritten != int64(len(content)) {
+		t.Errorf("BytesWritten = %d, want %d", resp.BytesWritten, len(content))
+	}
+
+	// Verify file content.
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if !bytes.Equal(got, content) {
+		t.Errorf("file content = %q, want %q", got, content)
+	}
+
+	// Verify permissions.
+	info, _ := os.Stat(path)
+	if info.Mode().Perm() != 0644 {
+		t.Errorf("file mode = %04o, want 0644", info.Mode().Perm())
+	}
+}
+
+func TestWrite_CreatesParentDirs(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "a", "b", "c", "file.txt")
+	content := []byte("nested")
+
+	h := &FileIOHandler{}
+	resp := h.HandleWrite(
+		func() (*operationspb.WriteHeader, error) {
+			return &operationspb.WriteHeader{Path: path, Mode: 0644}, nil
+		},
+		singleChunkRecv(content),
+	)
+
+	if !resp.Success {
+		t.Fatalf("write failed: %s", resp.Error)
+	}
+
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if !bytes.Equal(got, content) {
+		t.Errorf("content = %q, want %q", got, content)
+	}
+}
+
+func TestWrite_DefaultMode(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "default-mode.txt")
+
+	h := &FileIOHandler{}
+	resp := h.HandleWrite(
+		func() (*operationspb.WriteHeader, error) {
+			return &operationspb.WriteHeader{Path: path, Mode: 0}, nil // 0 = use default
+		},
+		singleChunkRecv([]byte("data")),
+	)
+
+	if !resp.Success {
+		t.Fatalf("write failed: %s", resp.Error)
+	}
+
+	info, _ := os.Stat(path)
+	if info.Mode().Perm() != 0644 {
+		t.Errorf("file mode = %04o, want 0644 (default)", info.Mode().Perm())
+	}
+}
+
+func TestWrite_MultipleChunks(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "multi.txt")
+
+	chunks := [][]byte{
+		[]byte("chunk1-"),
+		[]byte("chunk2-"),
+		[]byte("chunk3"),
+	}
+	idx := 0
+
+	h := &FileIOHandler{}
+	resp := h.HandleWrite(
+		func() (*operationspb.WriteHeader, error) {
+			return &operationspb.WriteHeader{Path: path, Mode: 0644}, nil
+		},
+		func() ([]byte, error) {
+			if idx >= len(chunks) {
+				return nil, io.EOF
+			}
+			data := chunks[idx]
+			idx++
+			return data, nil
+		},
+	)
+
+	if !resp.Success {
+		t.Fatalf("write failed: %s", resp.Error)
+	}
+
+	expected := []byte("chunk1-chunk2-chunk3")
+	got, _ := os.ReadFile(path)
+	if !bytes.Equal(got, expected) {
+		t.Errorf("content = %q, want %q", got, expected)
+	}
+	if resp.BytesWritten != int64(len(expected)) {
+		t.Errorf("BytesWritten = %d, want %d", resp.BytesWritten, len(expected))
+	}
+}
+
+func TestWrite_Overwrite(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "overwrite.txt")
+
+	// Write initial content.
+	_ = os.WriteFile(path, []byte("old content"), 0644)
+
+	h := &FileIOHandler{}
+	resp := h.HandleWrite(
+		func() (*operationspb.WriteHeader, error) {
+			return &operationspb.WriteHeader{Path: path, Mode: 0644}, nil
+		},
+		singleChunkRecv([]byte("new content")),
+	)
+
+	if !resp.Success {
+		t.Fatalf("write failed: %s", resp.Error)
+	}
+
+	got, _ := os.ReadFile(path)
+	if string(got) != "new content" {
+		t.Errorf("content = %q, want %q", got, "new content")
+	}
+}
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+func writeTempFile(t *testing.T, pattern string, content []byte, mode os.FileMode) string {
+	t.Helper()
+	f, err := os.CreateTemp("", pattern)
+	if err != nil {
+		t.Fatalf("CreateTemp: %v", err)
+	}
+	if _, err := f.Write(content); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if err := f.Chmod(mode); err != nil {
+		t.Fatalf("Chmod: %v", err)
+	}
+	_ = f.Close()
+	t.Cleanup(func() { _ = os.Remove(f.Name()) })
+	return f.Name()
+}
+
+func singleChunkRecv(data []byte) func() ([]byte, error) {
+	sent := false
+	return func() ([]byte, error) {
+		if sent {
+			return nil, io.EOF
+		}
+		sent = true
+		return data, nil
+	}
+}
+
+func contains(s, sub string) bool {
+	return len(s) >= len(sub) && bytes.Contains([]byte(s), []byte(sub))
+}


### PR DESCRIPTION
## C-11: Agent Read/Write Handlers

### What
`internal/agent/fileio.go` — FileIOHandler processes ReadRequest and WriteInput streams on the local filesystem.

**Read:**
- `stat()` → send `ReadMeta` (size, mode, mtime)
- Stream file content in 32KB chunks as `ReadOutput_Data`
- Error classification: not found, permission denied, is directory

**Write:**
- Receive `WriteHeader` (path, mode) → create parent directories
- Receive data chunks → write to temp file
- Atomic commit: `chmod` + `rename` (prevents partial writes)
- Default mode `0644` when not specified
- Returns `WriteResponse` with `bytes_written`

### Tests (10)
| Test | Validates |
|------|-----------|
| Read_SimpleFile | Meta + data content match |
| Read_LargeFile | 100KB file streamed in multiple chunks |
| Read_NotFound | Error message for missing file |
| Read_IsDirectory | Error message for directory path |
| Read_PermissionDenied | Error for 0000 mode file |
| Write_SimpleFile | Content + permissions correct |
| Write_CreatesParentDirs | Nested dirs created automatically |
| Write_DefaultMode | Mode 0 defaults to 0644 |
| Write_MultipleChunks | 3 chunks concatenated correctly |
| Write_Overwrite | Existing file replaced atomically |

### Dependencies
- C-9 (Agent control plane) ✅

### Checklist
- [x] Branch from `origin/dev` ✅
- [x] `go build ./...` passes
- [x] `go test ./...` all green
- [x] `go vet ./...` clean
- [x] Single clean commit
- [x] PR base: `dev`