### PR TITLE
feat: P2-4 auto-TLS with self-signed CA and server certificates

### DIFF
--- a/cmd/axon-server/main.go
+++ b/cmd/axon-server/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log"
 	"os"
 	"os/signal"
 	"runtime"
@@ -94,7 +95,7 @@ type fileConfig struct {
 }
 
 type tlsConfig struct {
-	Auto bool   `yaml:"auto"`
+	Auto *bool  `yaml:"auto"`  // pointer to distinguish unset from explicit false
 	Dir  string `yaml:"dir"`
 	Cert string `yaml:"cert"`
 	Key  string `yaml:"key"`
@@ -158,7 +159,17 @@ func loadServerConfig(path string) (*server.ServerConfig, error) {
 
 	// TLSAuto defaults to true when no explicit cert/key is provided.
 	// Set tls.auto: false in the config file to disable auto-TLS entirely.
-	tlsAuto := fc.TLS.Auto || (fc.TLS.Cert == "" && fc.TLS.Key == "")
+	var tlsAuto bool
+	if fc.TLS.Auto != nil {
+		// Explicit setting: honor it.
+		tlsAuto = *fc.TLS.Auto
+	} else {
+		// Not set: auto-generate when no cert/key configured.
+		tlsAuto = fc.TLS.Cert == "" && fc.TLS.Key == ""
+	}
+	if !tlsAuto && fc.TLS.Cert == "" && fc.TLS.Key == "" {
+		log.Println("WARNING: TLS disabled (tls.auto: false) with no cert/key — connections will be unencrypted")
+	}
 
 	cfg := &server.ServerConfig{
 		ListenAddr:        fc.Listen,

--- a/cmd/axon-server/main.go
+++ b/cmd/axon-server/main.go
@@ -94,6 +94,8 @@ type fileConfig struct {
 }
 
 type tlsConfig struct {
+	Auto bool   `yaml:"auto"`
+	Dir  string `yaml:"dir"`
 	Cert string `yaml:"cert"`
 	Key  string `yaml:"key"`
 }
@@ -154,10 +156,16 @@ func loadServerConfig(path string) (*server.ServerConfig, error) {
 		}
 	}
 
+	// TLSAuto defaults to true when no explicit cert/key is provided.
+	// Set tls.auto: false in the config file to disable auto-TLS entirely.
+	tlsAuto := fc.TLS.Auto || (fc.TLS.Cert == "" && fc.TLS.Key == "")
+
 	cfg := &server.ServerConfig{
 		ListenAddr:        fc.Listen,
 		TLSCertPath:       fc.TLS.Cert,
 		TLSKeyPath:        fc.TLS.Key,
+		TLSAuto:           tlsAuto,
+		TLSDir:            fc.TLS.Dir,
 		JWTSecret:         strings.TrimSpace(fc.Auth.JWTSigningKey),
 		HeartbeatInterval: hbInterval,
 		HeartbeatTimeout:  hbTimeout,

--- a/cmd/axon/client.go
+++ b/cmd/axon/client.go
@@ -8,8 +8,16 @@ import (
 	operationspb "github.com/garysng/axon/gen/proto/operations"
 	"github.com/garysng/axon/pkg/config"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/metadata"
+)
+
+// globalCACert and globalTLSInsecure are set by persistent root flags (--ca-cert,
+// --tls-insecure) and override values read from the CLI config file.
+var (
+	globalCACert      string
+	globalTLSInsecure bool
 )
 
 // dialConn creates a gRPC connection to the Axon server using CLI config.
@@ -24,9 +32,29 @@ func dialConn(withAuth bool) (*grpc.ClientConn, func(), error) {
 		return nil, nil, fmt.Errorf("server address not configured; run: axon config set server <addr>")
 	}
 
-	opts := []grpc.DialOption{
-		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	// Flags override config-file values.
+	if globalCACert != "" {
+		cfg.CACert = globalCACert
 	}
+	if globalTLSInsecure {
+		cfg.TLSInsecure = true
+	}
+
+	var transportOpt grpc.DialOption
+	switch {
+	case cfg.TLSInsecure:
+		transportOpt = grpc.WithTransportCredentials(insecure.NewCredentials())
+	case cfg.CACert != "":
+		creds, err := credentials.NewClientTLSFromFile(cfg.CACert, "")
+		if err != nil {
+			return nil, nil, fmt.Errorf("load CA cert %q: %w", cfg.CACert, err)
+		}
+		transportOpt = grpc.WithTransportCredentials(creds)
+	default:
+		transportOpt = grpc.WithTransportCredentials(credentials.NewClientTLSFromCert(nil, ""))
+	}
+
+	opts := []grpc.DialOption{transportOpt}
 
 	if withAuth {
 		if cfg.Token == "" {

--- a/cmd/axon/main.go
+++ b/cmd/axon/main.go
@@ -27,12 +27,15 @@ func main() {
 
 func rootCmd() *cobra.Command {
 	root := &cobra.Command{
-		Use:   "axon",
-		Short: "Axon CLI — remote operations on agent nodes",
-		Long:  "Axon connects AI agents to real machines. Use this CLI to execute commands, read/write files, and forward ports on remote nodes.",
+		Use:           "axon",
+		Short:         "Axon CLI — remote operations on agent nodes",
+		Long:          "Axon connects AI agents to real machines. Use this CLI to execute commands, read/write files, and forward ports on remote nodes.",
 		SilenceUsage:  true,
 		SilenceErrors: true,
 	}
+
+	root.PersistentFlags().StringVar(&globalCACert, "ca-cert", "", "path to CA certificate for TLS verification")
+	root.PersistentFlags().BoolVar(&globalTLSInsecure, "tls-insecure", false, "skip TLS certificate verification (insecure)")
 
 	root.AddCommand(
 		versionCmd(),

--- a/cmd/axon/main.go
+++ b/cmd/axon/main.go
@@ -94,8 +94,12 @@ func configGetCmd() *cobra.Command {
 				fmt.Println(display.MaskToken(cfg.Token))
 			case "output_format":
 				fmt.Println(cfg.OutputFormat)
+			case "ca_cert":
+				fmt.Println(cfg.CACert)
+			case "tls_insecure":
+				fmt.Println(cfg.TLSInsecure)
 			default:
-				return fmt.Errorf("unknown config key: %s (supported: server, token, output_format)", key)
+				return fmt.Errorf("unknown config key: %s (supported: server, token, output_format, ca_cert, tls_insecure)", key)
 			}
 			return nil
 		},
@@ -123,8 +127,12 @@ func configSetCmd() *cobra.Command {
 				cfg.Token = value
 			case "output_format":
 				cfg.OutputFormat = value
+			case "ca_cert":
+				cfg.CACert = value
+			case "tls_insecure":
+				cfg.TLSInsecure = value == "true" || value == "1"
 			default:
-				return fmt.Errorf("unknown config key: %s (supported: server, token, output_format)", key)
+				return fmt.Errorf("unknown config key: %s (supported: server, token, output_format, ca_cert, tls_insecure)", key)
 			}
 			if err := config.SaveCLIConfig(cfgPath, cfg); err != nil {
 				return fmt.Errorf("save config: %w", err)

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -150,9 +150,16 @@ func (a *Agent) runOnce(ctx context.Context) error {
 func (a *Agent) dial(ctx context.Context) (*grpc.ClientConn, error) {
 	opts := []grpc.DialOption{}
 
-	if a.cfg.TLSInsecure {
+	switch {
+	case a.cfg.TLSInsecure:
 		opts = append(opts, grpc.WithTransportCredentials(insecure.NewCredentials()))
-	} else {
+	case a.cfg.CACert != "":
+		creds, err := credentials.NewClientTLSFromFile(a.cfg.CACert, "")
+		if err != nil {
+			return nil, fmt.Errorf("load CA cert %q: %w", a.cfg.CACert, err)
+		}
+		opts = append(opts, grpc.WithTransportCredentials(creds))
+	default:
 		opts = append(opts, grpc.WithTransportCredentials(credentials.NewClientTLSFromCert(nil, "")))
 	}
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -140,13 +140,18 @@ func (s *Server) serve(ctx context.Context, lis net.Listener) error {
 			host != "" && host != "0.0.0.0" && host != "::" {
 			hostname = host
 		}
-		paths, err := autotls.EnsureTLS(tlsDir, hostname)
+		caCertPath, serverCertPath, serverKeyPath, generated, err := autotls.EnsureTLS(tlsDir, hostname)
 		if err != nil {
 			return fmt.Errorf("server: auto-TLS: %w", err)
 		}
-		s.cfg.TLSCertPath = paths.ServerCert
-		s.cfg.TLSKeyPath = paths.ServerKey
-		log.Printf("server: TLS enabled; CA cert: %s", paths.CACert)
+		s.cfg.TLSCertPath = serverCertPath
+		s.cfg.TLSKeyPath = serverKeyPath
+		if generated {
+			fp, _ := autotls.CAFingerprint(caCertPath)
+			log.Printf("server: auto-TLS: generated CA cert %s (SHA-256: %s)", caCertPath, fp)
+		} else {
+			log.Printf("server: auto-TLS: using existing CA cert %s", caCertPath)
+		}
 	}
 
 	// Build gRPC server with interceptors that check revoked tokens.

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -6,7 +6,10 @@ import (
 	"crypto/tls"
 	"database/sql"
 	"fmt"
+	"log"
 	"net"
+	"os"
+	"path/filepath"
 	"time"
 
 	"google.golang.org/grpc"
@@ -20,6 +23,7 @@ import (
 	"github.com/garysng/axon/internal/server/registry"
 	"github.com/garysng/axon/pkg/audit"
 	"github.com/garysng/axon/pkg/auth"
+	autotls "github.com/garysng/axon/pkg/tls"
 )
 
 // ServerConfig holds configuration for the gRPC server.
@@ -27,6 +31,8 @@ type ServerConfig struct {
 	ListenAddr        string
 	TLSCertPath       string
 	TLSKeyPath        string
+	TLSAuto           bool   // auto-generate self-signed CA + server cert if no explicit cert is set
+	TLSDir            string // directory for auto-generated TLS files; defaults to ~/.axon-server/tls
 	JWTSecret         string
 	HeartbeatInterval time.Duration
 	HeartbeatTimeout  time.Duration
@@ -114,6 +120,33 @@ func (s *Server) serve(ctx context.Context, lis net.Listener) error {
 	// since user management RPCs require authentication.
 	for i := range s.cfg.Users {
 		_, _ = userStore.InsertIfAbsent(&s.cfg.Users[i])
+	}
+
+	// Auto-TLS: generate a self-signed CA + server cert when enabled and no
+	// explicit cert/key paths are configured.
+	if s.cfg.TLSAuto && s.cfg.TLSCertPath == "" {
+		tlsDir := s.cfg.TLSDir
+		if tlsDir == "" {
+			home, err := os.UserHomeDir()
+			if err != nil {
+				return fmt.Errorf("server: resolve home dir for TLS: %w", err)
+			}
+			tlsDir = filepath.Join(home, ".axon-server", "tls")
+		}
+		// Use the listen address host as the server cert CN/SAN when it is a
+		// specific hostname rather than a wildcard bind address.
+		hostname := "localhost"
+		if host, _, err := net.SplitHostPort(s.cfg.ListenAddr); err == nil &&
+			host != "" && host != "0.0.0.0" && host != "::" {
+			hostname = host
+		}
+		paths, err := autotls.EnsureTLS(tlsDir, hostname)
+		if err != nil {
+			return fmt.Errorf("server: auto-TLS: %w", err)
+		}
+		s.cfg.TLSCertPath = paths.ServerCert
+		s.cfg.TLSKeyPath = paths.ServerKey
+		log.Printf("server: TLS enabled; CA cert: %s", paths.CACert)
 	}
 
 	// Build gRPC server with interceptors that check revoked tokens.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -13,12 +13,14 @@ import (
 
 // ServerConfig holds configuration for the Axon server.
 type ServerConfig struct {
-	ListenAddr               string `yaml:"listen_addr"`
-	TLSCertPath              string `yaml:"tls_cert_path"`
-	TLSKeyPath               string `yaml:"tls_key_path"`
-	JWTSecret                string `yaml:"jwt_secret"`
-	AuditDBPath              string `yaml:"audit_db_path"`
-	HeartbeatTimeoutSeconds  int    `yaml:"heartbeat_timeout_seconds"`
+	ListenAddr              string `yaml:"listen_addr"`
+	TLSCertPath             string `yaml:"tls_cert_path"`
+	TLSKeyPath              string `yaml:"tls_key_path"`
+	TLSAuto                 bool   `yaml:"tls_auto"`
+	TLSDir                  string `yaml:"tls_dir"`
+	JWTSecret               string `yaml:"jwt_secret"`
+	AuditDBPath             string `yaml:"audit_db_path"`
+	HeartbeatTimeoutSeconds int    `yaml:"heartbeat_timeout_seconds"`
 }
 
 // AgentConfig holds configuration for the Axon agent.
@@ -28,14 +30,16 @@ type AgentConfig struct {
 	NodeID      string            `yaml:"node_id,omitempty"` // assigned by server after first registration
 	NodeName    string            `yaml:"node_name"`
 	Labels      map[string]string `yaml:"labels"`
+	CACert      string            `yaml:"ca_cert"`
 	TLSInsecure bool              `yaml:"tls_insecure"`
 }
 
 // CLIConfig holds configuration for the Axon CLI.
 type CLIConfig struct {
-	ServerAddr  string `yaml:"server_addr"`
-	Token       string `yaml:"token"`
+	ServerAddr   string `yaml:"server_addr"`
+	Token        string `yaml:"token"`
 	OutputFormat string `yaml:"output_format"`
+	CACert       string `yaml:"ca_cert"`
 	TLSInsecure  bool   `yaml:"tls_insecure"`
 }
 
@@ -170,6 +174,9 @@ func applyServerEnv(cfg *ServerConfig) {
 	if v := os.Getenv("AXON_TLS_KEY"); v != "" {
 		cfg.TLSKeyPath = v
 	}
+	if v := os.Getenv("AXON_TLS_DIR"); v != "" {
+		cfg.TLSDir = v
+	}
 	if v := os.Getenv("AXON_JWT_SECRET"); v != "" {
 		cfg.JWTSecret = v
 	}
@@ -185,6 +192,9 @@ func applyAgentEnv(cfg *AgentConfig) {
 	if v := os.Getenv("AXON_TOKEN"); v != "" {
 		cfg.Token = v
 	}
+	if v := os.Getenv("AXON_CA_CERT"); v != "" {
+		cfg.CACert = v
+	}
 }
 
 func applyCLIEnv(cfg *CLIConfig) {
@@ -193,5 +203,8 @@ func applyCLIEnv(cfg *CLIConfig) {
 	}
 	if v := os.Getenv("AXON_TOKEN"); v != "" {
 		cfg.Token = v
+	}
+	if v := os.Getenv("AXON_CA_CERT"); v != "" {
+		cfg.CACert = v
 	}
 }

--- a/pkg/tls/autotls.go
+++ b/pkg/tls/autotls.go
@@ -1,0 +1,216 @@
+// Package autotls provides automatic TLS certificate generation for Axon.
+// It generates a self-signed CA and a server certificate signed by that CA.
+package autotls
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"log"
+	"math/big"
+	"net"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// Paths holds the file paths for the generated TLS certificates and keys.
+type Paths struct {
+	CACert     string // CA certificate (PEM)
+	CAKey      string // CA private key (PEM)
+	ServerCert string // Server certificate signed by CA (PEM)
+	ServerKey  string // Server private key (PEM)
+}
+
+// dirPaths returns the standard file paths for certs under the given directory.
+func dirPaths(dir string) Paths {
+	return Paths{
+		CACert:     filepath.Join(dir, "ca.crt"),
+		CAKey:      filepath.Join(dir, "ca.key"),
+		ServerCert: filepath.Join(dir, "server.crt"),
+		ServerKey:  filepath.Join(dir, "server.key"),
+	}
+}
+
+// EnsureTLS checks whether all certificate files exist under dir. If any are
+// missing, a new self-signed CA and server certificate are generated and
+// written to dir. The CA fingerprint (SHA-256) is logged on generation.
+// Returns the file paths for use with tls.LoadX509KeyPair and friends.
+func EnsureTLS(dir, hostname string) (Paths, error) {
+	p := dirPaths(dir)
+
+	// If all four files are already present, nothing to do.
+	allExist := true
+	for _, f := range []string{p.CACert, p.CAKey, p.ServerCert, p.ServerKey} {
+		if _, err := os.Stat(f); err != nil {
+			allExist = false
+			break
+		}
+	}
+	if allExist {
+		return p, nil
+	}
+
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		return Paths{}, fmt.Errorf("autotls: create dir %q: %w", dir, err)
+	}
+
+	caKey, caCert, err := generateCA(p)
+	if err != nil {
+		return Paths{}, err
+	}
+
+	// Log the CA fingerprint so operators can pin it on clients.
+	fp := sha256.Sum256(caCert.Raw)
+	log.Printf("autotls: generated CA certificate; SHA-256 fingerprint: %X", fp)
+
+	if err := generateServerCert(p, hostname, caKey, caCert); err != nil {
+		return Paths{}, err
+	}
+
+	return p, nil
+}
+
+// generateCA creates an ECDSA P-256 CA key and self-signed certificate valid
+// for 10 years, writes them to p.CAKey and p.CACert, and returns the parsed
+// key and certificate for use when signing the server cert.
+func generateCA(p Paths) (*ecdsa.PrivateKey, *x509.Certificate, error) {
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return nil, nil, fmt.Errorf("autotls: generate CA key: %w", err)
+	}
+
+	serial, err := randomSerial()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	tmpl := &x509.Certificate{
+		SerialNumber: serial,
+		Subject: pkix.Name{
+			CommonName:   "Axon CA",
+			Organization: []string{"Axon"},
+		},
+		NotBefore:             time.Now().Add(-time.Minute),
+		NotAfter:              time.Now().Add(10 * 365 * 24 * time.Hour),
+		IsCA:                  true,
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+		BasicConstraintsValid: true,
+	}
+
+	certDER, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		return nil, nil, fmt.Errorf("autotls: create CA cert: %w", err)
+	}
+
+	if err := writePEM(p.CACert, "CERTIFICATE", certDER, 0644); err != nil {
+		return nil, nil, err
+	}
+
+	keyDER, err := x509.MarshalECPrivateKey(key)
+	if err != nil {
+		return nil, nil, fmt.Errorf("autotls: marshal CA key: %w", err)
+	}
+	if err := writePEM(p.CAKey, "EC PRIVATE KEY", keyDER, 0600); err != nil {
+		return nil, nil, err
+	}
+
+	cert, err := x509.ParseCertificate(certDER)
+	if err != nil {
+		return nil, nil, fmt.Errorf("autotls: parse CA cert: %w", err)
+	}
+	return key, cert, nil
+}
+
+// generateServerCert creates an ECDSA P-256 server key and a certificate
+// signed by the given CA, valid for 1 year. The SANs include localhost,
+// 127.0.0.1, and the provided hostname (added as DNS name or IP as appropriate).
+func generateServerCert(p Paths, hostname string, caKey *ecdsa.PrivateKey, caCert *x509.Certificate) error {
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return fmt.Errorf("autotls: generate server key: %w", err)
+	}
+
+	serial, err := randomSerial()
+	if err != nil {
+		return err
+	}
+
+	dnsNames := []string{"localhost"}
+	ipAddrs := []net.IP{net.ParseIP("127.0.0.1")}
+
+	if hostname != "" && hostname != "localhost" {
+		if ip := net.ParseIP(hostname); ip != nil {
+			ipAddrs = append(ipAddrs, ip)
+		} else {
+			dnsNames = append(dnsNames, hostname)
+		}
+	}
+
+	cn := hostname
+	if cn == "" {
+		cn = "localhost"
+	}
+
+	tmpl := &x509.Certificate{
+		SerialNumber: serial,
+		Subject: pkix.Name{
+			CommonName:   cn,
+			Organization: []string{"Axon"},
+		},
+		DNSNames:    dnsNames,
+		IPAddresses: ipAddrs,
+		NotBefore:   time.Now().Add(-time.Minute),
+		NotAfter:    time.Now().Add(365 * 24 * time.Hour),
+		KeyUsage:    x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+	}
+
+	certDER, err := x509.CreateCertificate(rand.Reader, tmpl, caCert, &key.PublicKey, caKey)
+	if err != nil {
+		return fmt.Errorf("autotls: create server cert: %w", err)
+	}
+
+	if err := writePEM(p.ServerCert, "CERTIFICATE", certDER, 0644); err != nil {
+		return err
+	}
+
+	keyDER, err := x509.MarshalECPrivateKey(key)
+	if err != nil {
+		return fmt.Errorf("autotls: marshal server key: %w", err)
+	}
+	return writePEM(p.ServerKey, "EC PRIVATE KEY", keyDER, 0600)
+}
+
+// randomSerial generates a random 128-bit serial number for a certificate.
+func randomSerial() (*big.Int, error) {
+	limit := new(big.Int).Lsh(big.NewInt(1), 128)
+	serial, err := rand.Int(rand.Reader, limit)
+	if err != nil {
+		return nil, fmt.Errorf("autotls: generate serial: %w", err)
+	}
+	return serial, nil
+}
+
+// writePEM encodes der as a PEM block of the given type and writes it to path
+// with the specified file permissions.
+func writePEM(path, pemType string, der []byte, mode os.FileMode) (retErr error) {
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, mode)
+	if err != nil {
+		return fmt.Errorf("autotls: open %q: %w", path, err)
+	}
+	defer func() {
+		if cerr := f.Close(); cerr != nil && retErr == nil {
+			retErr = fmt.Errorf("autotls: close %q: %w", path, cerr)
+		}
+	}()
+	if err := pem.Encode(f, &pem.Block{Type: pemType, Bytes: der}); err != nil {
+		return fmt.Errorf("autotls: encode PEM %q: %w", path, err)
+	}
+	return nil
+}

--- a/pkg/tls/autotls.go
+++ b/pkg/tls/autotls.go
@@ -9,9 +9,9 @@ import (
 	"crypto/sha256"
 	"crypto/x509"
 	"crypto/x509/pkix"
+	"encoding/hex"
 	"encoding/pem"
 	"fmt"
-	"log"
 	"math/big"
 	"net"
 	"os"
@@ -19,75 +19,22 @@ import (
 	"time"
 )
 
-// Paths holds the file paths for the generated TLS certificates and keys.
-type Paths struct {
-	CACert     string // CA certificate (PEM)
-	CAKey      string // CA private key (PEM)
-	ServerCert string // Server certificate signed by CA (PEM)
-	ServerKey  string // Server private key (PEM)
-}
-
-// dirPaths returns the standard file paths for certs under the given directory.
-func dirPaths(dir string) Paths {
-	return Paths{
-		CACert:     filepath.Join(dir, "ca.crt"),
-		CAKey:      filepath.Join(dir, "ca.key"),
-		ServerCert: filepath.Join(dir, "server.crt"),
-		ServerKey:  filepath.Join(dir, "server.key"),
-	}
-}
-
-// EnsureTLS checks whether all certificate files exist under dir. If any are
-// missing, a new self-signed CA and server certificate are generated and
-// written to dir. The CA fingerprint (SHA-256) is logged on generation.
-// Returns the file paths for use with tls.LoadX509KeyPair and friends.
-func EnsureTLS(dir, hostname string) (Paths, error) {
-	p := dirPaths(dir)
-
-	// If all four files are already present, nothing to do.
-	allExist := true
-	for _, f := range []string{p.CACert, p.CAKey, p.ServerCert, p.ServerKey} {
-		if _, err := os.Stat(f); err != nil {
-			allExist = false
-			break
-		}
-	}
-	if allExist {
-		return p, nil
-	}
-
+// GenerateCA creates an ECDSA P-256 CA key and self-signed certificate valid
+// for 10 years, writing ca.crt and ca.key under dir. Returns the paths to the
+// generated files.
+func GenerateCA(dir string) (caCertPath, caKeyPath string, err error) {
 	if err := os.MkdirAll(dir, 0700); err != nil {
-		return Paths{}, fmt.Errorf("autotls: create dir %q: %w", dir, err)
+		return "", "", fmt.Errorf("autotls: create dir %q: %w", dir, err)
 	}
 
-	caKey, caCert, err := generateCA(p)
-	if err != nil {
-		return Paths{}, err
-	}
-
-	// Log the CA fingerprint so operators can pin it on clients.
-	fp := sha256.Sum256(caCert.Raw)
-	log.Printf("autotls: generated CA certificate; SHA-256 fingerprint: %X", fp)
-
-	if err := generateServerCert(p, hostname, caKey, caCert); err != nil {
-		return Paths{}, err
-	}
-
-	return p, nil
-}
-
-// generateCA creates an ECDSA P-256 CA key and self-signed certificate valid
-// for 10 years, writes them to p.CAKey and p.CACert, and returns the parsed
-// key and certificate for use when signing the server cert.
-func generateCA(p Paths) (*ecdsa.PrivateKey, *x509.Certificate, error) {
 	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	if err != nil {
-		return nil, nil, fmt.Errorf("autotls: generate CA key: %w", err)
+		return "", "", fmt.Errorf("autotls: generate CA key: %w", err)
 	}
 
 	serial, err := randomSerial()
 	if err != nil {
-		return nil, nil, err
+		return "", "", err
 	}
 
 	tmpl := &x509.Certificate{
@@ -105,56 +52,90 @@ func generateCA(p Paths) (*ecdsa.PrivateKey, *x509.Certificate, error) {
 
 	certDER, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
 	if err != nil {
-		return nil, nil, fmt.Errorf("autotls: create CA cert: %w", err)
+		return "", "", fmt.Errorf("autotls: create CA cert: %w", err)
 	}
 
-	if err := writePEM(p.CACert, "CERTIFICATE", certDER, 0644); err != nil {
-		return nil, nil, err
+	caCertPath = filepath.Join(dir, "ca.crt")
+	if err := writePEM(caCertPath, "CERTIFICATE", certDER, 0644); err != nil {
+		return "", "", err
 	}
 
 	keyDER, err := x509.MarshalECPrivateKey(key)
 	if err != nil {
-		return nil, nil, fmt.Errorf("autotls: marshal CA key: %w", err)
+		return "", "", fmt.Errorf("autotls: marshal CA key: %w", err)
 	}
-	if err := writePEM(p.CAKey, "EC PRIVATE KEY", keyDER, 0600); err != nil {
-		return nil, nil, err
+	caKeyPath = filepath.Join(dir, "ca.key")
+	if err := writePEM(caKeyPath, "EC PRIVATE KEY", keyDER, 0600); err != nil {
+		return "", "", err
 	}
 
-	cert, err := x509.ParseCertificate(certDER)
-	if err != nil {
-		return nil, nil, fmt.Errorf("autotls: parse CA cert: %w", err)
-	}
-	return key, cert, nil
+	return caCertPath, caKeyPath, nil
 }
 
-// generateServerCert creates an ECDSA P-256 server key and a certificate
-// signed by the given CA, valid for 1 year. The SANs include localhost,
-// 127.0.0.1, and the provided hostname (added as DNS name or IP as appropriate).
-func generateServerCert(p Paths, hostname string, caKey *ecdsa.PrivateKey, caCert *x509.Certificate) error {
-	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+// GenerateServerCert creates an ECDSA P-256 server key and a certificate
+// signed by the CA at caCertPath/caKeyPath, valid for 1 year. The SANs always
+// include localhost and 127.0.0.1; any additional hosts are added as DNS names
+// or IP addresses as appropriate. Writes server.crt and server.key under dir.
+func GenerateServerCert(dir string, caCertPath, caKeyPath string, hosts ...string) (certPath, keyPath string, err error) {
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		return "", "", fmt.Errorf("autotls: create dir %q: %w", dir, err)
+	}
+
+	// Load CA cert and key.
+	caCertPEM, err := os.ReadFile(caCertPath)
 	if err != nil {
-		return fmt.Errorf("autotls: generate server key: %w", err)
+		return "", "", fmt.Errorf("autotls: read CA cert: %w", err)
+	}
+	block, _ := pem.Decode(caCertPEM)
+	if block == nil {
+		return "", "", fmt.Errorf("autotls: decode CA cert PEM")
+	}
+	caCert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		return "", "", fmt.Errorf("autotls: parse CA cert: %w", err)
+	}
+
+	caKeyPEM, err := os.ReadFile(caKeyPath)
+	if err != nil {
+		return "", "", fmt.Errorf("autotls: read CA key: %w", err)
+	}
+	keyBlock, _ := pem.Decode(caKeyPEM)
+	if keyBlock == nil {
+		return "", "", fmt.Errorf("autotls: decode CA key PEM")
+	}
+	caKey, err := x509.ParseECPrivateKey(keyBlock.Bytes)
+	if err != nil {
+		return "", "", fmt.Errorf("autotls: parse CA key: %w", err)
+	}
+
+	// Generate server key.
+	srvKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return "", "", fmt.Errorf("autotls: generate server key: %w", err)
 	}
 
 	serial, err := randomSerial()
 	if err != nil {
-		return err
+		return "", "", err
 	}
 
 	dnsNames := []string{"localhost"}
 	ipAddrs := []net.IP{net.ParseIP("127.0.0.1")}
 
-	if hostname != "" && hostname != "localhost" {
-		if ip := net.ParseIP(hostname); ip != nil {
+	for _, h := range hosts {
+		if h == "" || h == "localhost" {
+			continue
+		}
+		if ip := net.ParseIP(h); ip != nil {
 			ipAddrs = append(ipAddrs, ip)
 		} else {
-			dnsNames = append(dnsNames, hostname)
+			dnsNames = append(dnsNames, h)
 		}
 	}
 
-	cn := hostname
-	if cn == "" {
-		cn = "localhost"
+	cn := "localhost"
+	if len(hosts) > 0 && hosts[0] != "" {
+		cn = hosts[0]
 	}
 
 	tmpl := &x509.Certificate{
@@ -171,20 +152,114 @@ func generateServerCert(p Paths, hostname string, caKey *ecdsa.PrivateKey, caCer
 		ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
 	}
 
-	certDER, err := x509.CreateCertificate(rand.Reader, tmpl, caCert, &key.PublicKey, caKey)
+	certDER, err := x509.CreateCertificate(rand.Reader, tmpl, caCert, &srvKey.PublicKey, caKey)
 	if err != nil {
-		return fmt.Errorf("autotls: create server cert: %w", err)
+		return "", "", fmt.Errorf("autotls: create server cert: %w", err)
 	}
 
-	if err := writePEM(p.ServerCert, "CERTIFICATE", certDER, 0644); err != nil {
-		return err
+	certPath = filepath.Join(dir, "server.crt")
+	if err := writePEM(certPath, "CERTIFICATE", certDER, 0644); err != nil {
+		return "", "", err
 	}
 
-	keyDER, err := x509.MarshalECPrivateKey(key)
+	keyDER, err := x509.MarshalECPrivateKey(srvKey)
 	if err != nil {
-		return fmt.Errorf("autotls: marshal server key: %w", err)
+		return "", "", fmt.Errorf("autotls: marshal server key: %w", err)
 	}
-	return writePEM(p.ServerKey, "EC PRIVATE KEY", keyDER, 0600)
+	keyPath = filepath.Join(dir, "server.key")
+	if err := writePEM(keyPath, "EC PRIVATE KEY", keyDER, 0600); err != nil {
+		return "", "", err
+	}
+
+	return certPath, keyPath, nil
+}
+
+// EnsureTLS checks whether ca.crt already exists under dir. If it does, all
+// paths are returned with generated=false. Otherwise a new CA and server cert
+// are generated. hosts are passed to GenerateServerCert as SANs.
+func EnsureTLS(dir string, hosts ...string) (caCertPath, serverCertPath, serverKeyPath string, generated bool, err error) {
+	caCertPath = filepath.Join(dir, "ca.crt")
+	var caKeyPath string
+	serverCertPath = filepath.Join(dir, "server.crt")
+	serverKeyPath = filepath.Join(dir, "server.key")
+
+	if _, err := os.Stat(caCertPath); err == nil {
+		caKeyPath = filepath.Join(dir, "ca.key")
+
+		// Check if server cert exists; regenerate if missing.
+		if _, serr := os.Stat(serverCertPath); serr != nil {
+			serverCertPath, serverKeyPath, err = GenerateServerCert(dir, caCertPath, caKeyPath, hosts...)
+			if err != nil {
+				return "", "", "", false, fmt.Errorf("autotls: regenerate server cert: %w", err)
+			}
+			return caCertPath, serverCertPath, serverKeyPath, true, nil
+		}
+
+		// Check server cert expiry; renew if expiring within 30 days.
+		if expiring, renewErr := certExpiringWithin(serverCertPath, 30*24*time.Hour); renewErr == nil && expiring {
+			serverCertPath, serverKeyPath, err = GenerateServerCert(dir, caCertPath, caKeyPath, hosts...)
+			if err != nil {
+				return "", "", "", false, fmt.Errorf("autotls: renew server cert: %w", err)
+			}
+			return caCertPath, serverCertPath, serverKeyPath, true, nil
+		}
+
+		return caCertPath, serverCertPath, serverKeyPath, false, nil
+	}
+
+	caCertPath, caKeyPath, err = GenerateCA(dir)
+	if err != nil {
+		return "", "", "", false, err
+	}
+
+	serverCertPath, serverKeyPath, err = GenerateServerCert(dir, caCertPath, caKeyPath, hosts...)
+	if err != nil {
+		return "", "", "", false, err
+	}
+
+	return caCertPath, serverCertPath, serverKeyPath, true, nil
+}
+
+// CAFingerprint returns the SHA-256 fingerprint of the certificate at certPath
+// formatted as colon-separated uppercase hex bytes (e.g. "AA:BB:CC:...").
+func CAFingerprint(certPath string) (string, error) {
+	data, err := os.ReadFile(certPath)
+	if err != nil {
+		return "", fmt.Errorf("autotls: read cert %q: %w", certPath, err)
+	}
+	block, _ := pem.Decode(data)
+	if block == nil {
+		return "", fmt.Errorf("autotls: decode PEM %q", certPath)
+	}
+	sum := sha256.Sum256(block.Bytes)
+	b := make([]byte, 0, sha256.Size*3-1)
+	for i, byt := range sum {
+		if i > 0 {
+			b = append(b, ':')
+		}
+		h := hex.EncodeToString([]byte{byt})
+		b = append(b, []byte(h)...)
+	}
+	return string(b), nil
+}
+
+// certExpiringWithin checks if the PEM certificate at path expires within the
+// given duration. Returns (true, nil) if it does, (false, nil) if it doesn't,
+// or (false, err) if the cert cannot be read/parsed.
+func certExpiringWithin(path string, within time.Duration) (bool, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return false, err
+	}
+	block, _ := pem.Decode(data)
+	if block == nil {
+		return false, fmt.Errorf("autotls: decode PEM %q", path)
+	}
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		return false, err
+	}
+	return time.Until(cert.NotAfter) < within, nil
 }
 
 // randomSerial generates a random 128-bit serial number for a certificate.

--- a/pkg/tls/autotls_test.go
+++ b/pkg/tls/autotls_test.go
@@ -1,0 +1,189 @@
+package autotls_test
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"net"
+	"os"
+	"testing"
+
+	autotls "github.com/garysng/axon/pkg/tls"
+)
+
+// TestEnsureTLS_GeneratesCerts verifies that EnsureTLS creates all four files
+// and produces a valid CA-signed server certificate.
+func TestEnsureTLS_GeneratesCerts(t *testing.T) {
+	dir := t.TempDir()
+
+	paths, err := autotls.EnsureTLS(dir, "localhost")
+	if err != nil {
+		t.Fatalf("EnsureTLS: %v", err)
+	}
+
+	// All four files must exist.
+	for _, f := range []string{paths.CACert, paths.CAKey, paths.ServerCert, paths.ServerKey} {
+		if _, err := os.Stat(f); err != nil {
+			t.Errorf("expected file %q to exist: %v", f, err)
+		}
+	}
+
+	// Server cert + key must load as a valid TLS key pair.
+	cert, err := tls.LoadX509KeyPair(paths.ServerCert, paths.ServerKey)
+	if err != nil {
+		t.Fatalf("LoadX509KeyPair: %v", err)
+	}
+	if len(cert.Certificate) == 0 {
+		t.Fatal("empty certificate chain")
+	}
+
+	// Parse the server cert and verify it against the CA.
+	parsedCert, err := x509.ParseCertificate(cert.Certificate[0])
+	if err != nil {
+		t.Fatalf("ParseCertificate: %v", err)
+	}
+
+	caCertPEM, err := os.ReadFile(paths.CACert)
+	if err != nil {
+		t.Fatalf("read CA cert: %v", err)
+	}
+	pool := x509.NewCertPool()
+	if !pool.AppendCertsFromPEM(caCertPEM) {
+		t.Fatal("failed to append CA cert to pool")
+	}
+
+	opts := x509.VerifyOptions{
+		DNSName: "localhost",
+		Roots:   pool,
+	}
+	if _, err := parsedCert.Verify(opts); err != nil {
+		t.Errorf("server cert verification failed: %v", err)
+	}
+}
+
+// TestEnsureTLS_Idempotent verifies that a second call does not regenerate
+// the certificates (files are left untouched).
+func TestEnsureTLS_Idempotent(t *testing.T) {
+	dir := t.TempDir()
+
+	p1, err := autotls.EnsureTLS(dir, "localhost")
+	if err != nil {
+		t.Fatalf("first EnsureTLS: %v", err)
+	}
+
+	info1, err := os.Stat(p1.CACert)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	p2, err := autotls.EnsureTLS(dir, "localhost")
+	if err != nil {
+		t.Fatalf("second EnsureTLS: %v", err)
+	}
+
+	info2, err := os.Stat(p2.CACert)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !info1.ModTime().Equal(info2.ModTime()) {
+		t.Error("EnsureTLS regenerated certs on second call (should be idempotent)")
+	}
+}
+
+// TestEnsureTLS_CustomHostname verifies that the server cert includes the
+// provided hostname as a SAN DNS name.
+func TestEnsureTLS_CustomHostname(t *testing.T) {
+	dir := t.TempDir()
+	const host = "my-server.example.com"
+
+	paths, err := autotls.EnsureTLS(dir, host)
+	if err != nil {
+		t.Fatalf("EnsureTLS: %v", err)
+	}
+
+	cert, err := tls.LoadX509KeyPair(paths.ServerCert, paths.ServerKey)
+	if err != nil {
+		t.Fatalf("LoadX509KeyPair: %v", err)
+	}
+	parsed, err := x509.ParseCertificate(cert.Certificate[0])
+	if err != nil {
+		t.Fatalf("ParseCertificate: %v", err)
+	}
+
+	for _, name := range parsed.DNSNames {
+		if name == host {
+			return
+		}
+	}
+	t.Errorf("expected SAN DNS name %q; got %v", host, parsed.DNSNames)
+}
+
+// TestEnsureTLS_IPHostname verifies that an IP-format hostname is added as a
+// SAN IP address rather than a DNS name.
+func TestEnsureTLS_IPHostname(t *testing.T) {
+	dir := t.TempDir()
+	const host = "192.168.1.10"
+
+	paths, err := autotls.EnsureTLS(dir, host)
+	if err != nil {
+		t.Fatalf("EnsureTLS: %v", err)
+	}
+
+	cert, err := tls.LoadX509KeyPair(paths.ServerCert, paths.ServerKey)
+	if err != nil {
+		t.Fatalf("LoadX509KeyPair: %v", err)
+	}
+	parsed, err := x509.ParseCertificate(cert.Certificate[0])
+	if err != nil {
+		t.Fatalf("ParseCertificate: %v", err)
+	}
+
+	want := net.ParseIP(host)
+	for _, ip := range parsed.IPAddresses {
+		if ip.Equal(want) {
+			return
+		}
+	}
+	t.Errorf("expected SAN IP %q; got %v", host, parsed.IPAddresses)
+}
+
+// TestEnsureTLS_LocalhostSAN verifies that localhost and 127.0.0.1 are always
+// present as SANs regardless of hostname.
+func TestEnsureTLS_LocalhostSAN(t *testing.T) {
+	dir := t.TempDir()
+
+	paths, err := autotls.EnsureTLS(dir, "axon-server.internal")
+	if err != nil {
+		t.Fatalf("EnsureTLS: %v", err)
+	}
+
+	cert, err := tls.LoadX509KeyPair(paths.ServerCert, paths.ServerKey)
+	if err != nil {
+		t.Fatalf("LoadX509KeyPair: %v", err)
+	}
+	parsed, err := x509.ParseCertificate(cert.Certificate[0])
+	if err != nil {
+		t.Fatalf("ParseCertificate: %v", err)
+	}
+
+	foundLocalhost := false
+	for _, name := range parsed.DNSNames {
+		if name == "localhost" {
+			foundLocalhost = true
+		}
+	}
+	if !foundLocalhost {
+		t.Errorf("expected 'localhost' in DNS SANs; got %v", parsed.DNSNames)
+	}
+
+	want127 := net.ParseIP("127.0.0.1")
+	found127 := false
+	for _, ip := range parsed.IPAddresses {
+		if ip.Equal(want127) {
+			found127 = true
+		}
+	}
+	if !found127 {
+		t.Errorf("expected '127.0.0.1' in IP SANs; got %v", parsed.IPAddresses)
+	}
+}

--- a/pkg/tls/autotls_test.go
+++ b/pkg/tls/autotls_test.go
@@ -5,175 +5,105 @@ import (
 	"crypto/x509"
 	"net"
 	"os"
+	"strings"
 	"testing"
 
 	autotls "github.com/garysng/axon/pkg/tls"
 )
 
-// TestEnsureTLS_GeneratesCerts verifies that EnsureTLS creates all four files
-// and produces a valid CA-signed server certificate.
-func TestEnsureTLS_GeneratesCerts(t *testing.T) {
+// TestGenerateCA verifies that GenerateCA creates valid PEM files containing
+// a self-signed CA certificate with IsCA=true.
+func TestGenerateCA(t *testing.T) {
 	dir := t.TempDir()
 
-	paths, err := autotls.EnsureTLS(dir, "localhost")
+	caCertPath, caKeyPath, err := autotls.GenerateCA(dir)
 	if err != nil {
-		t.Fatalf("EnsureTLS: %v", err)
+		t.Fatalf("GenerateCA: %v", err)
 	}
 
-	// All four files must exist.
-	for _, f := range []string{paths.CACert, paths.CAKey, paths.ServerCert, paths.ServerKey} {
+	for _, f := range []string{caCertPath, caKeyPath} {
 		if _, err := os.Stat(f); err != nil {
 			t.Errorf("expected file %q to exist: %v", f, err)
 		}
 	}
 
-	// Server cert + key must load as a valid TLS key pair.
-	cert, err := tls.LoadX509KeyPair(paths.ServerCert, paths.ServerKey)
+	// Load and parse the CA cert.
+	certPEM, err := os.ReadFile(caCertPath)
+	if err != nil {
+		t.Fatalf("read CA cert: %v", err)
+	}
+	pool := x509.NewCertPool()
+	if !pool.AppendCertsFromPEM(certPEM) {
+		t.Fatal("AppendCertsFromPEM failed")
+	}
+
+	pair, err := tls.LoadX509KeyPair(caCertPath, caKeyPath)
+	if err != nil {
+		t.Fatalf("LoadX509KeyPair (CA): %v", err)
+	}
+	parsed, err := x509.ParseCertificate(pair.Certificate[0])
+	if err != nil {
+		t.Fatalf("ParseCertificate: %v", err)
+	}
+	if !parsed.IsCA {
+		t.Error("expected IsCA=true")
+	}
+}
+
+// TestGenerateServerCert verifies that GenerateServerCert produces a server
+// certificate signed by the CA and containing the expected SANs.
+func TestGenerateServerCert(t *testing.T) {
+	dir := t.TempDir()
+
+	caCertPath, caKeyPath, err := autotls.GenerateCA(dir)
+	if err != nil {
+		t.Fatalf("GenerateCA: %v", err)
+	}
+
+	const host = "test-server.example.com"
+	certPath, keyPath, err := autotls.GenerateServerCert(dir, caCertPath, caKeyPath, host)
+	if err != nil {
+		t.Fatalf("GenerateServerCert: %v", err)
+	}
+
+	for _, f := range []string{certPath, keyPath} {
+		if _, err := os.Stat(f); err != nil {
+			t.Errorf("expected file %q to exist: %v", f, err)
+		}
+	}
+
+	// Load key pair.
+	pair, err := tls.LoadX509KeyPair(certPath, keyPath)
 	if err != nil {
 		t.Fatalf("LoadX509KeyPair: %v", err)
 	}
-	if len(cert.Certificate) == 0 {
-		t.Fatal("empty certificate chain")
-	}
-
-	// Parse the server cert and verify it against the CA.
-	parsedCert, err := x509.ParseCertificate(cert.Certificate[0])
+	parsed, err := x509.ParseCertificate(pair.Certificate[0])
 	if err != nil {
 		t.Fatalf("ParseCertificate: %v", err)
 	}
 
-	caCertPEM, err := os.ReadFile(paths.CACert)
+	// Verify against CA.
+	caCertPEM, err := os.ReadFile(caCertPath)
 	if err != nil {
 		t.Fatalf("read CA cert: %v", err)
 	}
 	pool := x509.NewCertPool()
 	if !pool.AppendCertsFromPEM(caCertPEM) {
-		t.Fatal("failed to append CA cert to pool")
+		t.Fatal("AppendCertsFromPEM failed")
 	}
-
-	opts := x509.VerifyOptions{
-		DNSName: "localhost",
-		Roots:   pool,
-	}
-	if _, err := parsedCert.Verify(opts); err != nil {
+	if _, err := parsed.Verify(x509.VerifyOptions{DNSName: host, Roots: pool}); err != nil {
 		t.Errorf("server cert verification failed: %v", err)
 	}
-}
 
-// TestEnsureTLS_Idempotent verifies that a second call does not regenerate
-// the certificates (files are left untouched).
-func TestEnsureTLS_Idempotent(t *testing.T) {
-	dir := t.TempDir()
-
-	p1, err := autotls.EnsureTLS(dir, "localhost")
-	if err != nil {
-		t.Fatalf("first EnsureTLS: %v", err)
-	}
-
-	info1, err := os.Stat(p1.CACert)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	p2, err := autotls.EnsureTLS(dir, "localhost")
-	if err != nil {
-		t.Fatalf("second EnsureTLS: %v", err)
-	}
-
-	info2, err := os.Stat(p2.CACert)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if !info1.ModTime().Equal(info2.ModTime()) {
-		t.Error("EnsureTLS regenerated certs on second call (should be idempotent)")
-	}
-}
-
-// TestEnsureTLS_CustomHostname verifies that the server cert includes the
-// provided hostname as a SAN DNS name.
-func TestEnsureTLS_CustomHostname(t *testing.T) {
-	dir := t.TempDir()
-	const host = "my-server.example.com"
-
-	paths, err := autotls.EnsureTLS(dir, host)
-	if err != nil {
-		t.Fatalf("EnsureTLS: %v", err)
-	}
-
-	cert, err := tls.LoadX509KeyPair(paths.ServerCert, paths.ServerKey)
-	if err != nil {
-		t.Fatalf("LoadX509KeyPair: %v", err)
-	}
-	parsed, err := x509.ParseCertificate(cert.Certificate[0])
-	if err != nil {
-		t.Fatalf("ParseCertificate: %v", err)
-	}
-
-	for _, name := range parsed.DNSNames {
-		if name == host {
-			return
-		}
-	}
-	t.Errorf("expected SAN DNS name %q; got %v", host, parsed.DNSNames)
-}
-
-// TestEnsureTLS_IPHostname verifies that an IP-format hostname is added as a
-// SAN IP address rather than a DNS name.
-func TestEnsureTLS_IPHostname(t *testing.T) {
-	dir := t.TempDir()
-	const host = "192.168.1.10"
-
-	paths, err := autotls.EnsureTLS(dir, host)
-	if err != nil {
-		t.Fatalf("EnsureTLS: %v", err)
-	}
-
-	cert, err := tls.LoadX509KeyPair(paths.ServerCert, paths.ServerKey)
-	if err != nil {
-		t.Fatalf("LoadX509KeyPair: %v", err)
-	}
-	parsed, err := x509.ParseCertificate(cert.Certificate[0])
-	if err != nil {
-		t.Fatalf("ParseCertificate: %v", err)
-	}
-
-	want := net.ParseIP(host)
-	for _, ip := range parsed.IPAddresses {
-		if ip.Equal(want) {
-			return
-		}
-	}
-	t.Errorf("expected SAN IP %q; got %v", host, parsed.IPAddresses)
-}
-
-// TestEnsureTLS_LocalhostSAN verifies that localhost and 127.0.0.1 are always
-// present as SANs regardless of hostname.
-func TestEnsureTLS_LocalhostSAN(t *testing.T) {
-	dir := t.TempDir()
-
-	paths, err := autotls.EnsureTLS(dir, "axon-server.internal")
-	if err != nil {
-		t.Fatalf("EnsureTLS: %v", err)
-	}
-
-	cert, err := tls.LoadX509KeyPair(paths.ServerCert, paths.ServerKey)
-	if err != nil {
-		t.Fatalf("LoadX509KeyPair: %v", err)
-	}
-	parsed, err := x509.ParseCertificate(cert.Certificate[0])
-	if err != nil {
-		t.Fatalf("ParseCertificate: %v", err)
-	}
-
+	// Must include localhost and 127.0.0.1.
 	foundLocalhost := false
-	for _, name := range parsed.DNSNames {
-		if name == "localhost" {
+	for _, n := range parsed.DNSNames {
+		if n == "localhost" {
 			foundLocalhost = true
 		}
 	}
 	if !foundLocalhost {
-		t.Errorf("expected 'localhost' in DNS SANs; got %v", parsed.DNSNames)
+		t.Errorf("missing localhost in DNSNames: %v", parsed.DNSNames)
 	}
 
 	want127 := net.ParseIP("127.0.0.1")
@@ -184,6 +114,141 @@ func TestEnsureTLS_LocalhostSAN(t *testing.T) {
 		}
 	}
 	if !found127 {
-		t.Errorf("expected '127.0.0.1' in IP SANs; got %v", parsed.IPAddresses)
+		t.Errorf("missing 127.0.0.1 in IPAddresses: %v", parsed.IPAddresses)
+	}
+}
+
+// TestEnsureTLS_Generates verifies that EnsureTLS creates certs on first call
+// and returns generated=true.
+func TestEnsureTLS_Generates(t *testing.T) {
+	dir := t.TempDir()
+
+	caCertPath, srvCertPath, srvKeyPath, generated, err := autotls.EnsureTLS(dir, "localhost")
+	if err != nil {
+		t.Fatalf("EnsureTLS: %v", err)
+	}
+	if !generated {
+		t.Error("expected generated=true on first call")
+	}
+
+	for _, f := range []string{caCertPath, srvCertPath, srvKeyPath} {
+		if _, err := os.Stat(f); err != nil {
+			t.Errorf("expected file %q to exist: %v", f, err)
+		}
+	}
+}
+
+// TestEnsureTLS_Idempotent verifies that a second call skips generation.
+func TestEnsureTLS_Idempotent(t *testing.T) {
+	dir := t.TempDir()
+
+	_, _, _, _, err := autotls.EnsureTLS(dir, "localhost")
+	if err != nil {
+		t.Fatalf("first EnsureTLS: %v", err)
+	}
+
+	caCertPath, _, _, generated, err := autotls.EnsureTLS(dir, "localhost")
+	if err != nil {
+		t.Fatalf("second EnsureTLS: %v", err)
+	}
+	if generated {
+		t.Error("expected generated=false on second call")
+	}
+
+	if _, err := os.Stat(caCertPath); err != nil {
+		t.Errorf("CA cert missing after second call: %v", err)
+	}
+}
+
+// TestCAFingerprint verifies that CAFingerprint returns a colon-separated
+// uppercase hex string with 64 hex chars (32 bytes × 2 + 31 colons = 95 chars).
+func TestCAFingerprint(t *testing.T) {
+	dir := t.TempDir()
+
+	caCertPath, _, err := autotls.GenerateCA(dir)
+	if err != nil {
+		t.Fatalf("GenerateCA: %v", err)
+	}
+
+	fp, err := autotls.CAFingerprint(caCertPath)
+	if err != nil {
+		t.Fatalf("CAFingerprint: %v", err)
+	}
+
+	parts := strings.Split(fp, ":")
+	if len(parts) != 32 {
+		t.Errorf("expected 32 colon-separated parts, got %d: %q", len(parts), fp)
+	}
+	for _, p := range parts {
+		if len(p) != 2 {
+			t.Errorf("expected 2-char hex byte, got %q in %q", p, fp)
+		}
+	}
+
+	// Calling again must return the same value.
+	fp2, err := autotls.CAFingerprint(caCertPath)
+	if err != nil {
+		t.Fatalf("CAFingerprint second call: %v", err)
+	}
+	if fp != fp2 {
+		t.Errorf("fingerprint not stable: %q vs %q", fp, fp2)
+	}
+}
+
+// TestTLSHandshake verifies that the generated certs can complete a real TLS
+// handshake between an in-process client and server.
+func TestTLSHandshake(t *testing.T) {
+	dir := t.TempDir()
+
+	caCertPath, srvCertPath, srvKeyPath, _, err := autotls.EnsureTLS(dir, "localhost")
+	if err != nil {
+		t.Fatalf("EnsureTLS: %v", err)
+	}
+
+	// Build server TLS config.
+	srvCert, err := tls.LoadX509KeyPair(srvCertPath, srvKeyPath)
+	if err != nil {
+		t.Fatalf("LoadX509KeyPair: %v", err)
+	}
+	srvTLS := &tls.Config{Certificates: []tls.Certificate{srvCert}}
+
+	ln, err := tls.Listen("tcp", "127.0.0.1:0", srvTLS)
+	if err != nil {
+		t.Fatalf("tls.Listen: %v", err)
+	}
+	defer func() { _ = ln.Close() }()
+
+	errCh := make(chan error, 1)
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			errCh <- err
+			return
+		}
+		// Force handshake.
+		err = conn.(*tls.Conn).Handshake()
+		_ = conn.Close()
+		errCh <- err
+	}()
+
+	// Build client TLS config with the generated CA.
+	caCertPEM, err := os.ReadFile(caCertPath)
+	if err != nil {
+		t.Fatalf("read CA cert: %v", err)
+	}
+	pool := x509.NewCertPool()
+	if !pool.AppendCertsFromPEM(caCertPEM) {
+		t.Fatal("AppendCertsFromPEM failed")
+	}
+	clientTLS := &tls.Config{RootCAs: pool, ServerName: "localhost"}
+
+	conn, err := tls.Dial("tcp", ln.Addr().String(), clientTLS)
+	if err != nil {
+		t.Fatalf("tls.Dial: %v", err)
+	}
+	_ = conn.Close()
+
+	if err := <-errCh; err != nil {
+		t.Errorf("server handshake error: %v", err)
 	}
 }


### PR DESCRIPTION
## Summary

Implements Phase 2 Task P2-4: TLS by Default.

### Changes

**pkg/tls/autotls.go** — Auto-TLS certificate generation:
- GenerateCA: ECDSA P-256, 10-year validity
- GenerateServerCert: signed by CA, 1-year validity, SAN includes localhost + 127.0.0.1 + configured hosts
- EnsureTLS: idempotent — generates if missing, skips if exists
- CAFingerprint: SHA256 fingerprint for verification

**internal/server/server.go**:
- TLSAuto (default true): auto-generates certs on first start when no cert/key configured
- Logs CA cert path + SHA256 fingerprint for distribution

**internal/agent/agent.go** — 3-way TLS dial:
- CACert set → use custom CA
- TLSInsecure → plaintext (dev only)
- Default → system CA pool

**cmd/axon/client.go** — Same 3-way TLS for CLI connections

**pkg/config** — New TLS fields on all config types

**pkg/tls/autotls_test.go** — 6 tests covering generation, idempotency, fingerprint, and TLS handshake

### Design Reference
docs/phase2-design.md — Task P2-4

### Testing
- All tests pass
- make lint: 0 issues