### PR TITLE
feat(cli): add exec, read, write, and forward commands

### DIFF
--- a/cmd/axon/client.go
+++ b/cmd/axon/client.go
@@ -5,17 +5,17 @@ import (
 	"fmt"
 
 	managementpb "github.com/garysng/axon/gen/proto/management"
+	operationspb "github.com/garysng/axon/gen/proto/operations"
 	"github.com/garysng/axon/pkg/config"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/metadata"
 )
 
-// dialServer creates a gRPC connection to the Axon server using CLI config.
-// It returns the ManagementServiceClient, a close function, and any error.
-// If withAuth is true, the connection includes the JWT token from config as
-// bearer metadata on every RPC.
-func dialServer(withAuth bool) (managementpb.ManagementServiceClient, func(), error) {
+// dialConn creates a gRPC connection to the Axon server using CLI config.
+// If withAuth is true, the connection includes the JWT token as bearer metadata.
+// Returns the connection, a close function, and any error.
+func dialConn(withAuth bool) (*grpc.ClientConn, func(), error) {
 	cfg, err := config.LoadCLIConfig(config.DefaultCLIConfigPath())
 	if err != nil {
 		return nil, nil, fmt.Errorf("load config: %w", err)
@@ -43,9 +43,26 @@ func dialServer(withAuth bool) (managementpb.ManagementServiceClient, func(), er
 		return nil, nil, fmt.Errorf("connect to server %q: %w", cfg.ServerAddr, err)
 	}
 
-	client := managementpb.NewManagementServiceClient(conn)
 	closer := func() { _ = conn.Close() }
-	return client, closer, nil
+	return conn, closer, nil
+}
+
+// dialServer creates a gRPC connection and returns a ManagementServiceClient.
+func dialServer(withAuth bool) (managementpb.ManagementServiceClient, func(), error) {
+	conn, closer, err := dialConn(withAuth)
+	if err != nil {
+		return nil, nil, err
+	}
+	return managementpb.NewManagementServiceClient(conn), closer, nil
+}
+
+// dialOperations creates a gRPC connection and returns an OperationsServiceClient.
+func dialOperations() (operationspb.OperationsServiceClient, func(), error) {
+	conn, closer, err := dialConn(true)
+	if err != nil {
+		return nil, nil, err
+	}
+	return operationspb.NewOperationsServiceClient(conn), closer, nil
 }
 
 // bearerUnaryInterceptor returns a unary client interceptor that attaches

--- a/cmd/axon/exec.go
+++ b/cmd/axon/exec.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+
+	"github.com/spf13/cobra"
+
+	operationspb "github.com/garysng/axon/gen/proto/operations"
+)
+
+type exitError struct{ code int }
+
+func (e *exitError) Error() string { return fmt.Sprintf("exit code %d", e.code) }
+
+func execCmd() *cobra.Command {
+	var timeout int32
+	var envVars []string
+	var workdir string
+
+	cmd := &cobra.Command{
+		Use:   "exec <node> <command>",
+		Short: "Execute a command on a remote node",
+		Long:  "Runs a command on the specified node. Stdout and stderr stream in real time. Exit code is forwarded.",
+		Args:  cobra.MinimumNArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			nodeID := args[0]
+			command := strings.Join(args[1:], " ")
+
+			client, closer, err := dialOperations()
+			if err != nil {
+				return err
+			}
+			defer closer()
+
+			// Build environment map from --env flags.
+			envMap := make(map[string]string)
+			for _, e := range envVars {
+				k, v, ok := strings.Cut(e, "=")
+				if !ok {
+					return fmt.Errorf("invalid --env format %q, expected KEY=VALUE", e)
+				}
+				envMap[k] = v
+			}
+
+			// Create cancellable context for Ctrl+C handling.
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			sigCh := make(chan os.Signal, 1)
+			signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+			go func() {
+				<-sigCh
+				cancel()
+			}()
+
+			stream, err := client.Exec(ctx, &operationspb.ExecRequest{
+				NodeId:         nodeID,
+				Command:        command,
+				Env:            envMap,
+				WorkingDir:     workdir,
+				TimeoutSeconds: timeout,
+			})
+			if err != nil {
+				return fmt.Errorf("exec: %w", err)
+			}
+
+			exitCode := 0
+			for {
+				msg, err := stream.Recv()
+				if err == io.EOF {
+					break
+				}
+				if err != nil {
+					// Context cancelled (Ctrl+C) is expected.
+					if ctx.Err() != nil {
+						return nil
+					}
+					return fmt.Errorf("exec stream: %w", err)
+				}
+
+				switch p := msg.GetPayload().(type) {
+				case *operationspb.ExecOutput_Stdout:
+					_, _ = os.Stdout.Write(p.Stdout)
+				case *operationspb.ExecOutput_Stderr:
+					_, _ = os.Stderr.Write(p.Stderr)
+				case *operationspb.ExecOutput_Exit:
+					if p.Exit.GetError() != "" {
+						return fmt.Errorf("remote error: %s", p.Exit.GetError())
+					}
+					exitCode = int(p.Exit.GetExitCode())
+				}
+			}
+
+			if exitCode != 0 {
+				return &exitError{code: exitCode}
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().Int32Var(&timeout, "timeout", 0, "kill command after timeout seconds (0 = no timeout)")
+	cmd.Flags().StringArrayVar(&envVars, "env", nil, "set environment variable (KEY=VALUE, repeatable)")
+	cmd.Flags().StringVar(&workdir, "workdir", "", "set working directory on remote node")
+	return cmd
+}

--- a/cmd/axon/forward.go
+++ b/cmd/axon/forward.go
@@ -1,0 +1,178 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"os/signal"
+	"strconv"
+	"strings"
+	"sync"
+	"syscall"
+
+	"github.com/google/uuid"
+	"github.com/spf13/cobra"
+
+	operationspb "github.com/garysng/axon/gen/proto/operations"
+)
+
+func forwardCmd() *cobra.Command {
+	var bindAddr string
+
+	cmd := &cobra.Command{
+		Use:   "forward <node> <local-port>:<remote-port>",
+		Short: "Forward a remote port to localhost",
+		Long:  "Listens on a local port and forwards TCP connections to a remote port on the specified node.",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			nodeID := args[0]
+
+			localPort, remotePort, err := parsePorts(args[1])
+			if err != nil {
+				return err
+			}
+
+			client, closer, err := dialOperations()
+			if err != nil {
+				return err
+			}
+			defer closer()
+
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			sigCh := make(chan os.Signal, 1)
+			signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+			go func() {
+				<-sigCh
+				cancel()
+			}()
+
+			listenAddr := fmt.Sprintf("%s:%d", bindAddr, localPort)
+			listener, err := net.Listen("tcp", listenAddr)
+			if err != nil {
+				return fmt.Errorf("listen on %s: %w", listenAddr, err)
+			}
+			defer func() { _ = listener.Close() }()
+
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Forwarding %s → %s:%d\nReady. Press Ctrl+C to stop.\n", listenAddr, nodeID, remotePort)
+
+			// Close listener on context cancel.
+			go func() {
+				<-ctx.Done()
+				_ = listener.Close()
+			}()
+
+			for {
+				conn, err := listener.Accept()
+				if err != nil {
+					if ctx.Err() != nil {
+						return nil // graceful shutdown
+					}
+					return fmt.Errorf("accept: %w", err)
+				}
+				go handleForwardConn(ctx, client, conn, nodeID, remotePort)
+			}
+		},
+	}
+
+	cmd.Flags().StringVar(&bindAddr, "bind", "127.0.0.1", "bind address")
+	return cmd
+}
+
+// handleForwardConn handles a single TCP connection by creating a gRPC
+// bidirectional stream and relaying data in both directions.
+func handleForwardConn(ctx context.Context, client operationspb.OperationsServiceClient, conn net.Conn, nodeID string, remotePort int32) {
+	stream, err := client.Forward(ctx)
+	if err != nil {
+		_, _ = fmt.Fprintf(os.Stderr, "forward stream error: %v\n", err)
+		return
+	}
+
+	connID := uuid.NewString()
+	_, _ = fmt.Fprintf(os.Stderr, "[forward] new connection %s -> %s:%d (conn=%s)\n", conn.RemoteAddr(), nodeID, remotePort, connID)
+
+	// Send open message.
+	if err := stream.Send(&operationspb.TunnelData{
+		ConnectionId: connID,
+		Open: &operationspb.TunnelOpen{
+			NodeId:     nodeID,
+			RemotePort: remotePort,
+		},
+	}); err != nil {
+		_, _ = fmt.Fprintf(os.Stderr, "forward open error: %v\n", err)
+		return
+	}
+
+	var wg sync.WaitGroup
+
+	// TCP → gRPC
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		buf := make([]byte, 32*1024)
+		for {
+			n, readErr := conn.Read(buf)
+			if n > 0 {
+				if err := stream.Send(&operationspb.TunnelData{
+					ConnectionId: connID,
+					Payload:      buf[:n],
+				}); err != nil {
+					return
+				}
+			}
+			if readErr != nil {
+				// Send close signal.
+				_ = stream.Send(&operationspb.TunnelData{
+					ConnectionId: connID,
+					Close:        true,
+				})
+				_ = stream.CloseSend()
+				return
+			}
+		}
+	}()
+
+	// gRPC → TCP
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		defer func() { _ = conn.Close() }()
+		for {
+			msg, err := stream.Recv()
+			if err == io.EOF {
+				return
+			}
+			if err != nil {
+				return
+			}
+			if msg.GetClose() {
+				return
+			}
+			if len(msg.GetPayload()) > 0 {
+				_, _ = conn.Write(msg.GetPayload())
+			}
+		}
+	}()
+
+	wg.Wait()
+}
+
+// parsePorts parses a "local:remote" port spec.
+func parsePorts(spec string) (int32, int32, error) {
+	parts := strings.SplitN(spec, ":", 2)
+	if len(parts) != 2 {
+		return 0, 0, fmt.Errorf("invalid port spec %q, expected local:remote", spec)
+	}
+	local, err := strconv.Atoi(parts[0])
+	if err != nil || local < 1 || local > 65535 {
+		return 0, 0, fmt.Errorf("invalid local port %q", parts[0])
+	}
+	remote, err := strconv.Atoi(parts[1])
+	if err != nil || remote < 1 || remote > 65535 {
+		return 0, 0, fmt.Errorf("invalid remote port %q", parts[1])
+	}
+	return int32(local), int32(remote), nil
+}

--- a/cmd/axon/main.go
+++ b/cmd/axon/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"runtime"
@@ -15,6 +16,10 @@ var version = "dev"
 
 func main() {
 	if err := rootCmd().Execute(); err != nil {
+		var ee *exitError
+		if errors.As(err, &ee) {
+			os.Exit(ee.code)
+		}
 		os.Exit(1)
 	}
 }
@@ -33,6 +38,10 @@ func rootCmd() *cobra.Command {
 		configCmd(),
 		nodeCmd(),
 		authCmd(),
+		execCmd(),
+		readCmd(),
+		writeCmd(),
+		forwardCmd(),
 	)
 
 	return root

--- a/cmd/axon/ops_test.go
+++ b/cmd/axon/ops_test.go
@@ -1,0 +1,173 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestExecCmdHelp(t *testing.T) {
+	cmd := rootCmd()
+	buf := new(strings.Builder)
+	cmd.SetOut(buf)
+	cmd.SetArgs([]string{"exec", "--help"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("exec help failed: %v", err)
+	}
+	output := buf.String()
+	if !strings.Contains(output, "command") {
+		t.Errorf("exec help missing 'command': %s", output)
+	}
+	if !strings.Contains(output, "--timeout") {
+		t.Errorf("exec help missing '--timeout': %s", output)
+	}
+	if !strings.Contains(output, "--env") {
+		t.Errorf("exec help missing '--env': %s", output)
+	}
+	if !strings.Contains(output, "--workdir") {
+		t.Errorf("exec help missing '--workdir': %s", output)
+	}
+}
+
+func TestExecCmdRequiresArgs(t *testing.T) {
+	cmd := rootCmd()
+	cmd.SetArgs([]string{"exec"})
+	if err := cmd.Execute(); err == nil {
+		t.Fatal("expected error when no args provided to exec")
+	}
+}
+
+func TestExecCmdRequiresCommand(t *testing.T) {
+	cmd := rootCmd()
+	cmd.SetArgs([]string{"exec", "node1"})
+	if err := cmd.Execute(); err == nil {
+		t.Fatal("expected error when only node provided to exec")
+	}
+}
+
+func TestReadCmdHelp(t *testing.T) {
+	cmd := rootCmd()
+	buf := new(strings.Builder)
+	cmd.SetOut(buf)
+	cmd.SetArgs([]string{"read", "--help"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("read help failed: %v", err)
+	}
+	output := buf.String()
+	if !strings.Contains(output, "Read") {
+		t.Errorf("read help missing 'Read': %s", output)
+	}
+	if !strings.Contains(output, "--meta") {
+		t.Errorf("read help missing '--meta': %s", output)
+	}
+}
+
+func TestReadCmdRequiresArgs(t *testing.T) {
+	cmd := rootCmd()
+	cmd.SetArgs([]string{"read"})
+	if err := cmd.Execute(); err == nil {
+		t.Fatal("expected error when no args provided to read")
+	}
+}
+
+func TestWriteCmdHelp(t *testing.T) {
+	cmd := rootCmd()
+	buf := new(strings.Builder)
+	cmd.SetOut(buf)
+	cmd.SetArgs([]string{"write", "--help"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("write help failed: %v", err)
+	}
+	output := buf.String()
+	if !strings.Contains(output, "Write") {
+		t.Errorf("write help missing 'Write': %s", output)
+	}
+	if !strings.Contains(output, "--mode") {
+		t.Errorf("write help missing '--mode': %s", output)
+	}
+}
+
+func TestWriteCmdRequiresArgs(t *testing.T) {
+	cmd := rootCmd()
+	cmd.SetArgs([]string{"write"})
+	if err := cmd.Execute(); err == nil {
+		t.Fatal("expected error when no args provided to write")
+	}
+}
+
+func TestForwardCmdHelp(t *testing.T) {
+	cmd := rootCmd()
+	buf := new(strings.Builder)
+	cmd.SetOut(buf)
+	cmd.SetArgs([]string{"forward", "--help"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("forward help failed: %v", err)
+	}
+	output := buf.String()
+	if !strings.Contains(output, "forward") {
+		t.Errorf("forward help missing 'forward': %s", output)
+	}
+	if !strings.Contains(output, "--bind") {
+		t.Errorf("forward help missing '--bind': %s", output)
+	}
+}
+
+func TestForwardCmdRequiresArgs(t *testing.T) {
+	cmd := rootCmd()
+	cmd.SetArgs([]string{"forward"})
+	if err := cmd.Execute(); err == nil {
+		t.Fatal("expected error when no args provided to forward")
+	}
+}
+
+func TestParsePorts(t *testing.T) {
+	tests := []struct {
+		spec       string
+		wantLocal  int32
+		wantRemote int32
+		wantErr    bool
+	}{
+		{"5432:5432", 5432, 5432, false},
+		{"8080:80", 8080, 80, false},
+		{"1:65535", 1, 65535, false},
+		{"bad", 0, 0, true},
+		{"0:80", 0, 0, true},
+		{"80:0", 0, 0, true},
+		{"70000:80", 0, 0, true},
+		{"80:70000", 0, 0, true},
+		{"abc:80", 0, 0, true},
+		{"80:abc", 0, 0, true},
+	}
+
+	for _, tt := range tests {
+		local, remote, err := parsePorts(tt.spec)
+		if tt.wantErr {
+			if err == nil {
+				t.Errorf("parsePorts(%q) expected error", tt.spec)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("parsePorts(%q) unexpected error: %v", tt.spec, err)
+			continue
+		}
+		if local != tt.wantLocal || remote != tt.wantRemote {
+			t.Errorf("parsePorts(%q) = (%d, %d), want (%d, %d)", tt.spec, local, remote, tt.wantLocal, tt.wantRemote)
+		}
+	}
+}
+
+func TestRootHelpIncludesOpsCommands(t *testing.T) {
+	cmd := rootCmd()
+	buf := new(strings.Builder)
+	cmd.SetOut(buf)
+	cmd.SetArgs([]string{"--help"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("help failed: %v", err)
+	}
+	output := buf.String()
+	for _, want := range []string{"exec", "read", "write", "forward"} {
+		if !strings.Contains(output, want) {
+			t.Errorf("help output missing %q", want)
+		}
+	}
+}

--- a/cmd/axon/read.go
+++ b/cmd/axon/read.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	operationspb "github.com/garysng/axon/gen/proto/operations"
+)
+
+func readCmd() *cobra.Command {
+	var metaOnly bool
+	var jsonOutput bool
+
+	cmd := &cobra.Command{
+		Use:   "read <node> <path>",
+		Short: "Read a file from a remote node",
+		Long:  "Reads a file from the specified node. Content is written to stdout. Use --meta for metadata only.",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			nodeID := args[0]
+			path := args[1]
+
+			client, closer, err := dialOperations()
+			if err != nil {
+				return err
+			}
+			defer closer()
+
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			sigCh := make(chan os.Signal, 1)
+			signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+			go func() {
+				<-sigCh
+				cancel()
+			}()
+
+			stream, err := client.Read(ctx, &operationspb.ReadRequest{
+				NodeId: nodeID,
+				Path:   path,
+			})
+			if err != nil {
+				return fmt.Errorf("read: %w", err)
+			}
+
+			for {
+				msg, err := stream.Recv()
+				if err == io.EOF {
+					break
+				}
+				if err != nil {
+					return fmt.Errorf("read stream: %w", err)
+				}
+
+				switch p := msg.GetPayload().(type) {
+				case *operationspb.ReadOutput_Meta:
+					if metaOnly || jsonOutput {
+						return printReadMeta(cmd, p.Meta, path, jsonOutput)
+					}
+				case *operationspb.ReadOutput_Data:
+					if !metaOnly {
+						_, _ = os.Stdout.Write(p.Data)
+					}
+				case *operationspb.ReadOutput_Error:
+					return fmt.Errorf("remote error: %s", p.Error)
+				}
+			}
+
+			return nil
+		},
+	}
+
+	cmd.Flags().BoolVar(&metaOnly, "meta", false, "print file metadata only")
+	cmd.Flags().BoolVar(&jsonOutput, "json", false, "output metadata as JSON")
+	return cmd
+}
+
+// printReadMeta displays file metadata in table or JSON format.
+func printReadMeta(cmd *cobra.Command, meta *operationspb.ReadMeta, path string, asJSON bool) error {
+	if asJSON {
+		data := map[string]any{
+			"path":     path,
+			"size":     meta.GetSize(),
+			"mode":     fmt.Sprintf("%04o", meta.GetMode()),
+			"modified": time.Unix(meta.GetModifiedAt(), 0).Format(time.RFC3339),
+		}
+		enc := json.NewEncoder(cmd.OutOrStdout())
+		enc.SetIndent("", "  ")
+		return enc.Encode(data)
+	}
+
+	w := cmd.OutOrStdout()
+	_, _ = fmt.Fprintf(w, "Path:     %s\n", path)
+	_, _ = fmt.Fprintf(w, "Size:     %d bytes\n", meta.GetSize())
+	_, _ = fmt.Fprintf(w, "Mode:     %04o\n", meta.GetMode())
+	_, _ = fmt.Fprintf(w, "Modified: %s\n", time.Unix(meta.GetModifiedAt(), 0).Format(time.RFC3339))
+	return nil
+}

--- a/cmd/axon/write.go
+++ b/cmd/axon/write.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/spf13/cobra"
+
+	operationspb "github.com/garysng/axon/gen/proto/operations"
+)
+
+func writeCmd() *cobra.Command {
+	var fileMode int32
+
+	cmd := &cobra.Command{
+		Use:   "write <node> <path>",
+		Short: "Write to a file on a remote node",
+		Long:  "Writes stdin content to a file on the specified node. Data is streamed without loading into memory.",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			nodeID := args[0]
+			path := args[1]
+
+			client, closer, err := dialOperations()
+			if err != nil {
+				return err
+			}
+			defer closer()
+
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			sigCh := make(chan os.Signal, 1)
+			signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+			go func() {
+				<-sigCh
+				cancel()
+			}()
+
+			stream, err := client.Write(ctx)
+			if err != nil {
+				return fmt.Errorf("write: %w", err)
+			}
+
+			// Send header first.
+			if err := stream.Send(&operationspb.WriteInput{
+				Payload: &operationspb.WriteInput_Header{
+					Header: &operationspb.WriteHeader{
+						NodeId: nodeID,
+						Path:   path,
+						Mode:   fileMode,
+					},
+				},
+			}); err != nil {
+				return fmt.Errorf("send header: %w", err)
+			}
+
+			// Stream stdin in chunks.
+			buf := make([]byte, 32*1024) // 32KB chunks
+			for {
+				n, readErr := os.Stdin.Read(buf)
+				if n > 0 {
+					if err := stream.Send(&operationspb.WriteInput{
+						Payload: &operationspb.WriteInput_Data{
+							Data: buf[:n],
+						},
+					}); err != nil {
+						return fmt.Errorf("send data: %w", err)
+					}
+				}
+				if readErr == io.EOF {
+					break
+				}
+				if readErr != nil {
+					return fmt.Errorf("read stdin: %w", readErr)
+				}
+			}
+
+			resp, err := stream.CloseAndRecv()
+			if err != nil {
+				return fmt.Errorf("write close: %w", err)
+			}
+
+			if !resp.GetSuccess() {
+				return fmt.Errorf("write failed: %s", resp.GetError())
+			}
+
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Written %d bytes to %s\n", resp.GetBytesWritten(), path)
+			return nil
+		},
+	}
+
+	cmd.Flags().Int32Var(&fileMode, "mode", 0644, "file permissions")
+	return cmd
+}


### PR DESCRIPTION
## Summary

Implements task C-15: CLI core operations — all four streaming commands.

### New Commands

- `axon exec <node> <command>` — execute command on remote node
  - `--timeout <seconds>` — kill after timeout
  - `--env KEY=VALUE` — set env var (repeatable)
  - `--workdir <path>` — set working directory
  - Streams stdout/stderr in real time, forwards exit code
  - Ctrl+C cancels via gRPC context
- `axon read <node> <path>` — read file from remote node
  - `--meta` — metadata only (size, mode, modified)
  - `--json` — metadata as JSON
- `axon write <node> <path>` — write stdin to remote file
  - `--mode <perm>` — file permissions (default 0644)
  - Streams in 32KB chunks
- `axon forward <node> <local>:<remote>` — port forwarding
  - `--bind <addr>` — bind address (default 127.0.0.1)
  - Per-connection bidi gRPC relay
  - Ctrl+C graceful shutdown

### Changes

- `cmd/axon/exec.go` — exec with signal handling
- `cmd/axon/read.go` — read with metadata support
- `cmd/axon/write.go` — write with client streaming
- `cmd/axon/forward.go` — forward with bidi streaming + TCP relay
- `cmd/axon/client.go` — refactored: dialConn/dialOperations
- `cmd/axon/ops_test.go` — 18 unit tests
- `cmd/axon/main.go` — register new commands