### PR TITLE
feat(agent): add agent binary with daemon, start/stop/status commands

### DIFF
--- a/cmd/axon-agent/main.go
+++ b/cmd/axon-agent/main.go
@@ -1,5 +1,388 @@
 package main
 
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"os/signal"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/garysng/axon/internal/agent"
+	"github.com/garysng/axon/pkg/config"
+)
+
+// version is set at build time via -ldflags.
+var version = "dev"
+
 func main() {
-	// TODO: implement axon agent
+	if err := rootCmd().Execute(); err != nil {
+		var ee *exitError
+		if errors.As(err, &ee) {
+			os.Exit(ee.code)
+		}
+		os.Exit(1)
+	}
+}
+
+type exitError struct {
+	code int
+	err  error
+}
+
+func (e *exitError) Error() string { return e.err.Error() }
+func (e *exitError) Unwrap() error { return e.err }
+
+func rootCmd() *cobra.Command {
+	root := &cobra.Command{
+		Use:           "axon-agent",
+		Short:         "Axon agent — connects this machine to the Axon control plane",
+		SilenceUsage:  true,
+		SilenceErrors: true,
+	}
+	root.AddCommand(
+		startCmd(),
+		stopCmd(),
+		statusCmd(),
+		agentConfigCmd(),
+		versionCmd(),
+	)
+	return root
+}
+
+// ── path helpers ───────────────────────────────────────────────────────────
+
+func pidFilePath() string {
+	return filepath.Join(filepath.Dir(config.DefaultAgentConfigPath()), "agent.pid")
+}
+
+func logFilePath() string {
+	return filepath.Join(filepath.Dir(config.DefaultAgentConfigPath()), "agent.log")
+}
+
+func writePID(path string, pid int) error {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		return fmt.Errorf("create dir: %w", err)
+	}
+	return os.WriteFile(path, []byte(strconv.Itoa(pid)+"\n"), 0600)
+}
+
+func readPID(path string) (int, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return 0, err
+	}
+	pid, err := strconv.Atoi(strings.TrimSpace(string(data)))
+	if err != nil {
+		return 0, fmt.Errorf("invalid PID in file: %w", err)
+	}
+	return pid, nil
+}
+
+func isProcessRunning(pid int) bool {
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		return false
+	}
+	return proc.Signal(syscall.Signal(0)) == nil
+}
+
+// maskToken returns a masked version of a token for display.
+func maskToken(token string) string {
+	if token == "" {
+		return "(not set)"
+	}
+	if len(token) < 12 {
+		return "***"
+	}
+	return token[:6] + "..." + token[len(token)-3:]
+}
+
+// ── version ────────────────────────────────────────────────────────────────
+
+func versionCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "version",
+		Short: "Print version info",
+		Run: func(cmd *cobra.Command, args []string) {
+			_, _ = fmt.Printf("axon-agent %s (%s, %s/%s)\n", version, runtime.Version(), runtime.GOOS, runtime.GOARCH)
+		},
+	}
+}
+
+// ── start ──────────────────────────────────────────────────────────────────
+
+func startCmd() *cobra.Command {
+	var (
+		flagServer     string
+		flagToken      string
+		flagName       string
+		flagLabels     []string
+		flagForeground bool
+	)
+
+	cmd := &cobra.Command{
+		Use:   "start",
+		Short: "Start the agent",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cfgPath := config.DefaultAgentConfigPath()
+			cfg, err := config.LoadAgentConfig(cfgPath)
+			if err != nil {
+				return fmt.Errorf("load config: %w", err)
+			}
+
+			// Apply flag overrides only when the flag was explicitly set.
+			if cmd.Flags().Changed("server") {
+				cfg.ServerAddr = flagServer
+			}
+			if cmd.Flags().Changed("token") {
+				cfg.Token = flagToken
+			}
+			if cmd.Flags().Changed("name") {
+				cfg.NodeName = flagName
+			}
+			if len(flagLabels) > 0 {
+				if cfg.Labels == nil {
+					cfg.Labels = make(map[string]string)
+				}
+				for _, kv := range flagLabels {
+					parts := strings.SplitN(kv, "=", 2)
+					if len(parts) != 2 {
+						return fmt.Errorf("invalid label %q (expected key=value)", kv)
+					}
+					cfg.Labels[parts[0]] = parts[1]
+				}
+			}
+
+			if flagForeground {
+				return runForeground(cfg, cfgPath)
+			}
+			return runDaemon(cmd, flagServer, flagToken, flagName, flagLabels)
+		},
+	}
+
+	cmd.Flags().StringVar(&flagServer, "server", "", "Server address (overrides config)")
+	cmd.Flags().StringVar(&flagToken, "token", "", "Auth token (overrides config)")
+	cmd.Flags().StringVar(&flagName, "name", "", "Node name (overrides config)")
+	cmd.Flags().StringArrayVar(&flagLabels, "labels", nil, "Label as key=value (repeatable)")
+	cmd.Flags().BoolVar(&flagForeground, "foreground", false, "Run in foreground (do not daemonize)")
+
+	return cmd
+}
+
+// runForeground runs the agent in the foreground, blocking until context
+// cancellation (SIGINT/SIGTERM).
+func runForeground(cfg *config.AgentConfig, cfgPath string) error {
+	pidPath := pidFilePath()
+	if err := writePID(pidPath, os.Getpid()); err != nil {
+		return fmt.Errorf("write PID: %w", err)
+	}
+	defer func() { _ = os.Remove(pidPath) }()
+
+	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer cancel()
+
+	a := agent.NewAgent(*cfg, cfgPath)
+	if err := a.Run(ctx); err != nil && !errors.Is(err, context.Canceled) {
+		return fmt.Errorf("agent: %w", err)
+	}
+	return nil
+}
+
+// runDaemon re-execs self with --foreground, detached from the current
+// process group. The parent exits immediately after spawning the daemon.
+func runDaemon(cmd *cobra.Command, server, token, name string, labels []string) error {
+	exe, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("get executable path: %w", err)
+	}
+
+	// Reconstruct start args with --foreground.
+	args := []string{"start", "--foreground"}
+	if cmd.Flags().Changed("server") {
+		args = append(args, "--server", server)
+	}
+	if cmd.Flags().Changed("token") {
+		args = append(args, "--token", token)
+	}
+	if cmd.Flags().Changed("name") {
+		args = append(args, "--name", name)
+	}
+	for _, l := range labels {
+		args = append(args, "--labels", l)
+	}
+
+	logPath := logFilePath()
+	if err := os.MkdirAll(filepath.Dir(logPath), 0700); err != nil {
+		return fmt.Errorf("create log dir: %w", err)
+	}
+	logFile, err := os.OpenFile(logPath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0600)
+	if err != nil {
+		return fmt.Errorf("open log file: %w", err)
+	}
+	defer func() { _ = logFile.Close() }()
+
+	daemonCmd := exec.Command(exe, args...)
+	daemonCmd.Stdout = logFile
+	daemonCmd.Stderr = logFile
+	daemonCmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+	if err := daemonCmd.Start(); err != nil {
+		return fmt.Errorf("start daemon: %w", err)
+	}
+
+	_, _ = fmt.Fprintf(os.Stdout, "axon-agent started (pid %d), log: %s\n", daemonCmd.Process.Pid, logPath)
+	return nil
+}
+
+// ── stop ───────────────────────────────────────────────────────────────────
+
+func stopCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "stop",
+		Short: "Stop the running agent",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			pidPath := pidFilePath()
+			pid, err := readPID(pidPath)
+			if err != nil {
+				if errors.Is(err, os.ErrNotExist) {
+					return fmt.Errorf("agent is not running (no PID file)")
+				}
+				return fmt.Errorf("read PID: %w", err)
+			}
+
+			proc, err := os.FindProcess(pid)
+			if err != nil {
+				return fmt.Errorf("find process %d: %w", pid, err)
+			}
+
+			if err := proc.Signal(syscall.SIGTERM); err != nil {
+				return fmt.Errorf("send SIGTERM to %d: %w", pid, err)
+			}
+			_, _ = fmt.Fprintf(os.Stdout, "Sent SIGTERM to pid %d, waiting...\n", pid)
+
+			deadline := time.Now().Add(5 * time.Second)
+			for time.Now().Before(deadline) {
+				if !isProcessRunning(pid) {
+					_ = os.Remove(pidPath)
+					_, _ = fmt.Fprintln(os.Stdout, "axon-agent stopped")
+					return nil
+				}
+				time.Sleep(200 * time.Millisecond)
+			}
+
+			// Process did not exit within 5 s — escalate to SIGKILL.
+			_ = proc.Signal(syscall.SIGKILL)
+			_ = os.Remove(pidPath)
+			_, _ = fmt.Fprintln(os.Stdout, "axon-agent killed (did not exit within 5s)")
+			return nil
+		},
+	}
+}
+
+// ── status ─────────────────────────────────────────────────────────────────
+
+func statusCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "status",
+		Short: "Show agent status",
+		Run: func(cmd *cobra.Command, args []string) {
+			pidPath := pidFilePath()
+			pid, err := readPID(pidPath)
+			if err != nil {
+				_, _ = fmt.Fprintln(os.Stdout, "Status: stopped (no PID file)")
+				return
+			}
+
+			if !isProcessRunning(pid) {
+				_, _ = fmt.Fprintf(os.Stdout, "Status: stopped (stale PID %d)\n", pid)
+				return
+			}
+
+			info, statErr := os.Stat(pidPath)
+			if statErr == nil {
+				uptime := time.Since(info.ModTime()).Truncate(time.Second)
+				_, _ = fmt.Fprintf(os.Stdout, "Status: running (pid %d, uptime %s)\n", pid, uptime)
+			} else {
+				_, _ = fmt.Fprintf(os.Stdout, "Status: running (pid %d)\n", pid)
+			}
+		},
+	}
+}
+
+// ── config ─────────────────────────────────────────────────────────────────
+
+func agentConfigCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "config",
+		Short: "Manage agent configuration",
+	}
+	cmd.AddCommand(agentConfigGetCmd(), agentConfigSetCmd())
+	return cmd
+}
+
+func agentConfigGetCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "get <key>",
+		Short: "Get a config value",
+		Long:  "Supported keys: server, token, name",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cfg, err := config.LoadAgentConfig(config.DefaultAgentConfigPath())
+			if err != nil {
+				return fmt.Errorf("load config: %w", err)
+			}
+			switch args[0] {
+			case "server":
+				_, _ = fmt.Fprintln(os.Stdout, cfg.ServerAddr)
+			case "token":
+				_, _ = fmt.Fprintln(os.Stdout, maskToken(cfg.Token))
+			case "name":
+				_, _ = fmt.Fprintln(os.Stdout, cfg.NodeName)
+			default:
+				return fmt.Errorf("unknown config key: %s (supported: server, token, name)", args[0])
+			}
+			return nil
+		},
+	}
+}
+
+func agentConfigSetCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "set <key> <value>",
+		Short: "Set a config value",
+		Long:  "Supported keys: server, token, name",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cfgPath := config.DefaultAgentConfigPath()
+			cfg, err := config.LoadAgentConfig(cfgPath)
+			if err != nil {
+				return fmt.Errorf("load config: %w", err)
+			}
+			key, value := args[0], args[1]
+			switch key {
+			case "server":
+				cfg.ServerAddr = value
+			case "token":
+				cfg.Token = value
+			case "name":
+				cfg.NodeName = value
+			default:
+				return fmt.Errorf("unknown config key: %s (supported: server, token, name)", key)
+			}
+			if err := config.SaveAgentConfig(cfgPath, cfg); err != nil {
+				return fmt.Errorf("save config: %w", err)
+			}
+			_, _ = fmt.Fprintf(os.Stdout, "Set %s = %s\n", key, value)
+			return nil
+		},
+	}
 }

--- a/cmd/axon-agent/main.go
+++ b/cmd/axon-agent/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -107,6 +108,41 @@ func maskToken(token string) string {
 	return token[:6] + "..." + token[len(token)-3:]
 }
 
+// agentStatus is the JSON-serialisable representation of the status command
+// output.
+type agentStatus struct {
+	Status   string `json:"status"`
+	PID      int    `json:"pid,omitempty"`
+	Server   string `json:"server"`
+	NodeID   string `json:"node_id"`
+	NodeName string `json:"node_name"`
+	Uptime   string `json:"uptime,omitempty"`
+}
+
+// formatUptime formats a duration as "Xd Yh Zm", omitting leading zero
+// components (except always emitting at least minutes).
+func formatUptime(d time.Duration) string {
+	d = d.Truncate(time.Minute)
+	total := int(d.Minutes())
+	if total <= 0 {
+		return "0m"
+	}
+	mins := total % 60
+	total /= 60
+	hours := total % 24
+	days := total / 24
+
+	var parts []string
+	if days > 0 {
+		parts = append(parts, fmt.Sprintf("%dd", days))
+	}
+	if hours > 0 || days > 0 {
+		parts = append(parts, fmt.Sprintf("%dh", hours))
+	}
+	parts = append(parts, fmt.Sprintf("%dm", mins))
+	return strings.Join(parts, " ")
+}
+
 // ── version ────────────────────────────────────────────────────────────────
 
 func versionCmd() *cobra.Command {
@@ -114,7 +150,7 @@ func versionCmd() *cobra.Command {
 		Use:   "version",
 		Short: "Print version info",
 		Run: func(cmd *cobra.Command, args []string) {
-			_, _ = fmt.Printf("axon-agent %s (%s, %s/%s)\n", version, runtime.Version(), runtime.GOOS, runtime.GOARCH)
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "axon-agent %s (%s, %s/%s)\n", version, runtime.Version(), runtime.GOOS, runtime.GOARCH)
 		},
 	}
 }
@@ -134,6 +170,12 @@ func startCmd() *cobra.Command {
 		Use:   "start",
 		Short: "Start the agent",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			// Prevent double-start.
+			pidPath := pidFilePath()
+			if pid, err := readPID(pidPath); err == nil && isProcessRunning(pid) {
+				return fmt.Errorf("agent is already running (PID %d)", pid)
+			}
+
 			cfgPath := config.DefaultAgentConfigPath()
 			cfg, err := config.LoadAgentConfig(cfgPath)
 			if err != nil {
@@ -291,31 +333,69 @@ func stopCmd() *cobra.Command {
 // ── status ─────────────────────────────────────────────────────────────────
 
 func statusCmd() *cobra.Command {
-	return &cobra.Command{
+	var flagJSON bool
+
+	cmd := &cobra.Command{
 		Use:   "status",
 		Short: "Show agent status",
 		Run: func(cmd *cobra.Command, args []string) {
+			cfg, _ := config.LoadAgentConfig(config.DefaultAgentConfigPath())
+			if cfg == nil {
+				cfg = &config.AgentConfig{ServerAddr: "localhost:50051"}
+			}
+
 			pidPath := pidFilePath()
-			pid, err := readPID(pidPath)
-			if err != nil {
-				_, _ = fmt.Fprintln(os.Stdout, "Status: stopped (no PID file)")
+			pid, pidErr := readPID(pidPath)
+
+			running := pidErr == nil && isProcessRunning(pid)
+			var uptime string
+			if running {
+				if info, err := os.Stat(pidPath); err == nil {
+					uptime = formatUptime(time.Since(info.ModTime()))
+				}
+			}
+
+			out := cmd.OutOrStdout()
+
+			if flagJSON {
+				s := agentStatus{
+					Server:   cfg.ServerAddr,
+					NodeID:   cfg.NodeID,
+					NodeName: cfg.NodeName,
+				}
+				if running {
+					s.Status = "running"
+					s.PID = pid
+					s.Uptime = uptime
+				} else {
+					s.Status = "stopped"
+				}
+				enc := json.NewEncoder(out)
+				enc.SetIndent("", "  ")
+				_ = enc.Encode(s)
 				return
 			}
 
-			if !isProcessRunning(pid) {
-				_, _ = fmt.Fprintf(os.Stdout, "Status: stopped (stale PID %d)\n", pid)
-				return
-			}
-
-			info, statErr := os.Stat(pidPath)
-			if statErr == nil {
-				uptime := time.Since(info.ModTime()).Truncate(time.Second)
-				_, _ = fmt.Fprintf(os.Stdout, "Status: running (pid %d, uptime %s)\n", pid, uptime)
+			if running {
+				_, _ = fmt.Fprintf(out, "Status:     running\n")
+				_, _ = fmt.Fprintf(out, "PID:        %d\n", pid)
+				_, _ = fmt.Fprintf(out, "Server:     %s\n", cfg.ServerAddr)
+				_, _ = fmt.Fprintf(out, "Node ID:    %s\n", cfg.NodeID)
+				_, _ = fmt.Fprintf(out, "Node Name:  %s\n", cfg.NodeName)
+				if uptime != "" {
+					_, _ = fmt.Fprintf(out, "Uptime:     %s\n", uptime)
+				}
 			} else {
-				_, _ = fmt.Fprintf(os.Stdout, "Status: running (pid %d)\n", pid)
+				_, _ = fmt.Fprintf(out, "Status:     stopped\n")
+				_, _ = fmt.Fprintf(out, "Server:     %s\n", cfg.ServerAddr)
+				_, _ = fmt.Fprintf(out, "Node ID:    %s\n", cfg.NodeID)
+				_, _ = fmt.Fprintf(out, "Node Name:  %s\n", cfg.NodeName)
 			}
 		},
 	}
+
+	cmd.Flags().BoolVar(&flagJSON, "json", false, "Output as JSON")
+	return cmd
 }
 
 // ── config ─────────────────────────────────────────────────────────────────

--- a/cmd/axon-agent/main_test.go
+++ b/cmd/axon-agent/main_test.go
@@ -1,0 +1,187 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// ── writePID / readPID ──────────────────────────────────────────────────────
+
+func TestWriteReadPIDRoundTrip(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "agent.pid")
+	if err := writePID(path, 42); err != nil {
+		t.Fatalf("writePID: %v", err)
+	}
+	pid, err := readPID(path)
+	if err != nil {
+		t.Fatalf("readPID: %v", err)
+	}
+	if pid != 42 {
+		t.Errorf("got pid %d, want 42", pid)
+	}
+}
+
+func TestReadPIDInvalidContent(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "agent.pid")
+	if err := os.WriteFile(path, []byte("not-a-number\n"), 0600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	_, err := readPID(path)
+	if err == nil {
+		t.Fatal("expected error for invalid content, got nil")
+	}
+}
+
+func TestReadPIDMissingFile(t *testing.T) {
+	_, err := readPID(filepath.Join(t.TempDir(), "nonexistent.pid"))
+	if err == nil {
+		t.Fatal("expected error for missing file, got nil")
+	}
+	if !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("expected os.ErrNotExist, got %v", err)
+	}
+}
+
+// ── isProcessRunning ────────────────────────────────────────────────────────
+
+func TestIsProcessRunningCurrentPID(t *testing.T) {
+	if !isProcessRunning(os.Getpid()) {
+		t.Error("current process should be detected as running")
+	}
+}
+
+func TestIsProcessRunningNonExistentPID(t *testing.T) {
+	if isProcessRunning(999_999_999) {
+		t.Error("PID 999999999 should not be detected as running")
+	}
+}
+
+// ── maskToken ───────────────────────────────────────────────────────────────
+
+func TestMaskToken(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"", "(not set)"},
+		{"short", "***"},           // len < 12
+		{"11chars_str", "***"},     // len == 11 < 12
+		{"123456789012", "123456...012"}, // len == 12
+		{"abcdefghijklmnopqrs", "abcdef...qrs"}, // normal length
+	}
+	for _, tc := range tests {
+		got := maskToken(tc.input)
+		if got != tc.want {
+			t.Errorf("maskToken(%q) = %q, want %q", tc.input, got, tc.want)
+		}
+	}
+}
+
+// ── formatUptime ────────────────────────────────────────────────────────────
+
+func TestFormatUptime(t *testing.T) {
+	tests := []struct {
+		d    time.Duration
+		want string
+	}{
+		{30 * time.Second, "0m"},
+		{5 * time.Minute, "5m"},
+		{90 * time.Minute, "1h 30m"},
+		{25*time.Hour + 5*time.Minute, "1d 1h 5m"},
+		{3*24*time.Hour + 12*time.Hour + 5*time.Minute, "3d 12h 5m"},
+	}
+	for _, tc := range tests {
+		got := formatUptime(tc.d)
+		if got != tc.want {
+			t.Errorf("formatUptime(%v) = %q, want %q", tc.d, got, tc.want)
+		}
+	}
+}
+
+// ── command help ────────────────────────────────────────────────────────────
+
+func TestStartCmdHelp(t *testing.T) {
+	var buf bytes.Buffer
+	cmd := startCmd()
+	cmd.SetOut(&buf)
+	if err := cmd.Help(); err != nil {
+		t.Fatalf("Help(): %v", err)
+	}
+	out := buf.String()
+	for _, want := range []string{"start", "--server", "--foreground"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("start help missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestStopCmdHelp(t *testing.T) {
+	var buf bytes.Buffer
+	cmd := stopCmd()
+	cmd.SetOut(&buf)
+	if err := cmd.Help(); err != nil {
+		t.Fatalf("Help(): %v", err)
+	}
+	if !strings.Contains(buf.String(), "stop") {
+		t.Errorf("stop help missing 'stop':\n%s", buf.String())
+	}
+}
+
+func TestStatusCmdHelp(t *testing.T) {
+	var buf bytes.Buffer
+	cmd := statusCmd()
+	cmd.SetOut(&buf)
+	if err := cmd.Help(); err != nil {
+		t.Fatalf("Help(): %v", err)
+	}
+	out := buf.String()
+	for _, want := range []string{"status", "--json"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("status help missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestConfigCmdHelp(t *testing.T) {
+	var buf bytes.Buffer
+	cmd := agentConfigCmd()
+	cmd.SetOut(&buf)
+	if err := cmd.Help(); err != nil {
+		t.Fatalf("Help(): %v", err)
+	}
+	if !strings.Contains(buf.String(), "config") {
+		t.Errorf("config help missing 'config':\n%s", buf.String())
+	}
+}
+
+func TestVersionCmdHelp(t *testing.T) {
+	var buf bytes.Buffer
+	cmd := versionCmd()
+	cmd.SetOut(&buf)
+	if err := cmd.Help(); err != nil {
+		t.Fatalf("Help(): %v", err)
+	}
+	if !strings.Contains(buf.String(), "version") {
+		t.Errorf("version help missing 'version':\n%s", buf.String())
+	}
+}
+
+func TestRootCmdHelpListsSubcommands(t *testing.T) {
+	var buf bytes.Buffer
+	cmd := rootCmd()
+	cmd.SetOut(&buf)
+	if err := cmd.Help(); err != nil {
+		t.Fatalf("Help(): %v", err)
+	}
+	out := buf.String()
+	for _, sub := range []string{"start", "stop", "status", "config", "version"} {
+		if !strings.Contains(out, sub) {
+			t.Errorf("root help missing subcommand %q:\n%s", sub, out)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Implements task C-16: Agent binary — the final Coder task in Phase 1.

### New Commands

- `axon-agent start` — start the agent
  - `--server <addr>` — server address (overrides config)
  - `--token <token>` — auth token (overrides config)
  - `--name <name>` — node name (overrides config)
  - `--labels key=value` — labels (repeatable, overrides config)
  - `--foreground` — run in foreground (default: daemon mode)
  - Daemon mode: re-exec with Setsid detach, log to `~/.axon-agent/agent.log`
  - Foreground: PID file + graceful SIGINT/SIGTERM shutdown
- `axon-agent stop` — stop the daemon
  - SIGTERM → 5s wait → SIGKILL → PID file cleanup
- `axon-agent status` — check daemon status
  - PID liveness via signal 0, uptime from PID file mtime
- `axon-agent config get/set` — manage agent config (server, token, name)
- `axon-agent version` — print version info

### Changes

- `cmd/axon-agent/main.go` — full implementation (+384 lines)

### Testing

- `go build`, `go vet`, `go test ./...`, `golangci-lint` all pass