### PR TITLE
feat: P2-1 registry persistence, stable node identity, heartbeat batching

### DIFF
--- a/gen/proto/control/control.pb.go
+++ b/gen/proto/control/control.pb.go
@@ -176,6 +176,7 @@ type RegisterRequest struct {
 	Token         string                 `protobuf:"bytes,1,opt,name=token,proto3" json:"token,omitempty"`                       // Agent token (one-time registration)
 	NodeName      string                 `protobuf:"bytes,2,opt,name=node_name,json=nodeName,proto3" json:"node_name,omitempty"` // Desired node name (falls back to hostname)
 	Info          *NodeInfo              `protobuf:"bytes,3,opt,name=info,proto3" json:"info,omitempty"`                         // Initial node info
+	NodeId        string                 `protobuf:"bytes,4,opt,name=node_id,json=nodeId,proto3" json:"node_id,omitempty"`       // Non-empty on reconnection (stable identity)
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -229,6 +230,13 @@ func (x *RegisterRequest) GetInfo() *NodeInfo {
 		return x.Info
 	}
 	return nil
+}
+
+func (x *RegisterRequest) GetNodeId() string {
+	if x != nil {
+		return x.NodeId
+	}
+	return ""
 }
 
 type Heartbeat struct {
@@ -706,11 +714,12 @@ const file_control_proto_rawDesc = "" +
 	"\bregister\x18\x01 \x01(\v2\x1d.axon.control.RegisterRequestH\x00R\bregister\x127\n" +
 	"\theartbeat\x18\x02 \x01(\v2\x17.axon.control.HeartbeatH\x00R\theartbeat\x125\n" +
 	"\tnode_info\x18\x03 \x01(\v2\x16.axon.control.NodeInfoH\x00R\bnodeInfoB\t\n" +
-	"\apayload\"p\n" +
+	"\apayload\"\x89\x01\n" +
 	"\x0fRegisterRequest\x12\x14\n" +
 	"\x05token\x18\x01 \x01(\tR\x05token\x12\x1b\n" +
 	"\tnode_name\x18\x02 \x01(\tR\bnodeName\x12*\n" +
-	"\x04info\x18\x03 \x01(\v2\x16.axon.control.NodeInfoR\x04info\")\n" +
+	"\x04info\x18\x03 \x01(\v2\x16.axon.control.NodeInfoR\x04info\x12\x17\n" +
+	"\anode_id\x18\x04 \x01(\tR\x06nodeId\")\n" +
 	"\tHeartbeat\x12\x1c\n" +
 	"\ttimestamp\x18\x01 \x01(\x03R\ttimestamp\"\xc5\x01\n" +
 	"\bNodeInfo\x12\x1a\n" +

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -174,6 +174,7 @@ func (a *Agent) register(stream controlpb.ControlService_ConnectClient) (time.Du
 				Token:    a.cfg.Token,
 				NodeName: a.nodeName,
 				Info:     info,
+				NodeId:   a.cfg.NodeID,
 			},
 		},
 	}); err != nil {

--- a/internal/agent/sysinfo.go
+++ b/internal/agent/sysinfo.go
@@ -5,7 +5,6 @@ import (
 	"net"
 	"os"
 	"runtime"
-	"strings"
 	"time"
 
 	controlpb "github.com/garysng/axon/gen/proto/control"
@@ -56,28 +55,4 @@ var processStart = time.Now()
 
 func uptimeSeconds() int64 {
 	return int64(time.Since(processStart).Seconds())
-}
-
-// parseKeyValueFile reads a file of KEY=VALUE lines (like /etc/os-release)
-// and returns a map of the values with optional quotes stripped.
-func parseKeyValueFile(path string) map[string]string {
-	data, err := os.ReadFile(path)
-	if err != nil {
-		return nil
-	}
-	result := make(map[string]string)
-	for _, line := range strings.Split(string(data), "\n") {
-		line = strings.TrimSpace(line)
-		if line == "" || strings.HasPrefix(line, "#") {
-			continue
-		}
-		parts := strings.SplitN(line, "=", 2)
-		if len(parts) != 2 {
-			continue
-		}
-		key := parts[0]
-		val := strings.Trim(parts[1], `"'`)
-		result[key] = val
-	}
-	return result
 }

--- a/internal/agent/sysinfo_linux.go
+++ b/internal/agent/sysinfo_linux.go
@@ -3,6 +3,7 @@
 package agent
 
 import (
+	"os"
 	"os/exec"
 	"strings"
 
@@ -28,4 +29,28 @@ func collectOSInfo() *controlpb.OSInfo {
 	}
 
 	return info
+}
+
+// parseKeyValueFile reads a file of KEY=VALUE lines (like /etc/os-release)
+// and returns a map of the values with optional quotes stripped.
+func parseKeyValueFile(path string) map[string]string {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil
+	}
+	result := make(map[string]string)
+	for _, line := range strings.Split(string(data), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		parts := strings.SplitN(line, "=", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		key := parts[0]
+		val := strings.Trim(parts[1], `"'`)
+		result[key] = val
+	}
+	return result
 }

--- a/internal/server/control.go
+++ b/internal/server/control.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"crypto/sha256"
 	"fmt"
 	"io"
 	"log"
@@ -62,10 +63,40 @@ func (cs *ControlService) Connect(stream controlpb.ControlService_ConnectServer)
 	}
 	_ = claims // claims available for future use (e.g. ACLs)
 
-	// Assign a node ID and register.
-	nodeID := uuid.NewString()
+	tokenHash := hashToken(req.Token)
 	info := protoNodeInfoToRegistry(req.Info)
-	if err := cs.reg.Register(nodeID, req.NodeName, info); err != nil {
+
+	// Determine node ID: reconnection (node_id set) or first registration.
+	var nodeID string
+	if req.NodeId != "" {
+		// Reconnection: verify the token hash matches the stored one.
+		existing, ok := cs.reg.Lookup(req.NodeId)
+		if !ok {
+			return status.Errorf(codes.NotFound, "control: node %q not found for reconnection", req.NodeId)
+		}
+		if existing.TokenHash != "" && existing.TokenHash != tokenHash {
+			return status.Errorf(codes.PermissionDenied, "control: token mismatch for node %q", req.NodeId)
+		}
+		nodeID = req.NodeId
+	} else {
+		// First registration: check if node_name already exists.
+		if existing, ok := cs.reg.LookupByName(req.NodeName); ok {
+			// Same name reconnecting — verify token hash only if online.
+			// Offline nodes can be reclaimed with a new token.
+			if existing.Status == "online" {
+				return status.Errorf(codes.AlreadyExists, "control: node name %q already connected", req.NodeName)
+			}
+			if existing.TokenHash != "" && existing.TokenHash != tokenHash {
+				return status.Errorf(codes.PermissionDenied,
+					"control: node name %q is owned by a different token", req.NodeName)
+			}
+			nodeID = existing.NodeID
+		} else {
+			nodeID = uuid.NewString()
+		}
+	}
+
+	if err := cs.reg.Register(nodeID, req.NodeName, tokenHash, info); err != nil {
 		return status.Errorf(codes.Internal, "control: register node: %v", err)
 	}
 
@@ -135,7 +166,7 @@ func (cs *ControlService) Connect(stream controlpb.ControlService_ConnectServer)
 				if entry, ok := cs.reg.Lookup(nodeID); ok {
 					nodeName = entry.NodeName
 				}
-				if err := cs.reg.Register(nodeID, nodeName, info); err != nil {
+				if err := cs.reg.Register(nodeID, nodeName, tokenHash, info); err != nil {
 					log.Printf("control: update node info %s: %v", nodeID, err)
 				}
 				// Restore stream reference (Register clears it on re-register).
@@ -192,4 +223,10 @@ func protoNodeInfoToRegistry(info *controlpb.NodeInfo) registry.NodeInfo {
 		}
 	}
 	return ri
+}
+
+// hashToken returns a hex-encoded SHA-256 hash of the given token string.
+func hashToken(token string) string {
+	h := sha256.Sum256([]byte(token))
+	return fmt.Sprintf("%x", h)
 }

--- a/internal/server/registry/heartbeat_batch.go
+++ b/internal/server/registry/heartbeat_batch.go
@@ -1,0 +1,86 @@
+package registry
+
+import (
+	"log"
+	"sync"
+	"time"
+)
+
+const defaultFlushInterval = 30 * time.Second
+
+// heartbeatBatcher aggregates heartbeat timestamps in memory and flushes
+// them to the Store periodically. This avoids writing to SQLite on every
+// heartbeat (which could be thousands per minute for many nodes).
+type heartbeatBatcher struct {
+	store    Store
+	interval time.Duration
+
+	mu      sync.Mutex
+	pending map[string]time.Time // nodeID → latest heartbeat time
+
+	done chan struct{}
+	wg   sync.WaitGroup
+}
+
+func newHeartbeatBatcher(store Store, interval time.Duration) *heartbeatBatcher {
+	if interval <= 0 {
+		interval = defaultFlushInterval
+	}
+	return &heartbeatBatcher{
+		store:    store,
+		interval: interval,
+		pending:  make(map[string]time.Time),
+		done:     make(chan struct{}),
+	}
+}
+
+// Record stores a heartbeat timestamp for later batch persistence.
+func (b *heartbeatBatcher) Record(nodeID string, t time.Time) {
+	b.mu.Lock()
+	b.pending[nodeID] = t
+	b.mu.Unlock()
+}
+
+// Start begins the background flush loop. Call Stop to shut down gracefully.
+func (b *heartbeatBatcher) Start() {
+	b.wg.Add(1)
+	go func() {
+		defer b.wg.Done()
+		ticker := time.NewTicker(b.interval)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-ticker.C:
+				b.flush()
+			case <-b.done:
+				b.flush() // Final flush on shutdown.
+				return
+			}
+		}
+	}()
+}
+
+// Stop signals the batcher to flush remaining entries and exit.
+func (b *heartbeatBatcher) Stop() {
+	close(b.done)
+	b.wg.Wait()
+}
+
+// flush writes all pending heartbeat timestamps to the store.
+func (b *heartbeatBatcher) flush() {
+	b.mu.Lock()
+	if len(b.pending) == 0 {
+		b.mu.Unlock()
+		return
+	}
+	batch := b.pending
+	b.pending = make(map[string]time.Time)
+	b.mu.Unlock()
+
+	for nodeID, t := range batch {
+		if err := b.store.UpdateHeartbeat(nodeID, t); err != nil {
+			log.Printf("registry: flush heartbeat %s: %v", nodeID, err)
+		}
+	}
+}

--- a/internal/server/registry/heartbeat_batch.go
+++ b/internal/server/registry/heartbeat_batch.go
@@ -67,7 +67,7 @@ func (b *heartbeatBatcher) Stop() {
 	b.wg.Wait()
 }
 
-// flush writes all pending heartbeat timestamps to the store.
+// flush writes all pending heartbeat timestamps to the store in one transaction.
 func (b *heartbeatBatcher) flush() {
 	b.mu.Lock()
 	if len(b.pending) == 0 {
@@ -78,9 +78,7 @@ func (b *heartbeatBatcher) flush() {
 	b.pending = make(map[string]time.Time)
 	b.mu.Unlock()
 
-	for nodeID, t := range batch {
-		if err := b.store.UpdateHeartbeat(nodeID, t); err != nil {
-			log.Printf("registry: flush heartbeat %s: %v", nodeID, err)
-		}
+	if err := b.store.FlushHeartbeats(batch); err != nil {
+		log.Printf("registry: flush heartbeats: %v", err)
 	}
 }

--- a/internal/server/registry/registry.go
+++ b/internal/server/registry/registry.go
@@ -4,6 +4,7 @@ package registry
 import (
 	"context"
 	"fmt"
+	"log"
 	"sync"
 	"time"
 )
@@ -31,6 +32,7 @@ type NodeInfo struct {
 type NodeEntry struct {
 	NodeID        string
 	NodeName      string
+	TokenHash     string // SHA-256 of the agent token used at first registration
 	Info          NodeInfo
 	Status        string // "online" | "offline"
 	ConnectedAt   time.Time
@@ -45,44 +47,80 @@ const (
 	StatusOffline = "offline"
 )
 
-// Registry is a thread-safe in-memory store of node entries.
+// Registry is a thread-safe in-memory store of node entries with optional
+// persistent backing via a Store.
 type Registry struct {
 	mu               sync.RWMutex
 	nodes            map[string]*NodeEntry // keyed by NodeID
 	heartbeatTimeout time.Duration
+	store            Store              // optional persistence backend (nil = in-memory only)
+	hbBatcher        *heartbeatBatcher  // batched heartbeat persistence (nil if no store)
 }
 
 // NewRegistry creates a new Registry with the given heartbeat timeout.
-func NewRegistry(heartbeatTimeout time.Duration) *Registry {
-	return &Registry{
+// If store is non-nil, all nodes are loaded from the store on startup
+// (with status set to offline until agents reconnect).
+func NewRegistry(heartbeatTimeout time.Duration, store ...Store) *Registry {
+	reg := &Registry{
 		nodes:            make(map[string]*NodeEntry),
 		heartbeatTimeout: heartbeatTimeout,
 	}
+	if len(store) > 0 && store[0] != nil {
+		reg.store = store[0]
+		entries, err := reg.store.LoadAll()
+		if err != nil {
+			log.Printf("registry: load from store: %v", err)
+		} else {
+			for i := range entries {
+				entries[i].Status = StatusOffline
+				cp := entries[i]
+				reg.nodes[cp.NodeID] = &cp
+			}
+			if len(entries) > 0 {
+				log.Printf("registry: loaded %d nodes from store", len(entries))
+			}
+		}
+		reg.hbBatcher = newHeartbeatBatcher(reg.store, defaultFlushInterval)
+		reg.hbBatcher.Start()
+	}
+	return reg
 }
 
 // Register adds or updates a node entry, setting its status to online.
-func (r *Registry) Register(nodeID, nodeName string, info NodeInfo) error {
+// tokenHash is the SHA-256 of the agent token (used for stable identity verification).
+func (r *Registry) Register(nodeID, nodeName string, info NodeInfo, tokenHash ...string) error {
 	if nodeID == "" {
 		return fmt.Errorf("registry: register: nodeID must not be empty")
 	}
 	now := time.Now()
+	th := ""
+	if len(tokenHash) > 0 {
+		th = tokenHash[0]
+	}
+
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
 	if existing, ok := r.nodes[nodeID]; ok {
-		// Re-registration: update fields but preserve RegisteredAt.
+		// Re-registration: update fields but preserve RegisteredAt and TokenHash.
 		existing.NodeName = nodeName
 		existing.Info = info
 		existing.Status = StatusOnline
 		existing.ConnectedAt = now
 		existing.LastHeartbeat = now
 		existing.stream = nil
+		if r.store != nil {
+			if err := r.store.Save(existing); err != nil {
+				log.Printf("registry: persist re-register %s: %v", nodeID, err)
+			}
+		}
 		return nil
 	}
 
-	r.nodes[nodeID] = &NodeEntry{
+	entry := &NodeEntry{
 		NodeID:        nodeID,
 		NodeName:      nodeName,
+		TokenHash:     th,
 		Info:          info,
 		Status:        StatusOnline,
 		ConnectedAt:   now,
@@ -90,11 +128,19 @@ func (r *Registry) Register(nodeID, nodeName string, info NodeInfo) error {
 		RegisteredAt:  now,
 		Labels:        make(map[string]string),
 	}
+	r.nodes[nodeID] = entry
+
+	if r.store != nil {
+		if err := r.store.Save(entry); err != nil {
+			log.Printf("registry: persist register %s: %v", nodeID, err)
+		}
+	}
 	return nil
 }
 
 // UpdateHeartbeat updates the LastHeartbeat timestamp for the given node.
 func (r *Registry) UpdateHeartbeat(nodeID string) error {
+	now := time.Now()
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
@@ -102,7 +148,10 @@ func (r *Registry) UpdateHeartbeat(nodeID string) error {
 	if !ok {
 		return fmt.Errorf("registry: update heartbeat: node %q not found", nodeID)
 	}
-	entry.LastHeartbeat = time.Now()
+	entry.LastHeartbeat = now
+	if r.hbBatcher != nil {
+		r.hbBatcher.Record(nodeID, now)
+	}
 	return nil
 }
 
@@ -117,6 +166,11 @@ func (r *Registry) MarkOffline(nodeID string) error {
 	}
 	entry.Status = StatusOffline
 	entry.stream = nil
+	if r.store != nil {
+		if err := r.store.UpdateStatus(nodeID, StatusOffline); err != nil {
+			log.Printf("registry: persist mark offline %s: %v", nodeID, err)
+		}
+	}
 	return nil
 }
 
@@ -129,6 +183,11 @@ func (r *Registry) Remove(nodeID string) error {
 		return fmt.Errorf("registry: remove: node %q not found", nodeID)
 	}
 	delete(r.nodes, nodeID)
+	if r.store != nil {
+		if err := r.store.Delete(nodeID); err != nil {
+			log.Printf("registry: persist remove %s: %v", nodeID, err)
+		}
+	}
 	return nil
 }
 
@@ -217,6 +276,18 @@ func (r *Registry) StartMonitor(ctx context.Context) {
 			}
 		}
 	}()
+}
+
+// Close shuts down the heartbeat batcher (flushing pending writes) and the
+// backing store, if any. Safe to call even without a store.
+func (r *Registry) Close() error {
+	if r.hbBatcher != nil {
+		r.hbBatcher.Stop()
+	}
+	if r.store != nil {
+		return r.store.Close()
+	}
+	return nil
 }
 
 // sweepExpired marks all online nodes whose heartbeat has expired as offline.

--- a/internal/server/registry/registry.go
+++ b/internal/server/registry/registry.go
@@ -87,28 +87,34 @@ func NewRegistry(heartbeatTimeout time.Duration, store ...Store) *Registry {
 }
 
 // Register adds or updates a node entry, setting its status to online.
-// tokenHash is the SHA-256 of the agent token (used for stable identity verification).
-func (r *Registry) Register(nodeID, nodeName string, info NodeInfo, tokenHash ...string) error {
+// tokenHash is the SHA-256 of the agent token (required; pass "" when not applicable).
+func (r *Registry) Register(nodeID, nodeName, tokenHash string, info NodeInfo) error {
 	if nodeID == "" {
 		return fmt.Errorf("registry: register: nodeID must not be empty")
 	}
 	now := time.Now()
-	th := ""
-	if len(tokenHash) > 0 {
-		th = tokenHash[0]
-	}
 
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
+	// Check for name collision from a different node_id.
+	for id, e := range r.nodes {
+		if e.NodeName == nodeName && id != nodeID {
+			return fmt.Errorf("registry: register: node name %q is already used by node %s", nodeName, id)
+		}
+	}
+
 	if existing, ok := r.nodes[nodeID]; ok {
-		// Re-registration: update fields but preserve RegisteredAt and TokenHash.
+		// Re-registration: update fields, preserve RegisteredAt, update TokenHash if provided.
 		existing.NodeName = nodeName
 		existing.Info = info
 		existing.Status = StatusOnline
 		existing.ConnectedAt = now
 		existing.LastHeartbeat = now
 		existing.stream = nil
+		if tokenHash != "" {
+			existing.TokenHash = tokenHash
+		}
 		if r.store != nil {
 			if err := r.store.Save(existing); err != nil {
 				log.Printf("registry: persist re-register %s: %v", nodeID, err)
@@ -120,7 +126,7 @@ func (r *Registry) Register(nodeID, nodeName string, info NodeInfo, tokenHash ..
 	entry := &NodeEntry{
 		NodeID:        nodeID,
 		NodeName:      nodeName,
-		TokenHash:     th,
+		TokenHash:     tokenHash,
 		Info:          info,
 		Status:        StatusOnline,
 		ConnectedAt:   now,

--- a/internal/server/registry/registry_test.go
+++ b/internal/server/registry/registry_test.go
@@ -28,7 +28,7 @@ func sampleInfo() NodeInfo {
 func TestRegisterAndLookup(t *testing.T) {
 	r := NewRegistry(30 * time.Second)
 
-	if err := r.Register("node-1", "web-1", sampleInfo()); err != nil {
+	if err := r.Register("node-1", "web-1", "", sampleInfo()); err != nil {
 		t.Fatalf("Register: %v", err)
 	}
 
@@ -52,7 +52,7 @@ func TestRegisterAndLookup(t *testing.T) {
 
 func TestRegisterEmptyIDError(t *testing.T) {
 	r := NewRegistry(30 * time.Second)
-	if err := r.Register("", "web-1", sampleInfo()); err == nil {
+	if err := r.Register("", "web-1", "", sampleInfo()); err == nil {
 		t.Fatal("expected error for empty nodeID")
 	}
 }
@@ -67,7 +67,7 @@ func TestLookupNotFound(t *testing.T) {
 
 func TestLookupByName(t *testing.T) {
 	r := NewRegistry(30 * time.Second)
-	if err := r.Register("node-1", "web-1", sampleInfo()); err != nil {
+	if err := r.Register("node-1", "web-1", "", sampleInfo()); err != nil {
 		t.Fatalf("Register: %v", err)
 	}
 
@@ -90,7 +90,7 @@ func TestLookupByNameNotFound(t *testing.T) {
 
 func TestUpdateHeartbeat(t *testing.T) {
 	r := NewRegistry(30 * time.Second)
-	if err := r.Register("node-1", "web-1", sampleInfo()); err != nil {
+	if err := r.Register("node-1", "web-1", "", sampleInfo()); err != nil {
 		t.Fatalf("Register: %v", err)
 	}
 
@@ -116,7 +116,7 @@ func TestUpdateHeartbeatNotFound(t *testing.T) {
 
 func TestMarkOffline(t *testing.T) {
 	r := NewRegistry(30 * time.Second)
-	if err := r.Register("node-1", "web-1", sampleInfo()); err != nil {
+	if err := r.Register("node-1", "web-1", "", sampleInfo()); err != nil {
 		t.Fatalf("Register: %v", err)
 	}
 
@@ -149,7 +149,7 @@ func TestMarkOfflineNotFound(t *testing.T) {
 
 func TestRemove(t *testing.T) {
 	r := NewRegistry(30 * time.Second)
-	if err := r.Register("node-1", "web-1", sampleInfo()); err != nil {
+	if err := r.Register("node-1", "web-1", "", sampleInfo()); err != nil {
 		t.Fatalf("Register: %v", err)
 	}
 
@@ -176,7 +176,7 @@ func TestList(t *testing.T) {
 	for i := 1; i <= 3; i++ {
 		id := fmt.Sprintf("node-%d", i)
 		name := fmt.Sprintf("web-%d", i)
-		if err := r.Register(id, name, sampleInfo()); err != nil {
+		if err := r.Register(id, name, "", sampleInfo()); err != nil {
 			t.Fatalf("Register %s: %v", id, err)
 		}
 	}
@@ -199,7 +199,7 @@ func TestHeartbeatTimeout(t *testing.T) {
 	timeout := 50 * time.Millisecond
 	r := NewRegistry(timeout)
 
-	if err := r.Register("node-1", "web-1", sampleInfo()); err != nil {
+	if err := r.Register("node-1", "web-1", "", sampleInfo()); err != nil {
 		t.Fatalf("Register: %v", err)
 	}
 
@@ -223,7 +223,7 @@ func TestHeartbeatNotExpiredWhenUpdated(t *testing.T) {
 	timeout := 100 * time.Millisecond
 	r := NewRegistry(timeout)
 
-	if err := r.Register("node-1", "web-1", sampleInfo()); err != nil {
+	if err := r.Register("node-1", "web-1", "", sampleInfo()); err != nil {
 		t.Fatalf("Register: %v", err)
 	}
 
@@ -269,7 +269,7 @@ func TestMonitorStopsOnContextCancel(t *testing.T) {
 
 func TestSetAndGetStream(t *testing.T) {
 	r := NewRegistry(30 * time.Second)
-	if err := r.Register("node-1", "web-1", sampleInfo()); err != nil {
+	if err := r.Register("node-1", "web-1", "", sampleInfo()); err != nil {
 		t.Fatalf("Register: %v", err)
 	}
 
@@ -310,7 +310,7 @@ func TestGetStreamNotFound(t *testing.T) {
 
 func TestReRegister(t *testing.T) {
 	r := NewRegistry(30 * time.Second)
-	if err := r.Register("node-1", "web-1", sampleInfo()); err != nil {
+	if err := r.Register("node-1", "web-1", "", sampleInfo()); err != nil {
 		t.Fatalf("first Register: %v", err)
 	}
 	if err := r.MarkOffline("node-1"); err != nil {
@@ -320,7 +320,7 @@ func TestReRegister(t *testing.T) {
 	// Re-register same node — should come back online.
 	newInfo := sampleInfo()
 	newInfo.AgentVersion = "0.2.0"
-	if err := r.Register("node-1", "web-1", newInfo); err != nil {
+	if err := r.Register("node-1", "web-1", "", newInfo); err != nil {
 		t.Fatalf("second Register: %v", err)
 	}
 
@@ -343,7 +343,7 @@ func TestConcurrentSafety(t *testing.T) {
 	for i := 0; i < numNodes; i++ {
 		id := fmt.Sprintf("node-%d", i)
 		name := fmt.Sprintf("web-%d", i)
-		if err := r.Register(id, name, sampleInfo()); err != nil {
+		if err := r.Register(id, name, "", sampleInfo()); err != nil {
 			t.Fatalf("Register %s: %v", id, err)
 		}
 	}

--- a/internal/server/registry/store.go
+++ b/internal/server/registry/store.go
@@ -1,0 +1,207 @@
+package registry
+
+import (
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	_ "modernc.org/sqlite"
+)
+
+const nodeSchema = `
+CREATE TABLE IF NOT EXISTS nodes (
+    node_id         TEXT PRIMARY KEY,
+    node_name       TEXT NOT NULL UNIQUE,
+    token_hash      TEXT NOT NULL,
+    arch            TEXT,
+    ip              TEXT,
+    agent_version   TEXT,
+    os_info         TEXT,
+    labels          TEXT,
+    status          TEXT NOT NULL DEFAULT 'offline',
+    connected_at    INTEGER,
+    last_heartbeat  INTEGER,
+    registered_at   INTEGER NOT NULL,
+    updated_at      INTEGER NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_nodes_name   ON nodes(node_name);
+CREATE INDEX IF NOT EXISTS idx_nodes_status ON nodes(status);
+`
+
+// Store defines the persistence interface for node entries.
+type Store interface {
+	LoadAll() ([]NodeEntry, error)
+	Save(entry *NodeEntry) error
+	Delete(nodeID string) error
+	UpdateHeartbeat(nodeID string, t time.Time) error
+	UpdateStatus(nodeID string, status string) error
+	Close() error
+}
+
+// SQLiteStore persists node entries in a SQLite database.
+type SQLiteStore struct {
+	db *sql.DB
+}
+
+// NewSQLiteStore opens (or creates) the SQLite database at dbPath and
+// initialises the nodes table. Use ":memory:" for testing.
+func NewSQLiteStore(dbPath string) (*SQLiteStore, error) {
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		return nil, fmt.Errorf("registry store: open db: %w", err)
+	}
+	// Enable WAL mode for better concurrent read/write performance.
+	if _, err := db.Exec("PRAGMA journal_mode=WAL"); err != nil {
+		_ = db.Close()
+		return nil, fmt.Errorf("registry store: set WAL: %w", err)
+	}
+	if _, err := db.Exec(nodeSchema); err != nil {
+		_ = db.Close()
+		return nil, fmt.Errorf("registry store: migrate schema: %w", err)
+	}
+	return &SQLiteStore{db: db}, nil
+}
+
+// LoadAll reads all node entries from the database.
+func (s *SQLiteStore) LoadAll() ([]NodeEntry, error) {
+	rows, err := s.db.Query(`
+		SELECT node_id, node_name, token_hash, arch, ip, agent_version,
+		       os_info, labels, status, connected_at, last_heartbeat,
+		       registered_at, updated_at
+		FROM nodes
+	`)
+	if err != nil {
+		return nil, fmt.Errorf("registry store: load all: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var entries []NodeEntry
+	for rows.Next() {
+		var (
+			e                                       NodeEntry
+			tokenHash, arch, ip, agentVer           string
+			osInfoJSON, labelsJSON                   sql.NullString
+			connAt, hbAt                            sql.NullInt64
+			regAt, updAt                            int64
+			statusStr                               string
+		)
+		if err := rows.Scan(
+			&e.NodeID, &e.NodeName, &tokenHash, &arch, &ip, &agentVer,
+			&osInfoJSON, &labelsJSON, &statusStr, &connAt, &hbAt,
+			&regAt, &updAt,
+		); err != nil {
+			return nil, fmt.Errorf("registry store: scan: %w", err)
+		}
+		e.TokenHash = tokenHash
+		e.Info.Arch = arch
+		e.Info.IP = ip
+		e.Info.AgentVersion = agentVer
+		e.Status = statusStr
+		e.RegisteredAt = time.Unix(regAt, 0)
+
+		if connAt.Valid {
+			e.ConnectedAt = time.Unix(connAt.Int64, 0)
+		}
+		if hbAt.Valid {
+			e.LastHeartbeat = time.Unix(hbAt.Int64, 0)
+		}
+		if osInfoJSON.Valid && osInfoJSON.String != "" {
+			_ = json.Unmarshal([]byte(osInfoJSON.String), &e.Info.OSInfo)
+		}
+		if labelsJSON.Valid && labelsJSON.String != "" {
+			_ = json.Unmarshal([]byte(labelsJSON.String), &e.Labels)
+		}
+		if e.Labels == nil {
+			e.Labels = make(map[string]string)
+		}
+		entries = append(entries, e)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("registry store: rows: %w", err)
+	}
+	return entries, nil
+}
+
+// Save inserts or updates a node entry (UPSERT).
+func (s *SQLiteStore) Save(entry *NodeEntry) error {
+	osInfoJSON, _ := json.Marshal(entry.Info.OSInfo)
+	labelsJSON, _ := json.Marshal(entry.Labels)
+	now := time.Now().Unix()
+
+	_, err := s.db.Exec(`
+		INSERT INTO nodes (node_id, node_name, token_hash, arch, ip, agent_version,
+		                   os_info, labels, status, connected_at, last_heartbeat,
+		                   registered_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT(node_id) DO UPDATE SET
+		    node_name = excluded.node_name,
+		    arch = excluded.arch,
+		    ip = excluded.ip,
+		    agent_version = excluded.agent_version,
+		    os_info = excluded.os_info,
+		    labels = excluded.labels,
+		    status = excluded.status,
+		    connected_at = excluded.connected_at,
+		    last_heartbeat = excluded.last_heartbeat,
+		    updated_at = excluded.updated_at
+	`,
+		entry.NodeID, entry.NodeName, entry.TokenHash,
+		entry.Info.Arch, entry.Info.IP, entry.Info.AgentVersion,
+		string(osInfoJSON), string(labelsJSON),
+		entry.Status,
+		nullableUnix(entry.ConnectedAt), nullableUnix(entry.LastHeartbeat),
+		entry.RegisteredAt.Unix(), now,
+	)
+	if err != nil {
+		return fmt.Errorf("registry store: save %s: %w", entry.NodeID, err)
+	}
+	return nil
+}
+
+// Delete removes a node entry from the database.
+func (s *SQLiteStore) Delete(nodeID string) error {
+	_, err := s.db.Exec("DELETE FROM nodes WHERE node_id = ?", nodeID)
+	if err != nil {
+		return fmt.Errorf("registry store: delete %s: %w", nodeID, err)
+	}
+	return nil
+}
+
+// UpdateHeartbeat updates the last_heartbeat timestamp for a node.
+func (s *SQLiteStore) UpdateHeartbeat(nodeID string, t time.Time) error {
+	_, err := s.db.Exec(
+		"UPDATE nodes SET last_heartbeat = ?, updated_at = ? WHERE node_id = ?",
+		t.Unix(), time.Now().Unix(), nodeID,
+	)
+	if err != nil {
+		return fmt.Errorf("registry store: update heartbeat %s: %w", nodeID, err)
+	}
+	return nil
+}
+
+// UpdateStatus updates the status field for a node.
+func (s *SQLiteStore) UpdateStatus(nodeID string, status string) error {
+	_, err := s.db.Exec(
+		"UPDATE nodes SET status = ?, updated_at = ? WHERE node_id = ?",
+		status, time.Now().Unix(), nodeID,
+	)
+	if err != nil {
+		return fmt.Errorf("registry store: update status %s: %w", nodeID, err)
+	}
+	return nil
+}
+
+// Close closes the underlying database connection.
+func (s *SQLiteStore) Close() error {
+	return s.db.Close()
+}
+
+// nullableUnix returns the Unix timestamp as *int64 if t is non-zero, or nil.
+func nullableUnix(t time.Time) *int64 {
+	if t.IsZero() {
+		return nil
+	}
+	v := t.Unix()
+	return &v
+}

--- a/internal/server/registry/store.go
+++ b/internal/server/registry/store.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"log"
 	"time"
 
 	_ "modernc.org/sqlite"
@@ -35,6 +36,9 @@ type Store interface {
 	Save(entry *NodeEntry) error
 	Delete(nodeID string) error
 	UpdateHeartbeat(nodeID string, t time.Time) error
+	// FlushHeartbeats persists multiple heartbeat timestamps atomically in a
+	// single transaction. Implementations must not partially commit on error.
+	FlushHeartbeats(records map[string]time.Time) error
 	UpdateStatus(nodeID string, status string) error
 	Close() error
 }
@@ -107,10 +111,14 @@ func (s *SQLiteStore) LoadAll() ([]NodeEntry, error) {
 			e.LastHeartbeat = time.Unix(hbAt.Int64, 0)
 		}
 		if osInfoJSON.Valid && osInfoJSON.String != "" {
-			_ = json.Unmarshal([]byte(osInfoJSON.String), &e.Info.OSInfo)
+			if err := json.Unmarshal([]byte(osInfoJSON.String), &e.Info.OSInfo); err != nil {
+				log.Printf("registry store: unmarshal os_info for %s: %v", e.NodeID, err)
+			}
 		}
 		if labelsJSON.Valid && labelsJSON.String != "" {
-			_ = json.Unmarshal([]byte(labelsJSON.String), &e.Labels)
+			if err := json.Unmarshal([]byte(labelsJSON.String), &e.Labels); err != nil {
+				log.Printf("registry store: unmarshal labels for %s: %v", e.NodeID, err)
+			}
 		}
 		if e.Labels == nil {
 			e.Labels = make(map[string]string)
@@ -136,6 +144,7 @@ func (s *SQLiteStore) Save(entry *NodeEntry) error {
 		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		ON CONFLICT(node_id) DO UPDATE SET
 		    node_name = excluded.node_name,
+		    token_hash = excluded.token_hash,
 		    arch = excluded.arch,
 		    ip = excluded.ip,
 		    agent_version = excluded.agent_version,
@@ -176,6 +185,32 @@ func (s *SQLiteStore) UpdateHeartbeat(nodeID string, t time.Time) error {
 	)
 	if err != nil {
 		return fmt.Errorf("registry store: update heartbeat %s: %w", nodeID, err)
+	}
+	return nil
+}
+
+// FlushHeartbeats updates last_heartbeat for all nodes in records atomically.
+func (s *SQLiteStore) FlushHeartbeats(records map[string]time.Time) error {
+	tx, err := s.db.Begin()
+	if err != nil {
+		return fmt.Errorf("registry store: begin heartbeat tx: %w", err)
+	}
+	stmt, err := tx.Prepare("UPDATE nodes SET last_heartbeat = ?, updated_at = ? WHERE node_id = ?")
+	if err != nil {
+		_ = tx.Rollback()
+		return fmt.Errorf("registry store: prepare heartbeat stmt: %w", err)
+	}
+	defer func() { _ = stmt.Close() }()
+
+	now := time.Now().Unix()
+	for nodeID, t := range records {
+		if _, err := stmt.Exec(t.Unix(), now, nodeID); err != nil {
+			_ = tx.Rollback()
+			return fmt.Errorf("registry store: flush heartbeat %s: %w", nodeID, err)
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("registry store: commit heartbeats: %w", err)
 	}
 	return nil
 }

--- a/internal/server/registry/store_test.go
+++ b/internal/server/registry/store_test.go
@@ -1,0 +1,195 @@
+package registry
+
+import (
+	"testing"
+	"time"
+)
+
+func newTestStore(t *testing.T) *SQLiteStore {
+	t.Helper()
+	s, err := NewSQLiteStore(":memory:")
+	if err != nil {
+		t.Fatalf("NewSQLiteStore: %v", err)
+	}
+	t.Cleanup(func() { _ = s.Close() })
+	return s
+}
+
+func TestStore_SaveAndLoadAll(t *testing.T) {
+	s := newTestStore(t)
+
+	entry := &NodeEntry{
+		NodeID:        "node-1",
+		NodeName:      "web-1",
+		TokenHash:     "sha256:abc123",
+		Info:          NodeInfo{Arch: "arm64", IP: "10.0.0.1", AgentVersion: "0.1.0"},
+		Status:        StatusOnline,
+		ConnectedAt:   time.Now().Truncate(time.Second),
+		LastHeartbeat: time.Now().Truncate(time.Second),
+		RegisteredAt:  time.Now().Add(-time.Hour).Truncate(time.Second),
+		Labels:        map[string]string{"env": "prod"},
+	}
+
+	if err := s.Save(entry); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	entries, err := s.LoadAll()
+	if err != nil {
+		t.Fatalf("LoadAll: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("len = %d, want 1", len(entries))
+	}
+
+	got := entries[0]
+	if got.NodeID != "node-1" {
+		t.Errorf("NodeID = %q", got.NodeID)
+	}
+	if got.NodeName != "web-1" {
+		t.Errorf("NodeName = %q", got.NodeName)
+	}
+	if got.TokenHash != "sha256:abc123" {
+		t.Errorf("TokenHash = %q", got.TokenHash)
+	}
+	if got.Info.Arch != "arm64" {
+		t.Errorf("Arch = %q", got.Info.Arch)
+	}
+	if got.Labels["env"] != "prod" {
+		t.Errorf("Labels = %v", got.Labels)
+	}
+}
+
+func TestStore_Upsert(t *testing.T) {
+	s := newTestStore(t)
+
+	entry := &NodeEntry{
+		NodeID:       "node-1",
+		NodeName:     "web-1",
+		TokenHash:    "hash",
+		Status:       StatusOnline,
+		RegisteredAt: time.Now(),
+		Labels:       make(map[string]string),
+	}
+	if err := s.Save(entry); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	// Update.
+	entry.Info.IP = "10.0.0.2"
+	entry.Status = StatusOffline
+	if err := s.Save(entry); err != nil {
+		t.Fatalf("Save (upsert): %v", err)
+	}
+
+	entries, err := s.LoadAll()
+	if err != nil {
+		t.Fatalf("LoadAll: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("len = %d, want 1", len(entries))
+	}
+	if entries[0].Info.IP != "10.0.0.2" {
+		t.Errorf("IP = %q after upsert", entries[0].Info.IP)
+	}
+	if entries[0].Status != StatusOffline {
+		t.Errorf("Status = %q after upsert", entries[0].Status)
+	}
+}
+
+func TestStore_Delete(t *testing.T) {
+	s := newTestStore(t)
+
+	entry := &NodeEntry{
+		NodeID:       "node-del",
+		NodeName:     "del-node",
+		TokenHash:    "hash",
+		Status:       StatusOnline,
+		RegisteredAt: time.Now(),
+		Labels:       make(map[string]string),
+	}
+	if err := s.Save(entry); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	if err := s.Delete("node-del"); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+
+	entries, err := s.LoadAll()
+	if err != nil {
+		t.Fatalf("LoadAll: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Errorf("len = %d after delete, want 0", len(entries))
+	}
+}
+
+func TestStore_UpdateHeartbeat(t *testing.T) {
+	s := newTestStore(t)
+
+	entry := &NodeEntry{
+		NodeID:       "node-hb",
+		NodeName:     "hb-node",
+		TokenHash:    "hash",
+		Status:       StatusOnline,
+		RegisteredAt: time.Now(),
+		Labels:       make(map[string]string),
+	}
+	if err := s.Save(entry); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	hbTime := time.Now().Add(5 * time.Minute).Truncate(time.Second)
+	if err := s.UpdateHeartbeat("node-hb", hbTime); err != nil {
+		t.Fatalf("UpdateHeartbeat: %v", err)
+	}
+
+	entries, err := s.LoadAll()
+	if err != nil {
+		t.Fatalf("LoadAll: %v", err)
+	}
+	if entries[0].LastHeartbeat.Unix() != hbTime.Unix() {
+		t.Errorf("LastHeartbeat = %v, want %v", entries[0].LastHeartbeat, hbTime)
+	}
+}
+
+func TestStore_UpdateStatus(t *testing.T) {
+	s := newTestStore(t)
+
+	entry := &NodeEntry{
+		NodeID:       "node-st",
+		NodeName:     "st-node",
+		TokenHash:    "hash",
+		Status:       StatusOnline,
+		RegisteredAt: time.Now(),
+		Labels:       make(map[string]string),
+	}
+	if err := s.Save(entry); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	if err := s.UpdateStatus("node-st", StatusOffline); err != nil {
+		t.Fatalf("UpdateStatus: %v", err)
+	}
+
+	entries, err := s.LoadAll()
+	if err != nil {
+		t.Fatalf("LoadAll: %v", err)
+	}
+	if entries[0].Status != StatusOffline {
+		t.Errorf("Status = %q, want %q", entries[0].Status, StatusOffline)
+	}
+}
+
+func TestStore_LoadAll_Empty(t *testing.T) {
+	s := newTestStore(t)
+
+	entries, err := s.LoadAll()
+	if err != nil {
+		t.Fatalf("LoadAll: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Errorf("len = %d, want 0", len(entries))
+	}
+}

--- a/internal/server/router_test.go
+++ b/internal/server/router_test.go
@@ -38,7 +38,7 @@ func TestRouter_Route_PermissionDenied(t *testing.T) {
 
 func TestRouter_Route_WildcardAccess(t *testing.T) {
 	reg := registry.NewRegistry(30 * time.Second)
-	_ = reg.Register("node-1", "web-1", registry.NodeInfo{})
+	_ = reg.Register("node-1", "web-1", "", registry.NodeInfo{})
 	r := newRouter(reg)
 
 	claims := &auth.Claims{UserID: "admin", NodeIDs: []string{"*"}, Kind: auth.KindCLI}
@@ -66,7 +66,7 @@ func TestRouter_Route_NotFound(t *testing.T) {
 
 func TestRouter_Route_LookupByName(t *testing.T) {
 	reg := registry.NewRegistry(30 * time.Second)
-	_ = reg.Register("uuid-1", "web-1", registry.NodeInfo{})
+	_ = reg.Register("uuid-1", "web-1", "", registry.NodeInfo{})
 	r := newRouter(reg)
 
 	claims := &auth.Claims{UserID: "user1", NodeIDs: []string{"web-1"}, Kind: auth.KindCLI}
@@ -83,7 +83,7 @@ func TestRouter_Route_LookupByName(t *testing.T) {
 
 func TestRouter_Route_Offline(t *testing.T) {
 	reg := registry.NewRegistry(30 * time.Second)
-	_ = reg.Register("node-1", "web-1", registry.NodeInfo{})
+	_ = reg.Register("node-1", "web-1", "", registry.NodeInfo{})
 	_ = reg.MarkOffline("node-1")
 	r := newRouter(reg)
 

--- a/proto/control.proto
+++ b/proto/control.proto
@@ -23,6 +23,7 @@ message RegisterRequest {
   string token = 1;           // Agent token (one-time registration)
   string node_name = 2;       // Desired node name (falls back to hostname)
   NodeInfo info = 3;          // Initial node info
+  string node_id = 4;         // Non-empty on reconnection (stable identity)
 }
 
 message Heartbeat {

--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -87,18 +87,21 @@ func TestIntegration_AgentDisconnectReconnect(t *testing.T) {
 	// Wait for node to go offline.
 	h.WaitForNodeStatus(nodeID, registry.StatusOffline)
 
-	// Connect a new agent with the same name — it gets a new node ID.
-	_, newNodeID := h.ConnectAgent("disc-reconnect-agent")
-	if newNodeID == "" {
+	// Reconnect with the same token — the agent reclaims its existing node ID.
+	_, reconnNodeID := h.ConnectAgentWithToken("disc-reconnect-agent", h.AgentToken())
+	if reconnNodeID == "" {
 		t.Fatal("expected non-empty node ID after reconnect")
 	}
-
-	newEntry, ok := h.Registry().Lookup(newNodeID)
-	if !ok {
-		t.Fatalf("reconnected node %s not found", newNodeID)
+	if reconnNodeID != nodeID {
+		t.Errorf("reconnected node ID = %q, want original %q", reconnNodeID, nodeID)
 	}
-	if newEntry.Status != registry.StatusOnline {
-		t.Errorf("reconnected status = %q, want %q", newEntry.Status, registry.StatusOnline)
+
+	reconnEntry, ok := h.Registry().Lookup(reconnNodeID)
+	if !ok {
+		t.Fatalf("reconnected node %s not found", reconnNodeID)
+	}
+	if reconnEntry.Status != registry.StatusOnline {
+		t.Errorf("reconnected status = %q, want %q", reconnEntry.Status, registry.StatusOnline)
 	}
 }
 

--- a/test/integration/testharness/harness.go
+++ b/test/integration/testharness/harness.go
@@ -33,6 +33,7 @@ type Harness struct {
 
 	opts harnessOpts
 
+	agentToken  string // JWT token used by the primary agent
 	agentNodeID string
 	agentCancel context.CancelFunc
 }
@@ -147,6 +148,7 @@ func NewHarness(t *testing.T, options ...HarnessOption) *Harness {
 		lis:         lis,
 		cancel:      cancel,
 		opts:        opts,
+		agentToken:  agentToken,
 		agentCancel: agentCancel,
 	}
 
@@ -206,6 +208,9 @@ func (h *Harness) Registry() *registry.Registry { return h.srv.Registry() }
 
 // AgentNodeID returns the node ID assigned to the agent.
 func (h *Harness) AgentNodeID() string { return h.agentNodeID }
+
+// AgentToken returns the JWT token used by the primary agent.
+func (h *Harness) AgentToken() string { return h.agentToken }
 
 // CLIConn returns a gRPC client connection authenticated with a CLI JWT token
 // that has wildcard ("*") node access.
@@ -292,6 +297,35 @@ func (h *Harness) ConnectAgent(name string) (*agent.Agent, string) {
 	h.t.Cleanup(agentCancel)
 
 	// Wait for agent to register.
+	nodeID := h.waitForNodeByName(name)
+	return agt, nodeID
+}
+
+// ConnectAgentWithToken connects a new agent using the given JWT token and
+// waits for it to register. Use this when the reconnecting agent must present
+// the same token hash as the previously registered node.
+func (h *Harness) ConnectAgentWithToken(name, token string) (*agent.Agent, string) {
+	h.t.Helper()
+
+	agentCfg := config.AgentConfig{
+		ServerAddr:  "passthrough://bufnet",
+		Token:       token,
+		NodeName:    name,
+		TLSInsecure: true,
+	}
+
+	agt := agent.NewAgent(agentCfg, "")
+	agt.SetDialOverride(grpc.WithContextDialer(func(ctx context.Context, _ string) (net.Conn, error) {
+		return h.lis.DialContext(ctx)
+	}))
+
+	agentCtx, agentCancel := context.WithCancel(context.Background())
+	go func() {
+		_ = agt.Run(agentCtx)
+	}()
+
+	h.t.Cleanup(agentCancel)
+
 	nodeID := h.waitForNodeByName(name)
 	return agt, nodeID
 }


### PR DESCRIPTION
## Summary

Implements Phase 2 Task P2-1 — Registry Persistence (all three sub-tasks).

### P2-1a: SQLite Store
- `Store` interface: LoadAll/Save/Delete/UpdateHeartbeat/UpdateStatus/Close
- `SQLiteStore` with WAL mode, UPSERT support
- Schema: node_id, node_name, token_hash, arch, ip, agent_version, os_info (JSON), labels (JSON), status, timestamps
- Indexes on node_name and status

### P2-1b: Stable Node Identity
- Proto: `node_id` field in `RegisterRequest` for reconnection
- Server: token hash verification on reconnection, name collision handling (online → reject, offline → allow reclaim)
- Agent: sends persisted `node_id` on reconnection

### P2-1c: Heartbeat Batching
- `heartbeatBatcher`: aggregates heartbeat timestamps in memory
- Flushes to SQLite every 30s (configurable)
- Final flush on graceful shutdown via `Registry.Close()`

### Registry Changes
- `NewRegistry` accepts optional `Store` parameter (backward compatible)
- Loads all nodes from store on startup (status=offline until reconnect)
- Register/MarkOffline/Remove persist to store
- `TokenHash` field on `NodeEntry`
- `Close()` method for graceful shutdown

### Tests
- `store_test.go`: 6 tests (CRUD, upsert, heartbeat update, status update)
- All existing registry + integration tests pass