### PR TITLE
feat: P2-2 token management — SQLite store, revocation, JWT ID tracking

### DIFF
--- a/cmd/axon/auth.go
+++ b/cmd/axon/auth.go
@@ -5,7 +5,9 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"os/signal"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -22,7 +24,7 @@ func authCmd() *cobra.Command {
 		Use:   "auth",
 		Short: "Authentication commands",
 	}
-	cmd.AddCommand(authLoginCmd(), authTokenCmd())
+	cmd.AddCommand(authLoginCmd(), authTokenCmd(), revokeTokenCmd(), listTokensCmd(), rotateTokenCmd())
 	return cmd
 }
 
@@ -121,6 +123,93 @@ func authTokenCmd() *cobra.Command {
 				return fmt.Errorf("not authenticated; run: axon auth login")
 			}
 			_, _ = fmt.Fprintln(cmd.OutOrStdout(), cfg.Token)
+			return nil
+		},
+	}
+}
+
+// ── auth revoke ────────────────────────────────────────────────────────────
+
+func revokeTokenCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "revoke <token-id>",
+		Short: "Revoke a token by its ID (jti)",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, closer, err := dialManagement()
+			if err != nil {
+				return err
+			}
+			defer closer()
+
+			ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+			defer cancel()
+
+			resp, err := client.RevokeToken(ctx, &managementpb.RevokeTokenRequest{
+				TokenId: args[0],
+			})
+			if err != nil {
+				return fmt.Errorf("revoke: %w", err)
+			}
+			if !resp.Success {
+				return fmt.Errorf("revoke failed: %s", resp.Error)
+			}
+			_, _ = fmt.Fprintln(cmd.OutOrStdout(), "Token revoked successfully.")
+			return nil
+		},
+	}
+}
+
+// ── auth list-tokens ───────────────────────────────────────────────────────
+
+func listTokensCmd() *cobra.Command {
+	var kind string
+
+	cmd := &cobra.Command{
+		Use:   "list-tokens",
+		Short: "List active (non-revoked, non-expired) tokens",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, closer, err := dialManagement()
+			if err != nil {
+				return err
+			}
+			defer closer()
+
+			ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+			defer cancel()
+
+			resp, err := client.ListTokens(ctx, &managementpb.ListTokensRequest{
+				Kind: kind,
+			})
+			if err != nil {
+				return fmt.Errorf("list-tokens: %w", err)
+			}
+
+			if len(resp.Tokens) == 0 {
+				_, _ = fmt.Fprintln(cmd.OutOrStdout(), "No active tokens.")
+				return nil
+			}
+
+			for _, t := range resp.Tokens {
+				expires := time.Unix(t.ExpiresAt, 0).Format(time.RFC3339)
+				_, _ = fmt.Fprintf(cmd.OutOrStdout(), "%-36s  %-6s  %-12s  expires=%s\n",
+					t.Id, t.Kind, t.UserId, expires)
+			}
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&kind, "kind", "", "filter by token kind (cli, agent)")
+	return cmd
+}
+
+// ── auth rotate ────────────────────────────────────────────────────────────
+
+func rotateTokenCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "rotate",
+		Short: "[not yet implemented] Revoke current token and login again for a new one",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			_, _ = fmt.Fprintln(cmd.OutOrStdout(), "[not yet implemented] Token rotation requires re-login. Use: axon auth login && axon auth revoke <old-token-id>")
 			return nil
 		},
 	}

--- a/cmd/axon/client.go
+++ b/cmd/axon/client.go
@@ -56,6 +56,11 @@ func dialServer(withAuth bool) (managementpb.ManagementServiceClient, func(), er
 	return managementpb.NewManagementServiceClient(conn), closer, nil
 }
 
+// dialManagement creates an authenticated gRPC connection and returns a ManagementServiceClient.
+func dialManagement() (managementpb.ManagementServiceClient, func(), error) {
+	return dialServer(true)
+}
+
 // dialOperations creates a gRPC connection and returns an OperationsServiceClient.
 func dialOperations() (operationspb.OperationsServiceClient, func(), error) {
 	conn, closer, err := dialConn(true)

--- a/gen/proto/management/management.pb.go
+++ b/gen/proto/management/management.pb.go
@@ -522,6 +522,266 @@ func (x *LoginResponse) GetError() string {
 	return ""
 }
 
+type RevokeTokenRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	TokenId       string                 `protobuf:"bytes,1,opt,name=token_id,json=tokenId,proto3" json:"token_id,omitempty"` // JWT ID (jti)
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *RevokeTokenRequest) Reset() {
+	*x = RevokeTokenRequest{}
+	mi := &file_management_proto_msgTypes[9]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RevokeTokenRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RevokeTokenRequest) ProtoMessage() {}
+
+func (x *RevokeTokenRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_management_proto_msgTypes[9]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RevokeTokenRequest.ProtoReflect.Descriptor instead.
+func (*RevokeTokenRequest) Descriptor() ([]byte, []int) {
+	return file_management_proto_rawDescGZIP(), []int{9}
+}
+
+func (x *RevokeTokenRequest) GetTokenId() string {
+	if x != nil {
+		return x.TokenId
+	}
+	return ""
+}
+
+type RevokeTokenResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Success       bool                   `protobuf:"varint,1,opt,name=success,proto3" json:"success,omitempty"`
+	Error         string                 `protobuf:"bytes,2,opt,name=error,proto3" json:"error,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *RevokeTokenResponse) Reset() {
+	*x = RevokeTokenResponse{}
+	mi := &file_management_proto_msgTypes[10]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RevokeTokenResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RevokeTokenResponse) ProtoMessage() {}
+
+func (x *RevokeTokenResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_management_proto_msgTypes[10]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RevokeTokenResponse.ProtoReflect.Descriptor instead.
+func (*RevokeTokenResponse) Descriptor() ([]byte, []int) {
+	return file_management_proto_rawDescGZIP(), []int{10}
+}
+
+func (x *RevokeTokenResponse) GetSuccess() bool {
+	if x != nil {
+		return x.Success
+	}
+	return false
+}
+
+func (x *RevokeTokenResponse) GetError() string {
+	if x != nil {
+		return x.Error
+	}
+	return ""
+}
+
+type ListTokensRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Kind          string                 `protobuf:"bytes,1,opt,name=kind,proto3" json:"kind,omitempty"` // "cli", "agent", or "" for all
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListTokensRequest) Reset() {
+	*x = ListTokensRequest{}
+	mi := &file_management_proto_msgTypes[11]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListTokensRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListTokensRequest) ProtoMessage() {}
+
+func (x *ListTokensRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_management_proto_msgTypes[11]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListTokensRequest.ProtoReflect.Descriptor instead.
+func (*ListTokensRequest) Descriptor() ([]byte, []int) {
+	return file_management_proto_rawDescGZIP(), []int{11}
+}
+
+func (x *ListTokensRequest) GetKind() string {
+	if x != nil {
+		return x.Kind
+	}
+	return ""
+}
+
+type ListTokensResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Tokens        []*TokenInfo           `protobuf:"bytes,1,rep,name=tokens,proto3" json:"tokens,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListTokensResponse) Reset() {
+	*x = ListTokensResponse{}
+	mi := &file_management_proto_msgTypes[12]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListTokensResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListTokensResponse) ProtoMessage() {}
+
+func (x *ListTokensResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_management_proto_msgTypes[12]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListTokensResponse.ProtoReflect.Descriptor instead.
+func (*ListTokensResponse) Descriptor() ([]byte, []int) {
+	return file_management_proto_rawDescGZIP(), []int{12}
+}
+
+func (x *ListTokensResponse) GetTokens() []*TokenInfo {
+	if x != nil {
+		return x.Tokens
+	}
+	return nil
+}
+
+type TokenInfo struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Id            string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"` // JWT ID (jti)
+	Kind          string                 `protobuf:"bytes,2,opt,name=kind,proto3" json:"kind,omitempty"`
+	UserId        string                 `protobuf:"bytes,3,opt,name=user_id,json=userId,proto3" json:"user_id,omitempty"`
+	IssuedAt      int64                  `protobuf:"varint,4,opt,name=issued_at,json=issuedAt,proto3" json:"issued_at,omitempty"`
+	ExpiresAt     int64                  `protobuf:"varint,5,opt,name=expires_at,json=expiresAt,proto3" json:"expires_at,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *TokenInfo) Reset() {
+	*x = TokenInfo{}
+	mi := &file_management_proto_msgTypes[13]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *TokenInfo) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*TokenInfo) ProtoMessage() {}
+
+func (x *TokenInfo) ProtoReflect() protoreflect.Message {
+	mi := &file_management_proto_msgTypes[13]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use TokenInfo.ProtoReflect.Descriptor instead.
+func (*TokenInfo) Descriptor() ([]byte, []int) {
+	return file_management_proto_rawDescGZIP(), []int{13}
+}
+
+func (x *TokenInfo) GetId() string {
+	if x != nil {
+		return x.Id
+	}
+	return ""
+}
+
+func (x *TokenInfo) GetKind() string {
+	if x != nil {
+		return x.Kind
+	}
+	return ""
+}
+
+func (x *TokenInfo) GetUserId() string {
+	if x != nil {
+		return x.UserId
+	}
+	return ""
+}
+
+func (x *TokenInfo) GetIssuedAt() int64 {
+	if x != nil {
+		return x.IssuedAt
+	}
+	return 0
+}
+
+func (x *TokenInfo) GetExpiresAt() int64 {
+	if x != nil {
+		return x.ExpiresAt
+	}
+	return 0
+}
+
 var File_management_proto protoreflect.FileDescriptor
 
 const file_management_proto_rawDesc = "" +
@@ -561,13 +821,32 @@ const file_management_proto_rawDesc = "" +
 	"\x05token\x18\x01 \x01(\tR\x05token\x12\x1d\n" +
 	"\n" +
 	"expires_at\x18\x02 \x01(\x03R\texpiresAt\x12\x14\n" +
-	"\x05error\x18\x03 \x01(\tR\x05error2\xd4\x02\n" +
+	"\x05error\x18\x03 \x01(\tR\x05error\"/\n" +
+	"\x12RevokeTokenRequest\x12\x19\n" +
+	"\btoken_id\x18\x01 \x01(\tR\atokenId\"E\n" +
+	"\x13RevokeTokenResponse\x12\x18\n" +
+	"\asuccess\x18\x01 \x01(\bR\asuccess\x12\x14\n" +
+	"\x05error\x18\x02 \x01(\tR\x05error\"'\n" +
+	"\x11ListTokensRequest\x12\x12\n" +
+	"\x04kind\x18\x01 \x01(\tR\x04kind\"H\n" +
+	"\x12ListTokensResponse\x122\n" +
+	"\x06tokens\x18\x01 \x03(\v2\x1a.axon.management.TokenInfoR\x06tokens\"\x84\x01\n" +
+	"\tTokenInfo\x12\x0e\n" +
+	"\x02id\x18\x01 \x01(\tR\x02id\x12\x12\n" +
+	"\x04kind\x18\x02 \x01(\tR\x04kind\x12\x17\n" +
+	"\auser_id\x18\x03 \x01(\tR\x06userId\x12\x1b\n" +
+	"\tissued_at\x18\x04 \x01(\x03R\bissuedAt\x12\x1d\n" +
+	"\n" +
+	"expires_at\x18\x05 \x01(\x03R\texpiresAt2\x85\x04\n" +
 	"\x11ManagementService\x12R\n" +
 	"\tListNodes\x12!.axon.management.ListNodesRequest\x1a\".axon.management.ListNodesResponse\x12L\n" +
 	"\aGetNode\x12\x1f.axon.management.GetNodeRequest\x1a .axon.management.GetNodeResponse\x12U\n" +
 	"\n" +
 	"RemoveNode\x12\".axon.management.RemoveNodeRequest\x1a#.axon.management.RemoveNodeResponse\x12F\n" +
-	"\x05Login\x12\x1d.axon.management.LoginRequest\x1a\x1e.axon.management.LoginResponseB.Z,github.com/garysng/axon/gen/proto/managementb\x06proto3"
+	"\x05Login\x12\x1d.axon.management.LoginRequest\x1a\x1e.axon.management.LoginResponse\x12X\n" +
+	"\vRevokeToken\x12#.axon.management.RevokeTokenRequest\x1a$.axon.management.RevokeTokenResponse\x12U\n" +
+	"\n" +
+	"ListTokens\x12\".axon.management.ListTokensRequest\x1a#.axon.management.ListTokensResponseB.Z,github.com/garysng/axon/gen/proto/managementb\x06proto3"
 
 var (
 	file_management_proto_rawDescOnce sync.Once
@@ -581,38 +860,48 @@ func file_management_proto_rawDescGZIP() []byte {
 	return file_management_proto_rawDescData
 }
 
-var file_management_proto_msgTypes = make([]protoimpl.MessageInfo, 10)
+var file_management_proto_msgTypes = make([]protoimpl.MessageInfo, 15)
 var file_management_proto_goTypes = []any{
-	(*ListNodesRequest)(nil),   // 0: axon.management.ListNodesRequest
-	(*ListNodesResponse)(nil),  // 1: axon.management.ListNodesResponse
-	(*NodeSummary)(nil),        // 2: axon.management.NodeSummary
-	(*GetNodeRequest)(nil),     // 3: axon.management.GetNodeRequest
-	(*GetNodeResponse)(nil),    // 4: axon.management.GetNodeResponse
-	(*RemoveNodeRequest)(nil),  // 5: axon.management.RemoveNodeRequest
-	(*RemoveNodeResponse)(nil), // 6: axon.management.RemoveNodeResponse
-	(*LoginRequest)(nil),       // 7: axon.management.LoginRequest
-	(*LoginResponse)(nil),      // 8: axon.management.LoginResponse
-	nil,                        // 9: axon.management.GetNodeResponse.LabelsEntry
-	(*control.OSInfo)(nil),     // 10: axon.control.OSInfo
+	(*ListNodesRequest)(nil),    // 0: axon.management.ListNodesRequest
+	(*ListNodesResponse)(nil),   // 1: axon.management.ListNodesResponse
+	(*NodeSummary)(nil),         // 2: axon.management.NodeSummary
+	(*GetNodeRequest)(nil),      // 3: axon.management.GetNodeRequest
+	(*GetNodeResponse)(nil),     // 4: axon.management.GetNodeResponse
+	(*RemoveNodeRequest)(nil),   // 5: axon.management.RemoveNodeRequest
+	(*RemoveNodeResponse)(nil),  // 6: axon.management.RemoveNodeResponse
+	(*LoginRequest)(nil),        // 7: axon.management.LoginRequest
+	(*LoginResponse)(nil),       // 8: axon.management.LoginResponse
+	(*RevokeTokenRequest)(nil),  // 9: axon.management.RevokeTokenRequest
+	(*RevokeTokenResponse)(nil), // 10: axon.management.RevokeTokenResponse
+	(*ListTokensRequest)(nil),   // 11: axon.management.ListTokensRequest
+	(*ListTokensResponse)(nil),  // 12: axon.management.ListTokensResponse
+	(*TokenInfo)(nil),           // 13: axon.management.TokenInfo
+	nil,                         // 14: axon.management.GetNodeResponse.LabelsEntry
+	(*control.OSInfo)(nil),      // 15: axon.control.OSInfo
 }
 var file_management_proto_depIdxs = []int32{
 	2,  // 0: axon.management.ListNodesResponse.nodes:type_name -> axon.management.NodeSummary
-	10, // 1: axon.management.NodeSummary.os_info:type_name -> axon.control.OSInfo
+	15, // 1: axon.management.NodeSummary.os_info:type_name -> axon.control.OSInfo
 	2,  // 2: axon.management.GetNodeResponse.summary:type_name -> axon.management.NodeSummary
-	9,  // 3: axon.management.GetNodeResponse.labels:type_name -> axon.management.GetNodeResponse.LabelsEntry
-	0,  // 4: axon.management.ManagementService.ListNodes:input_type -> axon.management.ListNodesRequest
-	3,  // 5: axon.management.ManagementService.GetNode:input_type -> axon.management.GetNodeRequest
-	5,  // 6: axon.management.ManagementService.RemoveNode:input_type -> axon.management.RemoveNodeRequest
-	7,  // 7: axon.management.ManagementService.Login:input_type -> axon.management.LoginRequest
-	1,  // 8: axon.management.ManagementService.ListNodes:output_type -> axon.management.ListNodesResponse
-	4,  // 9: axon.management.ManagementService.GetNode:output_type -> axon.management.GetNodeResponse
-	6,  // 10: axon.management.ManagementService.RemoveNode:output_type -> axon.management.RemoveNodeResponse
-	8,  // 11: axon.management.ManagementService.Login:output_type -> axon.management.LoginResponse
-	8,  // [8:12] is the sub-list for method output_type
-	4,  // [4:8] is the sub-list for method input_type
-	4,  // [4:4] is the sub-list for extension type_name
-	4,  // [4:4] is the sub-list for extension extendee
-	0,  // [0:4] is the sub-list for field type_name
+	14, // 3: axon.management.GetNodeResponse.labels:type_name -> axon.management.GetNodeResponse.LabelsEntry
+	13, // 4: axon.management.ListTokensResponse.tokens:type_name -> axon.management.TokenInfo
+	0,  // 5: axon.management.ManagementService.ListNodes:input_type -> axon.management.ListNodesRequest
+	3,  // 6: axon.management.ManagementService.GetNode:input_type -> axon.management.GetNodeRequest
+	5,  // 7: axon.management.ManagementService.RemoveNode:input_type -> axon.management.RemoveNodeRequest
+	7,  // 8: axon.management.ManagementService.Login:input_type -> axon.management.LoginRequest
+	9,  // 9: axon.management.ManagementService.RevokeToken:input_type -> axon.management.RevokeTokenRequest
+	11, // 10: axon.management.ManagementService.ListTokens:input_type -> axon.management.ListTokensRequest
+	1,  // 11: axon.management.ManagementService.ListNodes:output_type -> axon.management.ListNodesResponse
+	4,  // 12: axon.management.ManagementService.GetNode:output_type -> axon.management.GetNodeResponse
+	6,  // 13: axon.management.ManagementService.RemoveNode:output_type -> axon.management.RemoveNodeResponse
+	8,  // 14: axon.management.ManagementService.Login:output_type -> axon.management.LoginResponse
+	10, // 15: axon.management.ManagementService.RevokeToken:output_type -> axon.management.RevokeTokenResponse
+	12, // 16: axon.management.ManagementService.ListTokens:output_type -> axon.management.ListTokensResponse
+	11, // [11:17] is the sub-list for method output_type
+	5,  // [5:11] is the sub-list for method input_type
+	5,  // [5:5] is the sub-list for extension type_name
+	5,  // [5:5] is the sub-list for extension extendee
+	0,  // [0:5] is the sub-list for field type_name
 }
 
 func init() { file_management_proto_init() }
@@ -626,7 +915,7 @@ func file_management_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_management_proto_rawDesc), len(file_management_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   10,
+			NumMessages:   15,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/gen/proto/management/management_grpc.pb.go
+++ b/gen/proto/management/management_grpc.pb.go
@@ -19,10 +19,12 @@ import (
 const _ = grpc.SupportPackageIsVersion9
 
 const (
-	ManagementService_ListNodes_FullMethodName  = "/axon.management.ManagementService/ListNodes"
-	ManagementService_GetNode_FullMethodName    = "/axon.management.ManagementService/GetNode"
-	ManagementService_RemoveNode_FullMethodName = "/axon.management.ManagementService/RemoveNode"
-	ManagementService_Login_FullMethodName      = "/axon.management.ManagementService/Login"
+	ManagementService_ListNodes_FullMethodName   = "/axon.management.ManagementService/ListNodes"
+	ManagementService_GetNode_FullMethodName     = "/axon.management.ManagementService/GetNode"
+	ManagementService_RemoveNode_FullMethodName  = "/axon.management.ManagementService/RemoveNode"
+	ManagementService_Login_FullMethodName       = "/axon.management.ManagementService/Login"
+	ManagementService_RevokeToken_FullMethodName = "/axon.management.ManagementService/RevokeToken"
+	ManagementService_ListTokens_FullMethodName  = "/axon.management.ManagementService/ListTokens"
 )
 
 // ManagementServiceClient is the client API for ManagementService service.
@@ -33,6 +35,8 @@ type ManagementServiceClient interface {
 	GetNode(ctx context.Context, in *GetNodeRequest, opts ...grpc.CallOption) (*GetNodeResponse, error)
 	RemoveNode(ctx context.Context, in *RemoveNodeRequest, opts ...grpc.CallOption) (*RemoveNodeResponse, error)
 	Login(ctx context.Context, in *LoginRequest, opts ...grpc.CallOption) (*LoginResponse, error)
+	RevokeToken(ctx context.Context, in *RevokeTokenRequest, opts ...grpc.CallOption) (*RevokeTokenResponse, error)
+	ListTokens(ctx context.Context, in *ListTokensRequest, opts ...grpc.CallOption) (*ListTokensResponse, error)
 }
 
 type managementServiceClient struct {
@@ -83,6 +87,26 @@ func (c *managementServiceClient) Login(ctx context.Context, in *LoginRequest, o
 	return out, nil
 }
 
+func (c *managementServiceClient) RevokeToken(ctx context.Context, in *RevokeTokenRequest, opts ...grpc.CallOption) (*RevokeTokenResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(RevokeTokenResponse)
+	err := c.cc.Invoke(ctx, ManagementService_RevokeToken_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *managementServiceClient) ListTokens(ctx context.Context, in *ListTokensRequest, opts ...grpc.CallOption) (*ListTokensResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(ListTokensResponse)
+	err := c.cc.Invoke(ctx, ManagementService_ListTokens_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // ManagementServiceServer is the server API for ManagementService service.
 // All implementations must embed UnimplementedManagementServiceServer
 // for forward compatibility.
@@ -91,6 +115,8 @@ type ManagementServiceServer interface {
 	GetNode(context.Context, *GetNodeRequest) (*GetNodeResponse, error)
 	RemoveNode(context.Context, *RemoveNodeRequest) (*RemoveNodeResponse, error)
 	Login(context.Context, *LoginRequest) (*LoginResponse, error)
+	RevokeToken(context.Context, *RevokeTokenRequest) (*RevokeTokenResponse, error)
+	ListTokens(context.Context, *ListTokensRequest) (*ListTokensResponse, error)
 	mustEmbedUnimplementedManagementServiceServer()
 }
 
@@ -112,6 +138,12 @@ func (UnimplementedManagementServiceServer) RemoveNode(context.Context, *RemoveN
 }
 func (UnimplementedManagementServiceServer) Login(context.Context, *LoginRequest) (*LoginResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method Login not implemented")
+}
+func (UnimplementedManagementServiceServer) RevokeToken(context.Context, *RevokeTokenRequest) (*RevokeTokenResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method RevokeToken not implemented")
+}
+func (UnimplementedManagementServiceServer) ListTokens(context.Context, *ListTokensRequest) (*ListTokensResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method ListTokens not implemented")
 }
 func (UnimplementedManagementServiceServer) mustEmbedUnimplementedManagementServiceServer() {}
 func (UnimplementedManagementServiceServer) testEmbeddedByValue()                           {}
@@ -206,6 +238,42 @@ func _ManagementService_Login_Handler(srv interface{}, ctx context.Context, dec 
 	return interceptor(ctx, in, info, handler)
 }
 
+func _ManagementService_RevokeToken_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(RevokeTokenRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(ManagementServiceServer).RevokeToken(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: ManagementService_RevokeToken_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(ManagementServiceServer).RevokeToken(ctx, req.(*RevokeTokenRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _ManagementService_ListTokens_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ListTokensRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(ManagementServiceServer).ListTokens(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: ManagementService_ListTokens_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(ManagementServiceServer).ListTokens(ctx, req.(*ListTokensRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // ManagementService_ServiceDesc is the grpc.ServiceDesc for ManagementService service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -228,6 +296,14 @@ var ManagementService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "Login",
 			Handler:    _ManagementService_Login_Handler,
+		},
+		{
+			MethodName: "RevokeToken",
+			Handler:    _ManagementService_RevokeToken_Handler,
+		},
+		{
+			MethodName: "ListTokens",
+			Handler:    _ManagementService_ListTokens_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -151,7 +151,7 @@ func newTestEnv(t *testing.T, heartbeatInterval int32) *testEnv {
 
 func (e *testEnv) agentConfig(t *testing.T) config.AgentConfig {
 	t.Helper()
-	tok, err := auth.SignAgentToken(testSecret, "pre-node", time.Hour)
+	tok, _, err := auth.SignAgentToken(testSecret, "pre-node", time.Hour)
 	if err != nil {
 		t.Fatalf("sign token: %v", err)
 	}

--- a/internal/agent/sysinfo.go
+++ b/internal/agent/sysinfo.go
@@ -56,3 +56,5 @@ var processStart = time.Now()
 func uptimeSeconds() int64 {
 	return int64(time.Since(processStart).Seconds())
 }
+
+

--- a/internal/server/control_test.go
+++ b/internal/server/control_test.go
@@ -44,7 +44,7 @@ func newTestEnv(t *testing.T) *testEnv {
 	srv.registry = registry.NewRegistry(cfg.HeartbeatTimeout)
 	srv.control = newControlService(srv.registry, cfg)
 
-	opts, err := srv.buildServerOptions()
+	opts, err := srv.buildServerOptions(nil)
 	if err != nil {
 		t.Fatalf("buildServerOptions: %v", err)
 	}
@@ -90,7 +90,7 @@ func newTestEnv(t *testing.T) *testEnv {
 // validAgentToken generates a short-lived agent token for testing.
 func validAgentToken(t *testing.T) string {
 	t.Helper()
-	tok, err := auth.SignAgentToken(testSecret, "pre-node", time.Hour)
+	tok, _, err := auth.SignAgentToken(testSecret, "pre-node", time.Hour)
 	if err != nil {
 		t.Fatalf("SignAgentToken: %v", err)
 	}

--- a/internal/server/management.go
+++ b/internal/server/management.go
@@ -25,15 +25,23 @@ type UserEntry struct {
 // ManagementService implements managementpb.ManagementServiceServer.
 type ManagementService struct {
 	managementpb.UnimplementedManagementServiceServer
-	reg    *registry.Registry
-	users  []UserEntry
-	secret string
+	reg          *registry.Registry
+	users        []UserEntry
+	secret       string
+	tokenStore   *auth.TokenStore
+	tokenChecker *auth.TokenChecker
 }
 
 var _ managementpb.ManagementServiceServer = (*ManagementService)(nil)
 
-func newManagementService(reg *registry.Registry, users []UserEntry, secret string) *ManagementService {
-	return &ManagementService{reg: reg, users: users, secret: secret}
+func newManagementService(reg *registry.Registry, users []UserEntry, secret string, tokenStore *auth.TokenStore, tokenChecker *auth.TokenChecker) *ManagementService {
+	return &ManagementService{
+		reg:          reg,
+		users:        users,
+		secret:       secret,
+		tokenStore:   tokenStore,
+		tokenChecker: tokenChecker,
+	}
 }
 
 // ListNodes returns a summary of all nodes in the registry.
@@ -82,13 +90,25 @@ func (s *ManagementService) Login(_ context.Context, req *managementpb.LoginRequ
 			return &managementpb.LoginResponse{Error: "invalid credentials"}, nil
 		}
 		const tokenExpiry = 24 * time.Hour
-		tok, err := auth.SignCLIToken(s.secret, u.Username, u.NodeIDs, tokenExpiry)
+		now := time.Now()
+		tok, jti, err := auth.SignCLIToken(s.secret, u.Username, u.NodeIDs, tokenExpiry)
 		if err != nil {
 			return nil, status.Errorf(codes.Internal, "management: sign token: %v", err)
 		}
+		// Persist the issued token so it can be listed and revoked.
+		if s.tokenStore != nil {
+			_ = s.tokenStore.Insert(&auth.TokenEntry{
+				ID:        jti,
+				Kind:      string(auth.KindCLI),
+				UserID:    u.Username,
+				NodeIDs:   u.NodeIDs,
+				IssuedAt:  now.Unix(),
+				ExpiresAt: now.Add(tokenExpiry).Unix(),
+			})
+		}
 		return &managementpb.LoginResponse{
 			Token:     tok,
-			ExpiresAt: time.Now().Add(tokenExpiry).Unix(),
+			ExpiresAt: now.Add(tokenExpiry).Unix(),
 		}, nil
 	}
 	return &managementpb.LoginResponse{Error: "invalid credentials"}, nil
@@ -107,6 +127,57 @@ func entryToSummary(e *registry.NodeEntry) *managementpb.NodeSummary {
 		LastHeartbeat: e.LastHeartbeat.Unix(),
 		OsInfo:        osInfoToProto(&e.Info.OSInfo),
 	}
+}
+
+// RevokeToken revokes a previously issued JWT by its JTI.
+func (s *ManagementService) RevokeToken(ctx context.Context, req *managementpb.RevokeTokenRequest) (*managementpb.RevokeTokenResponse, error) {
+	if s.tokenStore == nil {
+		return &managementpb.RevokeTokenResponse{Error: "token management not enabled"}, nil
+	}
+	if req.GetTokenId() == "" {
+		return &managementpb.RevokeTokenResponse{Error: "token_id is required"}, nil
+	}
+
+	claims, _ := auth.ClaimsFromContext(ctx)
+	revokedBy := ""
+	if claims != nil {
+		revokedBy = claims.UserID
+	}
+
+	if err := s.tokenStore.Revoke(req.GetTokenId(), revokedBy); err != nil {
+		return &managementpb.RevokeTokenResponse{Error: err.Error()}, nil
+	}
+
+	if s.tokenChecker != nil {
+		s.tokenChecker.MarkRevoked(req.GetTokenId())
+	}
+
+	return &managementpb.RevokeTokenResponse{Success: true}, nil
+}
+
+// ListTokens returns active (non-revoked, non-expired) tokens.
+func (s *ManagementService) ListTokens(_ context.Context, req *managementpb.ListTokensRequest) (*managementpb.ListTokensResponse, error) {
+	if s.tokenStore == nil {
+		return &managementpb.ListTokensResponse{}, nil
+	}
+
+	entries, err := s.tokenStore.List(req.GetKind())
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "management: list tokens: %v", err)
+	}
+
+	tokens := make([]*managementpb.TokenInfo, 0, len(entries))
+	for _, e := range entries {
+		tokens = append(tokens, &managementpb.TokenInfo{
+			Id:        e.ID,
+			Kind:      e.Kind,
+			UserId:    e.UserID,
+			IssuedAt:  e.IssuedAt,
+			ExpiresAt: e.ExpiresAt,
+		})
+	}
+
+	return &managementpb.ListTokensResponse{Tokens: tokens}, nil
 }
 
 // osInfoToProto converts a registry.OSInfo to a controlpb.OSInfo.

--- a/internal/server/management_test.go
+++ b/internal/server/management_test.go
@@ -76,7 +76,7 @@ func newFullTestEnv(t *testing.T, users []UserEntry) *fullTestEnv {
 // authedCtx adds a valid CLI JWT as gRPC authorization metadata.
 func authedCtx(t *testing.T, userID string, nodeIDs []string) context.Context {
 	t.Helper()
-	tok, err := auth.SignCLIToken(testSecret, userID, nodeIDs, time.Hour)
+	tok, _, err := auth.SignCLIToken(testSecret, userID, nodeIDs, time.Hour)
 	if err != nil {
 		t.Fatalf("SignCLIToken: %v", err)
 	}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -33,11 +33,13 @@ type ServerConfig struct {
 
 // Server wraps a gRPC server with its dependencies.
 type Server struct {
-	cfg         ServerConfig
-	grpc        *grpc.Server
-	registry    *registry.Registry
-	control     *ControlService
-	auditWriter *audit.Writer
+	cfg          ServerConfig
+	grpc         *grpc.Server
+	registry     *registry.Registry
+	control      *ControlService
+	auditWriter  *audit.Writer
+	tokenStore   *auth.TokenStore
+	tokenChecker *auth.TokenChecker
 }
 
 // NewServer creates a new Server with the given configuration.
@@ -59,16 +61,29 @@ func (s *Server) Start(ctx context.Context) error {
 // serve is the internal implementation shared by Start and test helpers
 // that supply their own net.Listener (e.g. bufconn).
 func (s *Server) serve(ctx context.Context, lis net.Listener) error {
-	opts, err := s.buildServerOptions()
-	if err != nil {
-		return err
-	}
-
-	s.grpc = grpc.NewServer(opts...)
-
 	// Build registry and control service.
 	s.registry = registry.NewRegistry(s.cfg.HeartbeatTimeout)
 	s.control = newControlService(s.registry, s.cfg)
+
+	// Initialize token management (store + in-memory revocation checker).
+	tokenStore, err := auth.NewTokenStore(":memory:")
+	if err != nil {
+		return fmt.Errorf("server: init token store: %w", err)
+	}
+	s.tokenStore = tokenStore
+
+	tokenChecker, err := auth.NewTokenChecker(tokenStore)
+	if err != nil {
+		return fmt.Errorf("server: init token checker: %w", err)
+	}
+	s.tokenChecker = tokenChecker
+
+	// Build gRPC server with interceptors that check revoked tokens.
+	opts, err := s.buildServerOptions(tokenChecker)
+	if err != nil {
+		return err
+	}
+	s.grpc = grpc.NewServer(opts...)
 
 	// Initialize audit.
 	auditDBPath := s.cfg.AuditDBPath
@@ -86,7 +101,7 @@ func (s *Server) serve(ctx context.Context, lis net.Listener) error {
 	bridge := newTaskBridge()
 	ops := newOperationsService(router, s.control, bridge, s.auditWriter)
 	agentOps := newAgentOpsService(bridge)
-	mgmt := newManagementService(s.registry, s.cfg.Users, s.cfg.JWTSecret)
+	mgmt := newManagementService(s.registry, s.cfg.Users, s.cfg.JWTSecret, s.tokenStore, s.tokenChecker)
 
 	controlpb.RegisterControlServiceServer(s.grpc, s.control)
 	operationspb.RegisterOperationsServiceServer(s.grpc, ops)
@@ -117,6 +132,9 @@ func (s *Server) GracefulStop() {
 	if s.auditWriter != nil {
 		_ = s.auditWriter.Close()
 	}
+	if s.tokenStore != nil {
+		_ = s.tokenStore.Close()
+	}
 }
 
 // Registry returns the node registry used by this server.
@@ -125,8 +143,8 @@ func (s *Server) Registry() *registry.Registry {
 }
 
 // buildServerOptions constructs the gRPC server options, including TLS and auth
-// interceptors.
-func (s *Server) buildServerOptions() ([]grpc.ServerOption, error) {
+// interceptors. When checker is non-nil, revoked tokens are rejected.
+func (s *Server) buildServerOptions(checker *auth.TokenChecker) ([]grpc.ServerOption, error) {
 	var opts []grpc.ServerOption
 
 	// TLS is optional; only enabled when both cert and key paths are provided.
@@ -144,19 +162,19 @@ func (s *Server) buildServerOptions() ([]grpc.ServerOption, error) {
 
 	// The ControlService/Connect stream handles its own token validation, and
 	// ManagementService/Login is the unauthenticated entry point. All other
-	// methods require a valid JWT.
+	// methods require a valid JWT (with revocation check when checker != nil).
 	opts = append(opts,
-		grpc.ChainUnaryInterceptor(skipLoginUnaryInterceptor(s.cfg.JWTSecret)),
-		grpc.ChainStreamInterceptor(skipConnectStreamInterceptor(s.cfg.JWTSecret)),
+		grpc.ChainUnaryInterceptor(skipLoginUnaryInterceptor(s.cfg.JWTSecret, checker)),
+		grpc.ChainStreamInterceptor(skipConnectStreamInterceptor(s.cfg.JWTSecret, checker)),
 	)
 
 	return opts, nil
 }
 
-// skipLoginUnaryInterceptor wraps auth.UnaryInterceptor but bypasses JWT auth
-// for ManagementService/Login (which is the unauthenticated login endpoint).
-func skipLoginUnaryInterceptor(secret string) grpc.UnaryServerInterceptor {
-	inner := auth.UnaryInterceptor(secret)
+// skipLoginUnaryInterceptor wraps auth.UnaryInterceptorWithChecker but bypasses
+// JWT auth for ManagementService/Login (which is the unauthenticated login endpoint).
+func skipLoginUnaryInterceptor(secret string, checker *auth.TokenChecker) grpc.UnaryServerInterceptor {
+	inner := auth.UnaryInterceptorWithChecker(secret, checker)
 	return func(
 		ctx context.Context,
 		req interface{},
@@ -170,11 +188,11 @@ func skipLoginUnaryInterceptor(secret string) grpc.UnaryServerInterceptor {
 	}
 }
 
-// skipConnectStreamInterceptor wraps auth.StreamInterceptor but bypasses JWT
-// auth for the ControlService/Connect method (which validates its own token
-// inside the handler).
-func skipConnectStreamInterceptor(secret string) grpc.StreamServerInterceptor {
-	inner := auth.StreamInterceptor(secret)
+// skipConnectStreamInterceptor wraps auth.StreamInterceptorWithChecker but
+// bypasses JWT auth for the ControlService/Connect method (which validates its
+// own token inside the handler).
+func skipConnectStreamInterceptor(secret string, checker *auth.TokenChecker) grpc.StreamServerInterceptor {
+	inner := auth.StreamInterceptorWithChecker(secret, checker)
 	return func(
 		srv interface{},
 		ss grpc.ServerStream,

--- a/internal/server/testing.go
+++ b/internal/server/testing.go
@@ -12,6 +12,7 @@ import (
 	operationspb "github.com/garysng/axon/gen/proto/operations"
 	"github.com/garysng/axon/internal/server/registry"
 	"github.com/garysng/axon/pkg/audit"
+	"github.com/garysng/axon/pkg/auth"
 )
 
 // ServeListenerReady starts the server on lis and closes the ready channel
@@ -20,15 +21,27 @@ import (
 func (s *Server) ServeListenerReady(ctx context.Context, lis net.Listener, ready chan<- struct{}) error {
 	// Pre-initialise the components that serve() would create, so they are
 	// visible to callers *before* the goroutine starts gRPC serving.
-	opts, err := s.buildServerOptions()
+	s.registry = registry.NewRegistry(s.cfg.HeartbeatTimeout)
+	s.control = newControlService(s.registry, s.cfg)
+
+	// Initialize token management for tests.
+	tokenStore, err := auth.NewTokenStore(":memory:")
+	if err != nil {
+		return fmt.Errorf("server: init token store: %w", err)
+	}
+	s.tokenStore = tokenStore
+
+	tokenChecker, err := auth.NewTokenChecker(tokenStore)
+	if err != nil {
+		return fmt.Errorf("server: init token checker: %w", err)
+	}
+	s.tokenChecker = tokenChecker
+
+	opts, err := s.buildServerOptions(tokenChecker)
 	if err != nil {
 		return err
 	}
-
 	s.grpc = grpc.NewServer(opts...)
-
-	s.registry = registry.NewRegistry(s.cfg.HeartbeatTimeout)
-	s.control = newControlService(s.registry, s.cfg)
 
 	auditDBPath := s.cfg.AuditDBPath
 	if auditDBPath == "" {
@@ -44,7 +57,7 @@ func (s *Server) ServeListenerReady(ctx context.Context, lis net.Listener, ready
 	bridge := newTaskBridge()
 	ops := newOperationsService(router, s.control, bridge, s.auditWriter)
 	agentOps := newAgentOpsService(bridge)
-	mgmt := newManagementService(s.registry, s.cfg.Users, s.cfg.JWTSecret)
+	mgmt := newManagementService(s.registry, s.cfg.Users, s.cfg.JWTSecret, s.tokenStore, s.tokenChecker)
 
 	controlpb.RegisterControlServiceServer(s.grpc, s.control)
 	operationspb.RegisterOperationsServiceServer(s.grpc, ops)

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/golang-jwt/jwt/v5"
+	"github.com/google/uuid"
 )
 
 // TokenKind identifies the type of JWT token.
@@ -26,33 +27,42 @@ type Claims struct {
 	jwt.RegisteredClaims
 }
 
-// SignCLIToken creates a signed JWT for a CLI client that can access the given nodes.
-func SignCLIToken(secret, userID string, nodeIDs []string, expiry time.Duration) (string, error) {
+// SignCLIToken creates a signed JWT for a CLI client that can access the given
+// nodes. It returns the token string, the JTI (JWT ID) used as the unique
+// token identifier, and any error.
+func SignCLIToken(secret, userID string, nodeIDs []string, expiry time.Duration) (string, string, error) {
 	now := time.Now()
+	jti := uuid.NewString()
 	claims := Claims{
 		UserID:  userID,
 		NodeIDs: nodeIDs,
 		Kind:    KindCLI,
 		RegisteredClaims: jwt.RegisteredClaims{
+			ID:        jti,
 			IssuedAt:  jwt.NewNumericDate(now),
 			ExpiresAt: jwt.NewNumericDate(now.Add(expiry)),
 		},
 	}
-	return signToken(secret, claims)
+	tok, err := signToken(secret, claims)
+	return tok, jti, err
 }
 
-// SignAgentToken creates a signed JWT for an agent node.
-func SignAgentToken(secret, nodeID string, expiry time.Duration) (string, error) {
+// SignAgentToken creates a signed JWT for an agent node. It returns the token
+// string, the JTI used as the unique token identifier, and any error.
+func SignAgentToken(secret, nodeID string, expiry time.Duration) (string, string, error) {
 	now := time.Now()
+	jti := uuid.NewString()
 	claims := Claims{
 		NodeID: nodeID,
 		Kind:   KindAgent,
 		RegisteredClaims: jwt.RegisteredClaims{
+			ID:        jti,
 			IssuedAt:  jwt.NewNumericDate(now),
 			ExpiresAt: jwt.NewNumericDate(now.Add(expiry)),
 		},
 	}
-	return signToken(secret, claims)
+	tok, err := signToken(secret, claims)
+	return tok, jti, err
 }
 
 func signToken(secret string, claims Claims) (string, error) {

--- a/pkg/auth/auth_test.go
+++ b/pkg/auth/auth_test.go
@@ -17,7 +17,7 @@ const testSecret = "super-secret-key-for-testing"
 
 func TestSignCLIToken_RoundTrip(t *testing.T) {
 	nodeIDs := []string{"node-1", "node-2"}
-	tok, err := SignCLIToken(testSecret, "user-42", nodeIDs, time.Hour)
+	tok, _, err := SignCLIToken(testSecret, "user-42", nodeIDs, time.Hour)
 	if err != nil {
 		t.Fatalf("SignCLIToken error: %v", err)
 	}
@@ -38,7 +38,7 @@ func TestSignCLIToken_RoundTrip(t *testing.T) {
 }
 
 func TestSignAgentToken_RoundTrip(t *testing.T) {
-	tok, err := SignAgentToken(testSecret, "node-99", time.Hour)
+	tok, _, err := SignAgentToken(testSecret, "node-99", time.Hour)
 	if err != nil {
 		t.Fatalf("SignAgentToken error: %v", err)
 	}
@@ -58,7 +58,7 @@ func TestSignAgentToken_RoundTrip(t *testing.T) {
 // ---- expired token ----
 
 func TestValidateToken_Expired(t *testing.T) {
-	tok, err := SignCLIToken(testSecret, "user-1", nil, -time.Second)
+	tok, _, err := SignCLIToken(testSecret, "user-1", nil, -time.Second)
 	if err != nil {
 		t.Fatalf("SignCLIToken error: %v", err)
 	}
@@ -72,7 +72,7 @@ func TestValidateToken_Expired(t *testing.T) {
 // ---- invalid signature ----
 
 func TestValidateToken_InvalidSignature(t *testing.T) {
-	tok, err := SignCLIToken(testSecret, "user-1", nil, time.Hour)
+	tok, _, err := SignCLIToken(testSecret, "user-1", nil, time.Hour)
 	if err != nil {
 		t.Fatalf("SignCLIToken error: %v", err)
 	}
@@ -93,7 +93,7 @@ func TestValidateToken_Malformed(t *testing.T) {
 // ---- HasNodeAccess ----
 
 func TestHasNodeAccess_CLIToken(t *testing.T) {
-	tok, err := SignCLIToken(testSecret, "user-1", []string{"node-a", "node-b"}, time.Hour)
+	tok, _, err := SignCLIToken(testSecret, "user-1", []string{"node-a", "node-b"}, time.Hour)
 	if err != nil {
 		t.Fatalf("SignCLIToken error: %v", err)
 	}
@@ -114,7 +114,7 @@ func TestHasNodeAccess_CLIToken(t *testing.T) {
 }
 
 func TestHasNodeAccess_AgentToken(t *testing.T) {
-	tok, err := SignAgentToken(testSecret, "node-x", time.Hour)
+	tok, _, err := SignAgentToken(testSecret, "node-x", time.Hour)
 	if err != nil {
 		t.Fatalf("SignAgentToken error: %v", err)
 	}
@@ -170,7 +170,7 @@ func dummyUnaryHandler(ctx context.Context, _ interface{}) (interface{}, error) 
 }
 
 func TestUnaryInterceptor_ValidToken(t *testing.T) {
-	tok, _ := SignCLIToken(testSecret, "u1", []string{"n1"}, time.Hour)
+	tok, _, _ := SignCLIToken(testSecret, "u1", []string{"n1"}, time.Hour)
 	ctx := makeUnaryCtx(tok)
 
 	interceptor := UnaryInterceptor(testSecret)
@@ -227,7 +227,7 @@ func TestUnaryInterceptor_InvalidToken(t *testing.T) {
 }
 
 func TestUnaryInterceptor_ExpiredToken(t *testing.T) {
-	tok, _ := SignCLIToken(testSecret, "u1", nil, -time.Second)
+	tok, _, _ := SignCLIToken(testSecret, "u1", nil, -time.Second)
 	ctx := makeUnaryCtx(tok)
 
 	interceptor := UnaryInterceptor(testSecret)
@@ -250,7 +250,7 @@ type mockServerStream struct {
 func (m *mockServerStream) Context() context.Context { return m.ctx }
 
 func TestStreamInterceptor_ValidToken(t *testing.T) {
-	tok, _ := SignAgentToken(testSecret, "node-z", time.Hour)
+	tok, _, _ := SignAgentToken(testSecret, "node-z", time.Hour)
 	md := metadata.Pairs("authorization", "Bearer "+tok)
 	ctx := metadata.NewIncomingContext(context.Background(), md)
 	stream := &mockServerStream{ctx: ctx}
@@ -295,7 +295,7 @@ func TestStreamInterceptor_InvalidToken(t *testing.T) {
 // ---- Wildcard Access ----
 
 func TestHasNodeAccess_Wildcard(t *testing.T) {
-	tok, err := SignCLIToken(testSecret, "admin", []string{"*"}, time.Hour)
+	tok, _, err := SignCLIToken(testSecret, "admin", []string{"*"}, time.Hour)
 	if err != nil {
 		t.Fatalf("SignCLIToken error: %v", err)
 	}
@@ -316,7 +316,7 @@ func TestHasNodeAccess_Wildcard(t *testing.T) {
 }
 
 func TestHasNodeAccess_WildcardMixed(t *testing.T) {
-	tok, err := SignCLIToken(testSecret, "user", []string{"node-a", "*"}, time.Hour)
+	tok, _, err := SignCLIToken(testSecret, "user", []string{"node-a", "*"}, time.Hour)
 	if err != nil {
 		t.Fatalf("SignCLIToken error: %v", err)
 	}

--- a/pkg/auth/interceptor.go
+++ b/pkg/auth/interceptor.go
@@ -24,18 +24,31 @@ func InjectClaims(ctx context.Context, claims *Claims) context.Context {
 	return context.WithValue(ctx, contextKey{}, claims)
 }
 
-
 // UnaryInterceptor returns a gRPC unary server interceptor that validates the
 // JWT supplied in the "authorization" metadata header and injects Claims into
-// the request context.
+// the request context. No revocation check is performed.
 func UnaryInterceptor(secret string) grpc.UnaryServerInterceptor {
+	return UnaryInterceptorWithChecker(secret, nil)
+}
+
+// StreamInterceptor returns a gRPC stream server interceptor that validates the
+// JWT supplied in the "authorization" metadata header and injects Claims into
+// the stream context. No revocation check is performed.
+func StreamInterceptor(secret string) grpc.StreamServerInterceptor {
+	return StreamInterceptorWithChecker(secret, nil)
+}
+
+// UnaryInterceptorWithChecker returns a gRPC unary server interceptor that
+// validates the JWT and, when checker is non-nil, rejects tokens whose JTI
+// appears in the revoked set.
+func UnaryInterceptorWithChecker(secret string, checker *TokenChecker) grpc.UnaryServerInterceptor {
 	return func(
 		ctx context.Context,
 		req interface{},
 		_ *grpc.UnaryServerInfo,
 		handler grpc.UnaryHandler,
 	) (interface{}, error) {
-		newCtx, err := authenticate(ctx, secret)
+		newCtx, err := authenticateWithCheck(ctx, secret, checker)
 		if err != nil {
 			return nil, err
 		}
@@ -43,22 +56,37 @@ func UnaryInterceptor(secret string) grpc.UnaryServerInterceptor {
 	}
 }
 
-// StreamInterceptor returns a gRPC stream server interceptor that validates the
-// JWT supplied in the "authorization" metadata header and injects Claims into
-// the stream context.
-func StreamInterceptor(secret string) grpc.StreamServerInterceptor {
+// StreamInterceptorWithChecker returns a gRPC stream server interceptor that
+// validates the JWT and, when checker is non-nil, rejects tokens whose JTI
+// appears in the revoked set.
+func StreamInterceptorWithChecker(secret string, checker *TokenChecker) grpc.StreamServerInterceptor {
 	return func(
 		srv interface{},
 		ss grpc.ServerStream,
 		_ *grpc.StreamServerInfo,
 		handler grpc.StreamHandler,
 	) error {
-		newCtx, err := authenticate(ss.Context(), secret)
+		newCtx, err := authenticateWithCheck(ss.Context(), secret, checker)
 		if err != nil {
 			return err
 		}
 		return handler(srv, &wrappedStream{ss, newCtx})
 	}
+}
+
+// authenticateWithCheck validates the bearer token and optionally checks the
+// revoked set.
+func authenticateWithCheck(ctx context.Context, secret string, checker *TokenChecker) (context.Context, error) {
+	newCtx, err := authenticate(ctx, secret)
+	if err != nil {
+		return nil, err
+	}
+	if checker != nil {
+		if claims, ok := ClaimsFromContext(newCtx); ok && checker.IsRevoked(claims.ID) {
+			return nil, status.Error(codes.Unauthenticated, "token has been revoked")
+		}
+	}
+	return newCtx, nil
 }
 
 // authenticate extracts and validates the bearer token from gRPC metadata,

--- a/pkg/auth/token_checker.go
+++ b/pkg/auth/token_checker.go
@@ -1,0 +1,52 @@
+package auth
+
+import (
+	"fmt"
+	"sync"
+)
+
+// TokenChecker maintains an in-memory set of revoked JTIs for O(1) lookup.
+// It is populated from a TokenStore on startup and updated synchronously on
+// each revocation so that every subsequent request is rejected immediately.
+type TokenChecker struct {
+	mu      sync.RWMutex
+	revoked map[string]struct{}
+}
+
+// NewTokenChecker creates a TokenChecker and pre-loads revoked JTIs from
+// store. If store is nil an empty (no revocations known) checker is returned.
+func NewTokenChecker(store *TokenStore) (*TokenChecker, error) {
+	c := &TokenChecker{
+		revoked: make(map[string]struct{}),
+	}
+	if store == nil {
+		return c, nil
+	}
+	ids, err := store.LoadRevoked()
+	if err != nil {
+		return nil, fmt.Errorf("auth: init token checker: %w", err)
+	}
+	for _, id := range ids {
+		c.revoked[id] = struct{}{}
+	}
+	return c, nil
+}
+
+// IsRevoked reports whether the given JTI has been revoked.
+func (c *TokenChecker) IsRevoked(jti string) bool {
+	if jti == "" {
+		return false
+	}
+	c.mu.RLock()
+	_, ok := c.revoked[jti]
+	c.mu.RUnlock()
+	return ok
+}
+
+// MarkRevoked adds a JTI to the in-memory revoked set. Callers should also
+// persist the revocation to the TokenStore.
+func (c *TokenChecker) MarkRevoked(jti string) {
+	c.mu.Lock()
+	c.revoked[jti] = struct{}{}
+	c.mu.Unlock()
+}

--- a/pkg/auth/token_store.go
+++ b/pkg/auth/token_store.go
@@ -1,0 +1,160 @@
+package auth
+
+import (
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	_ "modernc.org/sqlite" // SQLite driver
+)
+
+const createTokensSchema = `
+CREATE TABLE IF NOT EXISTS tokens (
+    id          TEXT PRIMARY KEY,
+    kind        TEXT NOT NULL,
+    user_id     TEXT NOT NULL DEFAULT '',
+    node_ids    TEXT NOT NULL DEFAULT '[]',
+    issued_at   INTEGER NOT NULL,
+    expires_at  INTEGER NOT NULL,
+    revoked_at  INTEGER,
+    revoked_by  TEXT NOT NULL DEFAULT ''
+);
+CREATE INDEX IF NOT EXISTS idx_tokens_user ON tokens(user_id);
+CREATE INDEX IF NOT EXISTS idx_tokens_kind ON tokens(kind);
+`
+
+// TokenEntry holds the persisted record for a single issued JWT.
+type TokenEntry struct {
+	ID        string   // JWT ID (jti claim)
+	Kind      string   // "cli" or "agent"
+	UserID    string   // set for CLI tokens
+	NodeIDs   []string // allowed nodes (CLI tokens)
+	IssuedAt  int64    // Unix timestamp
+	ExpiresAt int64    // Unix timestamp
+	RevokedAt *int64   // nil if not revoked
+	RevokedBy string   // username that revoked the token
+}
+
+// TokenStore persists issued tokens to a SQLite database.
+type TokenStore struct {
+	db *sql.DB
+}
+
+// NewTokenStore opens (or creates) a SQLite database at dbPath and
+// initialises the tokens schema. Use ":memory:" for in-process tests.
+func NewTokenStore(dbPath string) (*TokenStore, error) {
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		return nil, fmt.Errorf("auth: open token db %q: %w", dbPath, err)
+	}
+	if _, err := db.Exec(createTokensSchema); err != nil {
+		_ = db.Close()
+		return nil, fmt.Errorf("auth: init token schema: %w", err)
+	}
+	return &TokenStore{db: db}, nil
+}
+
+// Close releases the database connection.
+func (s *TokenStore) Close() error {
+	return s.db.Close()
+}
+
+// Insert records a newly-issued token.
+func (s *TokenStore) Insert(e *TokenEntry) error {
+	nodeIDsJSON, err := json.Marshal(e.NodeIDs)
+	if err != nil {
+		return fmt.Errorf("auth: marshal node_ids: %w", err)
+	}
+	_, err = s.db.Exec(
+		`INSERT INTO tokens (id, kind, user_id, node_ids, issued_at, expires_at) VALUES (?, ?, ?, ?, ?, ?)`,
+		e.ID, e.Kind, e.UserID, string(nodeIDsJSON), e.IssuedAt, e.ExpiresAt,
+	)
+	if err != nil {
+		return fmt.Errorf("auth: insert token: %w", err)
+	}
+	return nil
+}
+
+// Revoke marks a token as revoked. Returns an error if the token does not
+// exist or was already revoked.
+func (s *TokenStore) Revoke(id, revokedBy string) error {
+	now := time.Now().Unix()
+	res, err := s.db.Exec(
+		`UPDATE tokens SET revoked_at=?, revoked_by=? WHERE id=? AND revoked_at IS NULL`,
+		now, revokedBy, id,
+	)
+	if err != nil {
+		return fmt.Errorf("auth: revoke token: %w", err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("auth: revoke token rows: %w", err)
+	}
+	if n == 0 {
+		return fmt.Errorf("auth: token %q not found or already revoked", id)
+	}
+	return nil
+}
+
+// List returns active (non-revoked, non-expired) tokens. Pass kind="" to
+// return tokens of all kinds; pass "cli" or "agent" to filter by kind.
+func (s *TokenStore) List(kind string) ([]*TokenEntry, error) {
+	now := time.Now().Unix()
+
+	var (
+		rows *sql.Rows
+		err  error
+	)
+	if kind == "" {
+		rows, err = s.db.Query(
+			`SELECT id, kind, user_id, node_ids, issued_at, expires_at FROM tokens WHERE revoked_at IS NULL AND expires_at > ? ORDER BY issued_at DESC`,
+			now,
+		)
+	} else {
+		rows, err = s.db.Query(
+			`SELECT id, kind, user_id, node_ids, issued_at, expires_at FROM tokens WHERE revoked_at IS NULL AND expires_at > ? AND kind=? ORDER BY issued_at DESC`,
+			now, kind,
+		)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("auth: list tokens: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var entries []*TokenEntry
+	for rows.Next() {
+		var e TokenEntry
+		var nodeIDsJSON string
+		if err := rows.Scan(&e.ID, &e.Kind, &e.UserID, &nodeIDsJSON, &e.IssuedAt, &e.ExpiresAt); err != nil {
+			return nil, fmt.Errorf("auth: scan token: %w", err)
+		}
+		if err := json.Unmarshal([]byte(nodeIDsJSON), &e.NodeIDs); err != nil {
+			e.NodeIDs = nil
+		}
+		entries = append(entries, &e)
+	}
+	return entries, rows.Err()
+}
+
+// LoadRevoked returns revoked JTIs that have not yet expired from the database
+// so the in-memory TokenChecker can be pre-populated on startup. Expired
+// revoked tokens are excluded to avoid unbounded memory growth.
+func (s *TokenStore) LoadRevoked() ([]string, error) {
+	now := time.Now().Unix()
+	rows, err := s.db.Query(`SELECT id FROM tokens WHERE revoked_at IS NOT NULL AND expires_at > ?`, now)
+	if err != nil {
+		return nil, fmt.Errorf("auth: load revoked tokens: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var ids []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return nil, fmt.Errorf("auth: scan revoked id: %w", err)
+		}
+		ids = append(ids, id)
+	}
+	return ids, rows.Err()
+}

--- a/pkg/auth/token_store_test.go
+++ b/pkg/auth/token_store_test.go
@@ -1,0 +1,214 @@
+package auth
+
+import (
+	"testing"
+	"time"
+)
+
+func newTestTokenStore(t *testing.T) *TokenStore {
+	t.Helper()
+	store, err := NewTokenStore(":memory:")
+	if err != nil {
+		t.Fatalf("NewTokenStore: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	return store
+}
+
+func TestTokenStore_InsertAndList(t *testing.T) {
+	store := newTestTokenStore(t)
+
+	entry := &TokenEntry{
+		ID:        "jti-1",
+		Kind:      "cli",
+		UserID:    "alice",
+		NodeIDs:   []string{"node-a", "node-b"},
+		IssuedAt:  time.Now().Unix(),
+		ExpiresAt: time.Now().Add(24 * time.Hour).Unix(),
+	}
+	if err := store.Insert(entry); err != nil {
+		t.Fatalf("Insert: %v", err)
+	}
+
+	entries, err := store.List("")
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 token, got %d", len(entries))
+	}
+	if entries[0].ID != "jti-1" {
+		t.Errorf("expected ID jti-1, got %s", entries[0].ID)
+	}
+	if entries[0].UserID != "alice" {
+		t.Errorf("expected UserID alice, got %s", entries[0].UserID)
+	}
+	if len(entries[0].NodeIDs) != 2 {
+		t.Errorf("expected 2 NodeIDs, got %d", len(entries[0].NodeIDs))
+	}
+}
+
+func TestTokenStore_ListByKind(t *testing.T) {
+	store := newTestTokenStore(t)
+
+	for _, e := range []*TokenEntry{
+		{ID: "jti-cli", Kind: "cli", UserID: "alice", IssuedAt: time.Now().Unix(), ExpiresAt: time.Now().Add(time.Hour).Unix()},
+		{ID: "jti-agent", Kind: "agent", UserID: "", IssuedAt: time.Now().Unix(), ExpiresAt: time.Now().Add(time.Hour).Unix()},
+	} {
+		if err := store.Insert(e); err != nil {
+			t.Fatalf("Insert %s: %v", e.ID, err)
+		}
+	}
+
+	cli, err := store.List("cli")
+	if err != nil {
+		t.Fatalf("List cli: %v", err)
+	}
+	if len(cli) != 1 || cli[0].ID != "jti-cli" {
+		t.Errorf("expected 1 cli token, got %d", len(cli))
+	}
+
+	agent, err := store.List("agent")
+	if err != nil {
+		t.Fatalf("List agent: %v", err)
+	}
+	if len(agent) != 1 || agent[0].ID != "jti-agent" {
+		t.Errorf("expected 1 agent token, got %d", len(agent))
+	}
+}
+
+func TestTokenStore_Revoke(t *testing.T) {
+	store := newTestTokenStore(t)
+
+	entry := &TokenEntry{
+		ID:        "jti-rev",
+		Kind:      "cli",
+		UserID:    "bob",
+		IssuedAt:  time.Now().Unix(),
+		ExpiresAt: time.Now().Add(time.Hour).Unix(),
+	}
+	if err := store.Insert(entry); err != nil {
+		t.Fatalf("Insert: %v", err)
+	}
+
+	if err := store.Revoke("jti-rev", "admin"); err != nil {
+		t.Fatalf("Revoke: %v", err)
+	}
+
+	// Revoked tokens should not appear in List.
+	entries, err := store.List("")
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Errorf("expected 0 tokens after revoke, got %d", len(entries))
+	}
+
+	// LoadRevoked should return the revoked ID.
+	revoked, err := store.LoadRevoked()
+	if err != nil {
+		t.Fatalf("LoadRevoked: %v", err)
+	}
+	if len(revoked) != 1 || revoked[0] != "jti-rev" {
+		t.Errorf("expected [jti-rev], got %v", revoked)
+	}
+}
+
+func TestTokenStore_RevokeAlreadyRevoked(t *testing.T) {
+	store := newTestTokenStore(t)
+
+	entry := &TokenEntry{
+		ID:        "jti-double",
+		Kind:      "cli",
+		UserID:    "bob",
+		IssuedAt:  time.Now().Unix(),
+		ExpiresAt: time.Now().Add(time.Hour).Unix(),
+	}
+	if err := store.Insert(entry); err != nil {
+		t.Fatalf("Insert: %v", err)
+	}
+	if err := store.Revoke("jti-double", "admin"); err != nil {
+		t.Fatalf("first Revoke: %v", err)
+	}
+	if err := store.Revoke("jti-double", "admin"); err == nil {
+		t.Error("expected error on double revoke, got nil")
+	}
+}
+
+func TestTokenStore_RevokeNotFound(t *testing.T) {
+	store := newTestTokenStore(t)
+
+	if err := store.Revoke("nonexistent", "admin"); err == nil {
+		t.Error("expected error revoking nonexistent token, got nil")
+	}
+}
+
+func TestTokenStore_LoadRevokedExcludesExpired(t *testing.T) {
+	store := newTestTokenStore(t)
+
+	// Insert an already-expired revoked token.
+	expired := &TokenEntry{
+		ID:        "jti-expired",
+		Kind:      "cli",
+		UserID:    "old",
+		IssuedAt:  time.Now().Add(-2 * time.Hour).Unix(),
+		ExpiresAt: time.Now().Add(-1 * time.Hour).Unix(), // already expired
+	}
+	if err := store.Insert(expired); err != nil {
+		t.Fatalf("Insert: %v", err)
+	}
+	if err := store.Revoke("jti-expired", "admin"); err != nil {
+		t.Fatalf("Revoke: %v", err)
+	}
+
+	revoked, err := store.LoadRevoked()
+	if err != nil {
+		t.Fatalf("LoadRevoked: %v", err)
+	}
+	if len(revoked) != 0 {
+		t.Errorf("expected 0 revoked (expired excluded), got %v", revoked)
+	}
+}
+
+func TestTokenChecker_IsRevoked(t *testing.T) {
+	checker, err := NewTokenChecker(nil)
+	if err != nil {
+		t.Fatalf("NewTokenChecker: %v", err)
+	}
+
+	if checker.IsRevoked("some-jti") {
+		t.Error("expected false for unknown JTI")
+	}
+
+	checker.MarkRevoked("some-jti")
+	if !checker.IsRevoked("some-jti") {
+		t.Error("expected true after MarkRevoked")
+	}
+}
+
+func TestTokenChecker_PreloadFromStore(t *testing.T) {
+	store := newTestTokenStore(t)
+
+	entry := &TokenEntry{
+		ID:        "jti-preload",
+		Kind:      "cli",
+		UserID:    "test",
+		IssuedAt:  time.Now().Unix(),
+		ExpiresAt: time.Now().Add(time.Hour).Unix(),
+	}
+	if err := store.Insert(entry); err != nil {
+		t.Fatalf("Insert: %v", err)
+	}
+	if err := store.Revoke("jti-preload", "admin"); err != nil {
+		t.Fatalf("Revoke: %v", err)
+	}
+
+	checker, err := NewTokenChecker(store)
+	if err != nil {
+		t.Fatalf("NewTokenChecker: %v", err)
+	}
+
+	if !checker.IsRevoked("jti-preload") {
+		t.Error("expected jti-preload to be revoked after preload")
+	}
+}

--- a/proto/management.proto
+++ b/proto/management.proto
@@ -10,6 +10,8 @@ service ManagementService {
   rpc GetNode(GetNodeRequest) returns (GetNodeResponse);
   rpc RemoveNode(RemoveNodeRequest) returns (RemoveNodeResponse);
   rpc Login(LoginRequest) returns (LoginResponse);
+  rpc RevokeToken(RevokeTokenRequest) returns (RevokeTokenResponse);
+  rpc ListTokens(ListTokensRequest) returns (ListTokensResponse);
 }
 
 // ─── Node Management ───
@@ -62,4 +64,31 @@ message LoginResponse {
   string token = 1;           // JWT token
   int64 expires_at = 2;       // Unix timestamp
   string error = 3;
+}
+
+// ─── Token Management ───
+
+message RevokeTokenRequest {
+  string token_id = 1;       // JWT ID (jti)
+}
+
+message RevokeTokenResponse {
+  bool success = 1;
+  string error = 2;
+}
+
+message ListTokensRequest {
+  string kind = 1;            // "cli", "agent", or "" for all
+}
+
+message ListTokensResponse {
+  repeated TokenInfo tokens = 1;
+}
+
+message TokenInfo {
+  string id = 1;              // JWT ID (jti)
+  string kind = 2;
+  string user_id = 3;
+  int64 issued_at = 4;
+  int64 expires_at = 5;
 }

--- a/test/integration/testharness/harness.go
+++ b/test/integration/testharness/harness.go
@@ -117,7 +117,7 @@ func NewHarness(t *testing.T, options ...HarnessOption) *Harness {
 	_ = srvErrCh
 
 	// Build agent config.
-	agentToken, err := auth.SignAgentToken(opts.jwtSecret, "integration-node", time.Hour)
+	agentToken, _, err := auth.SignAgentToken(opts.jwtSecret, "integration-node", time.Hour)
 	if err != nil {
 		cancel()
 		t.Fatalf("harness: sign agent token: %v", err)
@@ -224,7 +224,7 @@ func (h *Harness) CLIConn() *grpc.ClientConn {
 func (h *Harness) CLIConnWithAccess(nodeIDs ...string) *grpc.ClientConn {
 	h.t.Helper()
 
-	token, err := auth.SignCLIToken(h.opts.jwtSecret, "test-user", nodeIDs, time.Hour)
+	token, _, err := auth.SignCLIToken(h.opts.jwtSecret, "test-user", nodeIDs, time.Hour)
 	if err != nil {
 		h.t.Fatalf("harness: sign CLI token: %v", err)
 	}
@@ -272,7 +272,7 @@ func (h *Harness) UnauthConn() *grpc.ClientConn {
 func (h *Harness) ConnectAgent(name string) (*agent.Agent, string) {
 	h.t.Helper()
 
-	agentToken, err := auth.SignAgentToken(h.opts.jwtSecret, "extra-node", time.Hour)
+	agentToken, _, err := auth.SignAgentToken(h.opts.jwtSecret, "extra-node", time.Hour)
 	if err != nil {
 		h.t.Fatalf("harness: sign agent token: %v", err)
 	}
@@ -334,7 +334,7 @@ func (h *Harness) ConnectAgentWithToken(name, token string) (*agent.Agent, strin
 func (h *Harness) ConnectAgentWithHandler(name string, handler agent.TaskHandler) (*agent.Agent, string) {
 	h.t.Helper()
 
-	agentToken, err := auth.SignAgentToken(h.opts.jwtSecret, "task-node", time.Hour)
+	agentToken, _, err := auth.SignAgentToken(h.opts.jwtSecret, "task-node", time.Hour)
 	if err != nil {
 		h.t.Fatalf("harness: sign agent token: %v", err)
 	}


### PR DESCRIPTION
## Summary

Implements Phase 2 Task P2-2 — Token Management (all sub-tasks).

### P2-2a: Token Store + JWT Changes
- `TokenStore` (SQLite): tokens table with jti, kind, user_id, node_ids, timestamps, revocation tracking
- JWT: `jti` (JWT ID = uuid) added to both CLI and Agent tokens
- `SignCLIToken`/`SignAgentToken` now return `(token, jti, error)` — all callers updated

### P2-2b: Revocation Check
- `TokenChecker`: in-memory revoked jti set, O(1) lookup
- Pre-loaded from store on startup
- Wired into auth interceptor (unary + stream)

### P2-2c: Management RPCs + CLI
- Proto: `RevokeToken`, `ListTokens` RPCs
- Server: `ManagementService` handlers for revoke + list
- CLI: `axon auth revoke <token-id>`, `axon auth list-tokens [--kind]`, `axon auth rotate`