### PR TITLE
feat(agent): add port forward handler with bidirectional relay

### DIFF
--- a/internal/agent/forward.go
+++ b/internal/agent/forward.go
@@ -49,7 +49,11 @@ func (h *ForwardHandler) Handle(
 	// gRPC → TCP: read from stream, write to TCP.
 	go func() {
 		defer wg.Done()
-		defer func() { _ = conn.(*net.TCPConn).CloseWrite() }()
+		defer func() {
+			if tc, ok := conn.(*net.TCPConn); ok {
+				_ = tc.CloseWrite()
+			}
+		}()
 
 		for {
 			msg, err := recv()
@@ -122,20 +126,18 @@ func (h *ForwardHandler) HandleStream(
 	// Create a wrapper recv that returns the first payload then delegates.
 	var firstPayloadConsumed bool
 	wrappedRecv := func() (*operationspb.TunnelData, error) {
-		if !firstPayloadConsumed && len(first.Payload) > 0 {
+		if !firstPayloadConsumed {
 			firstPayloadConsumed = true
-			return &operationspb.TunnelData{
-				ConnectionId: connID,
-				Payload:      first.Payload,
-			}, nil
+			if len(first.Payload) > 0 {
+				return &operationspb.TunnelData{
+					ConnectionId: connID,
+					Payload:      first.Payload,
+				}, nil
+			}
+			if first.Close {
+				return &operationspb.TunnelData{Close: true}, io.EOF
+			}
 		}
-		firstPayloadConsumed = true
-
-		// Check if first message was also a close.
-		if !firstPayloadConsumed && first.Close {
-			return &operationspb.TunnelData{Close: true}, io.EOF
-		}
-
 		return recv()
 	}
 

--- a/internal/agent/forward.go
+++ b/internal/agent/forward.go
@@ -1,0 +1,143 @@
+package agent
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"sync"
+
+	operationspb "github.com/garysng/axon/gen/proto/operations"
+)
+
+const forwardBufSize = 32 * 1024 // 32 KB
+
+// ForwardHandler relays traffic between a gRPC stream and a local TCP port.
+type ForwardHandler struct{}
+
+// Handle dials localhost:<remotePort> and relays data bidirectionally between
+// the gRPC stream and the TCP connection. It blocks until either side closes
+// or ctx is cancelled.
+func (h *ForwardHandler) Handle(
+	ctx context.Context,
+	remotePort int32,
+	connID string,
+	recv func() (*operationspb.TunnelData, error),
+	send func(*operationspb.TunnelData) error,
+) error {
+	addr := fmt.Sprintf("127.0.0.1:%d", remotePort)
+	conn, err := net.Dial("tcp", addr)
+	if err != nil {
+		// Send close signal with error context, then return.
+		_ = send(&operationspb.TunnelData{
+			ConnectionId: connID,
+			Close:        true,
+		})
+		return fmt.Errorf("forward: dial %s: %w", addr, err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	// Cancel everything when ctx is done.
+	go func() {
+		<-ctx.Done()
+		_ = conn.Close()
+	}()
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	// gRPC → TCP: read from stream, write to TCP.
+	go func() {
+		defer wg.Done()
+		defer func() { _ = conn.(*net.TCPConn).CloseWrite() }()
+
+		for {
+			msg, err := recv()
+			if err != nil {
+				return
+			}
+			if msg.Close {
+				return
+			}
+			if len(msg.Payload) > 0 {
+				if _, err := conn.Write(msg.Payload); err != nil {
+					return
+				}
+			}
+		}
+	}()
+
+	// TCP → gRPC: read from TCP, write to stream.
+	go func() {
+		defer wg.Done()
+
+		buf := make([]byte, forwardBufSize)
+		for {
+			n, err := conn.Read(buf)
+			if n > 0 {
+				data := make([]byte, n)
+				copy(data, buf[:n])
+				if sendErr := send(&operationspb.TunnelData{
+					ConnectionId: connID,
+					Payload:      data,
+				}); sendErr != nil {
+					return
+				}
+			}
+			if err != nil {
+				// Send close signal on EOF or error.
+				_ = send(&operationspb.TunnelData{
+					ConnectionId: connID,
+					Close:        true,
+				})
+				return
+			}
+		}
+	}()
+
+	wg.Wait()
+	return nil
+}
+
+// HandleStream is a convenience wrapper that reads the first TunnelData
+// message to extract TunnelOpen, then calls Handle with the remaining stream.
+// This matches the server-side Forward RPC pattern.
+func (h *ForwardHandler) HandleStream(
+	ctx context.Context,
+	first *operationspb.TunnelData,
+	recv func() (*operationspb.TunnelData, error),
+	send func(*operationspb.TunnelData) error,
+) error {
+	open := first.GetOpen()
+	if open == nil {
+		return fmt.Errorf("forward: first message must contain TunnelOpen")
+	}
+
+	connID := first.ConnectionId
+	if connID == "" {
+		connID = "default"
+	}
+
+	// If the first message also carries payload, we need to handle it.
+	// Create a wrapper recv that returns the first payload then delegates.
+	var firstPayloadConsumed bool
+	wrappedRecv := func() (*operationspb.TunnelData, error) {
+		if !firstPayloadConsumed && len(first.Payload) > 0 {
+			firstPayloadConsumed = true
+			return &operationspb.TunnelData{
+				ConnectionId: connID,
+				Payload:      first.Payload,
+			}, nil
+		}
+		firstPayloadConsumed = true
+
+		// Check if first message was also a close.
+		if !firstPayloadConsumed && first.Close {
+			return &operationspb.TunnelData{Close: true}, io.EOF
+		}
+
+		return recv()
+	}
+
+	return h.Handle(ctx, open.RemotePort, connID, wrappedRecv, send)
+}

--- a/internal/agent/forward_test.go
+++ b/internal/agent/forward_test.go
@@ -30,7 +30,7 @@ func startEchoServer(t *testing.T) int {
 				return
 			}
 			go func(c net.Conn) {
-				defer c.Close()
+				defer func() { _ = c.Close() }()
 				_, _ = io.Copy(c, c)
 			}(conn)
 		}

--- a/internal/agent/forward_test.go
+++ b/internal/agent/forward_test.go
@@ -1,0 +1,382 @@
+package agent
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	operationspb "github.com/garysng/axon/gen/proto/operations"
+)
+
+// startEchoServer starts a TCP server that echoes received data back.
+// Returns the port and a cleanup function.
+func startEchoServer(t *testing.T) int {
+	t.Helper()
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	port := lis.Addr().(*net.TCPAddr).Port
+
+	go func() {
+		for {
+			conn, err := lis.Accept()
+			if err != nil {
+				return
+			}
+			go func(c net.Conn) {
+				defer c.Close()
+				_, _ = io.Copy(c, c)
+			}(conn)
+		}
+	}()
+
+	t.Cleanup(func() { _ = lis.Close() })
+	return port
+}
+
+// startCloseServer starts a TCP server that accepts and immediately closes.
+func startCloseServer(t *testing.T) int {
+	t.Helper()
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	port := lis.Addr().(*net.TCPAddr).Port
+
+	go func() {
+		for {
+			conn, err := lis.Accept()
+			if err != nil {
+				return
+			}
+			_ = conn.Close()
+		}
+	}()
+
+	t.Cleanup(func() { _ = lis.Close() })
+	return port
+}
+
+// tunnelPipe simulates a gRPC bidi stream for testing.
+type tunnelPipe struct {
+	mu       sync.Mutex
+	incoming chan *operationspb.TunnelData // "client" → handler
+	outgoing []*operationspb.TunnelData   // handler → "client"
+	outCh    chan struct{}
+}
+
+func newTunnelPipe() *tunnelPipe {
+	return &tunnelPipe{
+		incoming: make(chan *operationspb.TunnelData, 100),
+		outCh:    make(chan struct{}, 100),
+	}
+}
+
+func (p *tunnelPipe) recv() (*operationspb.TunnelData, error) {
+	msg, ok := <-p.incoming
+	if !ok {
+		return nil, io.EOF
+	}
+	return msg, nil
+}
+
+func (p *tunnelPipe) send(msg *operationspb.TunnelData) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.outgoing = append(p.outgoing, msg)
+	select {
+	case p.outCh <- struct{}{}:
+	default:
+	}
+	return nil
+}
+
+func (p *tunnelPipe) clientSend(msg *operationspb.TunnelData) {
+	p.incoming <- msg
+}
+
+func (p *tunnelPipe) clientClose() {
+	close(p.incoming)
+}
+
+func (p *tunnelPipe) waitOutput(n int, timeout time.Duration) []*operationspb.TunnelData {
+	deadline := time.After(timeout)
+	for {
+		p.mu.Lock()
+		if len(p.outgoing) >= n {
+			out := make([]*operationspb.TunnelData, len(p.outgoing))
+			copy(out, p.outgoing)
+			p.mu.Unlock()
+			return out
+		}
+		p.mu.Unlock()
+
+		select {
+		case <-p.outCh:
+		case <-deadline:
+			p.mu.Lock()
+			out := make([]*operationspb.TunnelData, len(p.outgoing))
+			copy(out, p.outgoing)
+			p.mu.Unlock()
+			return out
+		}
+	}
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────
+
+func TestForward_EchoRoundTrip(t *testing.T) {
+	port := startEchoServer(t)
+	h := &ForwardHandler{}
+	pipe := newTunnelPipe()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	// Run handler in background.
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- h.Handle(ctx, int32(port), "conn-1", pipe.recv, pipe.send)
+	}()
+
+	// Give handler time to connect.
+	time.Sleep(100 * time.Millisecond)
+
+	// Send data.
+	pipe.clientSend(&operationspb.TunnelData{
+		ConnectionId: "conn-1",
+		Payload:      []byte("hello"),
+	})
+
+	// Wait for echo response.
+	outputs := pipe.waitOutput(1, 3*time.Second)
+	if len(outputs) == 0 {
+		t.Fatal("no output received from echo server")
+	}
+
+	var echoed bytes.Buffer
+	for _, o := range outputs {
+		if !o.Close {
+			echoed.Write(o.Payload)
+		}
+	}
+	if echoed.String() != "hello" {
+		t.Errorf("echo = %q, want %q", echoed.String(), "hello")
+	}
+
+	// Close client side.
+	pipe.clientClose()
+
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Logf("handler returned: %v (expected)", err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("handler did not exit after client close")
+	}
+}
+
+func TestForward_PortUnreachable(t *testing.T) {
+	h := &ForwardHandler{}
+	pipe := newTunnelPipe()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	// Use a port that is (very likely) not listening.
+	err := h.Handle(ctx, 1, "conn-1", pipe.recv, pipe.send)
+	if err == nil {
+		t.Fatal("expected error for unreachable port")
+	}
+
+	// Should have sent a close signal.
+	outputs := pipe.waitOutput(1, time.Second)
+	if len(outputs) == 0 {
+		t.Fatal("expected close signal for unreachable port")
+	}
+	if !outputs[0].Close {
+		t.Error("expected close=true in response")
+	}
+}
+
+func TestForward_ServerCloses(t *testing.T) {
+	port := startCloseServer(t)
+	h := &ForwardHandler{}
+	pipe := newTunnelPipe()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- h.Handle(ctx, int32(port), "conn-1", pipe.recv, pipe.send)
+	}()
+
+	// Server immediately closes, handler should detect and send close.
+	outputs := pipe.waitOutput(1, 3*time.Second)
+
+	foundClose := false
+	for _, o := range outputs {
+		if o.Close {
+			foundClose = true
+		}
+	}
+	if !foundClose {
+		t.Error("expected close signal when server closes connection")
+	}
+
+	pipe.clientClose()
+
+	select {
+	case <-errCh:
+	case <-time.After(3 * time.Second):
+		t.Fatal("handler did not exit")
+	}
+}
+
+func TestForward_ContextCancel(t *testing.T) {
+	port := startEchoServer(t)
+	h := &ForwardHandler{}
+	pipe := newTunnelPipe()
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- h.Handle(ctx, int32(port), "conn-1", pipe.recv, pipe.send)
+	}()
+
+	// Give handler time to connect.
+	time.Sleep(100 * time.Millisecond)
+
+	// Cancel context and close client channel (simulating gRPC stream close).
+	cancel()
+	pipe.clientClose()
+
+	select {
+	case <-errCh:
+		// OK, handler exited.
+	case <-time.After(3 * time.Second):
+		t.Fatal("handler did not exit after context cancel")
+	}
+}
+
+func TestForward_HandleStream(t *testing.T) {
+	port := startEchoServer(t)
+	h := &ForwardHandler{}
+	pipe := newTunnelPipe()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	first := &operationspb.TunnelData{
+		ConnectionId: "stream-1",
+		Open: &operationspb.TunnelOpen{
+			NodeId:     "node-1",
+			RemotePort: int32(port),
+		},
+	}
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- h.HandleStream(ctx, first, pipe.recv, pipe.send)
+	}()
+
+	time.Sleep(100 * time.Millisecond)
+
+	pipe.clientSend(&operationspb.TunnelData{
+		ConnectionId: "stream-1",
+		Payload:      []byte("via-stream"),
+	})
+
+	outputs := pipe.waitOutput(1, 3*time.Second)
+	if len(outputs) == 0 {
+		t.Fatal("no output received")
+	}
+
+	var echoed bytes.Buffer
+	for _, o := range outputs {
+		if !o.Close {
+			echoed.Write(o.Payload)
+		}
+	}
+	if echoed.String() != "via-stream" {
+		t.Errorf("echo = %q, want %q", echoed.String(), "via-stream")
+	}
+
+	pipe.clientClose()
+
+	select {
+	case <-errCh:
+	case <-time.After(3 * time.Second):
+		t.Fatal("handler did not exit")
+	}
+}
+
+func TestForward_HandleStream_NoTunnelOpen(t *testing.T) {
+	h := &ForwardHandler{}
+	first := &operationspb.TunnelData{
+		ConnectionId: "bad",
+		Payload:      []byte("data"),
+	}
+
+	err := h.HandleStream(context.Background(), first, nil, nil)
+	if err == nil {
+		t.Fatal("expected error for missing TunnelOpen")
+	}
+}
+
+func TestForward_MultipleMessages(t *testing.T) {
+	port := startEchoServer(t)
+	h := &ForwardHandler{}
+	pipe := newTunnelPipe()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- h.Handle(ctx, int32(port), "conn-1", pipe.recv, pipe.send)
+	}()
+
+	time.Sleep(100 * time.Millisecond)
+
+	// Send multiple messages.
+	for i := 0; i < 5; i++ {
+		pipe.clientSend(&operationspb.TunnelData{
+			ConnectionId: "conn-1",
+			Payload:      []byte(fmt.Sprintf("msg%d-", i)),
+		})
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	// Wait for echoed data.
+	outputs := pipe.waitOutput(3, 3*time.Second)
+
+	var echoed bytes.Buffer
+	for _, o := range outputs {
+		if !o.Close {
+			echoed.Write(o.Payload)
+		}
+	}
+
+	expected := "msg0-msg1-msg2-msg3-msg4-"
+	if echoed.String() != expected {
+		t.Errorf("echo = %q, want %q", echoed.String(), expected)
+	}
+
+	pipe.clientClose()
+
+	select {
+	case <-errCh:
+	case <-time.After(3 * time.Second):
+		t.Fatal("handler did not exit")
+	}
+}


### PR DESCRIPTION
## C-12: Agent Forward (Port Tunneling)

### What
`internal/agent/forward.go` — ForwardHandler relays traffic between a gRPC bidi stream and a local TCP port.

**Flow:**
1. Receive `TunnelOpen` with target port
2. Dial `127.0.0.1:<port>`
3. Bidirectional relay via concurrent goroutines:
   - gRPC → TCP: read `TunnelData.payload`, write to TCP
   - TCP → gRPC: read TCP data in 32KB chunks, send as `TunnelData`
4. Close propagation: either side closes → send `TunnelData{close: true}`
5. Context cancel → TCP connection closed → both goroutines exit

**Also provides:** `HandleStream` convenience method that extracts `TunnelOpen` from the first message.

### Tests (7)
| Test | Validates |
|------|-----------|
| EchoRoundTrip | Send data → echo server → receive same data |
| PortUnreachable | Dial port 1 → error + close signal |
| ServerCloses | TCP server closes immediately → close signal |
| ContextCancel | ctx.Cancel → handler exits cleanly |
| HandleStream | Full flow via HandleStream wrapper |
| HandleStream_NoTunnelOpen | Missing TunnelOpen → error |
| MultipleMessages | 5 sequential messages echoed correctly |

### Dependencies
- C-9 (Agent control plane) ✅

### Checklist
- [x] Branch from `origin/dev` ✅
- [x] `go build ./...` passes
- [x] `go test ./...` all green (incl. integration tests)
- [x] `go vet ./...` clean
- [x] Single clean commit
- [x] PR base: `dev`