### PR TITLE
docs: update all documentation for Phase 2, add quickstart and config reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,36 +156,53 @@ Different scenario? Different skill. Same CLI.
 
 ## Security
 
-- **Token-based auth** — Server issues tokens, agents present tokens
+- **Token-based auth** — JWT with unique JTI, revocation support
+- **User management** — SQLite-backed users with bcrypt passwords, CRUD via CLI
 - **Audit log** — Every operation logged with timestamp, caller, node, command, result
 - **No inbound ports on nodes** — Reverse connection only
-- **TLS everywhere** — Server ↔ Agent, CLI ↔ Server
+- **Auto-TLS** — Self-signed CA + server cert generated automatically; bring-your-own-cert supported
+- **Token lifecycle** — List, revoke, and rotate tokens via CLI
 
 ## Roadmap
 
-### Phase 1: Foundation
-- [x] axon-server: gRPC server, node registry, auth
-- [ ] axon-agent: reverse connection, command execution, file I/O
-- [ ] axon CLI: exec, read, write, forward, node management
-- [x] Token-based authentication
-- [x] Audit logging
+### Phase 1: Foundation ✅
+- [x] axon-server: gRPC server, node registry, auth, routing, audit
+- [x] axon-agent: reverse connection, exec, read, write, forward
+- [x] axon CLI: full command set (exec, read, write, forward, node management)
+- [x] Token-based authentication (JWT)
+- [x] Audit logging (SQLite)
+- [x] Data plane bridge (CLI ↔ Server ↔ Agent streaming)
 
-### Phase 2: Production Hardening
-- [ ] Agent auto-update
-- [ ] Connection multiplexing
-- [ ] Rate limiting and resource quotas
-- [ ] Multi-tenant support
+### Phase 2: Production Hardening (in progress)
+- [x] P2-1: Registry SQLite persistence + stable node_id
+- [x] P2-2: Token management (JTI, revoke, list)
+- [x] P2-3: User store persistence (SQLite CRUD, bootstrap from config)
+- [x] P2-4: Auto-TLS (self-signed CA, server cert, auto-renewal)
+- [ ] P2-5: Agent security policies (command allowlist, path restrictions)
 
 ### Phase 3: Ecosystem
+- [ ] Web dashboard (read-only status, grpc-gateway)
 - [ ] Plugin system for custom node capabilities
-- [ ] Web dashboard (read-only status, for humans)
 - [ ] Pre-built skills library
+- [ ] Agent auto-update
+
+## Documentation
+
+- [Quick Start Guide](docs/quickstart.md) — Get running in 5 minutes
+- [Configuration Reference](docs/configuration.md) — All config options
+- [Architecture Overview](docs/architecture.md) — How components fit together
+- [CLI Reference](docs/cli.md) — Full command reference
+- [Protocol Design](docs/protocol.md) — gRPC/protobuf details
+- [Server Design](docs/server.md) — Server internals
+- [Agent Design](docs/agent.md) — Agent internals
 
 ## Tech Stack
 
 - **Language**: Go
 - **Communication**: gRPC over HTTP/2 (full chain)
-- **Auth**: JWT tokens (CLI token bound to user + node list)
+- **Auth**: JWT (HMAC-SHA256) with JTI + revocation
+- **Persistence**: SQLite (WAL mode, single shared DB)
+- **TLS**: Auto-TLS (ECDSA P-256) or explicit certs
 - **Build**: Single binary per component, cross-platform
 
 ## License

--- a/docs/agent.md
+++ b/docs/agent.md
@@ -1,5 +1,7 @@
 # Axon Agent Design
 
+> [中文版 / Chinese](zh/agent.md)
+
 ## Overview
 
 `axon-agent` is a lightweight daemon installed on each target machine. It reverse-connects to axon-server via gRPC, registers itself, maintains a heartbeat, and responds to tasks dispatched by the server.
@@ -16,33 +18,29 @@ axon-agent start --server <addr> --token <token> [--name <name>]
     │
     ├── First run:
     │   1. Save config to ~/.axon-agent/config.yaml
-    │   2. Connect to server (gRPC TLS)
-    │   3. Send RegisterRequest (token + node info)
+    │   2. Connect to server (gRPC + TLS)
+    │   3. Send RegisterRequest (token + node_name + NodeInfo)
     │   4. Receive RegisterResponse (node_id + heartbeat interval)
-    │   5. Begin heartbeat loop
+    │   5. Save node_id to config (stable identity)
+    │   6. Begin heartbeat loop
     │
     ├── Subsequent runs:
     │   1. Read config from ~/.axon-agent/config.yaml
     │   2. Connect to server
-    │   3. Re-register (server recognizes returning node by node_id)
+    │   3. Re-register with existing node_id (server recognizes returning node)
     │   4. Begin heartbeat loop
     │
     ▼
 Running (waiting for tasks)
     ├── Heartbeat every N seconds (server-configured)
-    ├── Node info reporting (periodic, or on change)
+    ├── Node info reporting (periodic)
     ├── Task execution (on demand)
     │
     ├── Connection lost → exponential backoff reconnect
     │   Initial: 1s, max: 60s, jitter: ±20%
     │
     ▼
-Stop
-    ├── axon-agent stop → graceful shutdown
-    │   - Complete in-flight tasks (with timeout)
-    │   - Close gRPC streams
-    │   - Exit
-    └── kill -9 → server detects via heartbeat timeout → mark offline
+Stop → graceful shutdown → complete in-flight tasks → exit
 ```
 
 ## Config
@@ -50,102 +48,63 @@ Stop
 Stored at `~/.axon-agent/config.yaml`:
 
 ```yaml
-server: "axon.example.com:443"
+server: "axon.example.com:9090"
 token: "agent-token-xxx"
-node_id: "a1b2c3d4"           # Assigned by server after first registration
-node_name: "web-1"            # User-specified or hostname
+node_id: "a1b2c3d4"           # assigned by server after first registration
+node_name: "web-1"            # user-specified or hostname
 labels:
   env: production
   role: web
+ca_cert: "/path/to/ca.crt"    # CA certificate for TLS verification
+tls_insecure: false            # skip TLS verification (dev only)
 ```
 
-- `token`: used for initial registration, validated by server
-- `node_id`: persisted after first registration, used for reconnection identity
-- `node_name`: if not specified, defaults to hostname
-- `labels`: optional key-value pairs for node grouping
+See [Configuration Reference](configuration.md) for all fields and environment variables.
+
+## TLS
+
+The agent uses a 3-way TLS selection:
+
+| Priority | Condition | Behavior |
+|----------|-----------|----------|
+| 1 | `tls_insecure: true` | No TLS verification (plaintext gRPC) |
+| 2 | `ca_cert` set | Verify server cert against specified CA file |
+| 3 | Neither | Verify server cert against system CA pool |
+
+**For auto-TLS setups:** Copy the server's `~/.axon-server/tls/ca.crt` to the agent machine and set `ca_cert` in config or pass `--ca-cert` flag.
 
 ## Commands
 
 ### `axon-agent start`
 
-Start the agent daemon.
-
 ```
-$ axon-agent start --server axon.example.com:443 --token <token>
-[INFO] connecting to axon.example.com:443...
+$ axon-agent start --server axon.example.com:9090 --token <token> --ca-cert /path/to/ca.crt
+[INFO] connecting to axon.example.com:9090...
 [INFO] registered as node "web-1" (id: a1b2c3d4)
 [INFO] heartbeat interval: 10s
 [INFO] ready, waiting for tasks
-
-# Subsequent starts (config already saved):
-$ axon-agent start
-[INFO] connecting to axon.example.com:443...
-[INFO] reconnected as node "web-1" (id: a1b2c3d4)
-[INFO] ready, waiting for tasks
 ```
 
-- **Server**: ✅ required
 - **Flags**:
-  - `--server <address>` — server address (first run, saved to config)
-  - `--token <token>` — agent token (first run, saved to config)
+  - `--server <address>` — server address (saved to config on first run)
+  - `--token <token>` — agent token (saved to config)
   - `--name <name>` — node name (optional, defaults to hostname)
   - `--labels key=value` — labels (repeatable)
-  - `--foreground` — run in foreground (default: daemonize)
+  - `--ca-cert <path>` — CA certificate for TLS verification
+  - `--tls-insecure` — skip TLS verification (dev only)
+  - `--foreground` — run in foreground
 
 ### `axon-agent stop`
 
-Stop the agent daemon.
-
-```
-$ axon-agent stop
-[INFO] shutting down...
-[INFO] completing 2 in-flight tasks...
-[INFO] stopped
-```
-
-- **Server**: ❌ local only
-- **Behavior**: sends SIGTERM to daemon process, waits for graceful shutdown
+Stop the agent daemon gracefully.
 
 ### `axon-agent status`
 
-Show agent status.
-
-```
-$ axon-agent status
-Status:      running
-Server:      axon.example.com:443
-Connection:  connected
-Node ID:     a1b2c3d4
-Node Name:   web-1
-Uptime:      3d 12h 5m
-Last Heartbeat: 2s ago
-Active Tasks: 0
-```
-
-- **Server**: local process check + connection health ping
-- **Flags**:
-  - `--json` — JSON output
-
-### `axon-agent config set/get`
-
-Manage local config.
-
-```
-$ axon-agent config set labels.env staging
-$ axon-agent config get server
-axon.example.com:443
-```
-
-- **Server**: ❌ local only
+Show agent status (running, connection, node info).
 
 ### `axon-agent version`
 
-```
-$ axon-agent version
-axon-agent 0.1.0 (go1.22, linux/amd64)
-```
-
-- **Server**: ❌ local only
+Print version info.
 
 ## Task Execution
 
@@ -155,92 +114,69 @@ Agent receives tasks via the control plane stream and opens data plane streams t
 
 ```
 1. Server sends TaskSignal{task_id, TASK_EXEC} via control stream
-2. Agent opens data stream, receives ExecRequest{command, env, workdir, timeout}
-3. Agent spawns local process:
-   - os/exec.Command(shell, "-c", command)
-   - Pipe stdout/stderr
-   - Set environment variables
-   - Set working directory
-4. Stream stdout/stderr chunks back as ExecOutput messages
+2. Agent opens HandleTask stream, receives ExecRequest
+3. Agent spawns local process (os/exec.Command)
+4. Stream stdout/stderr chunks as ExecOutput messages
 5. Process exits → send ExecExit{exit_code} → close stream
 ```
 
-**Process management:**
 - Each exec runs as a child process of the agent
-- Agent inherits its user's permissions (no sandboxing in Phase 1)
-- Timeout: agent kills the process with SIGTERM, then SIGKILL after 5s
+- Agent inherits its user's permissions
+- Timeout: SIGTERM → wait 5s → SIGKILL
 - Cancellation: gRPC context cancel → SIGTERM → SIGKILL
 
 ### Read
 
 ```
-1. Server sends TaskSignal{task_id, TASK_READ}
-2. Agent opens data stream, receives ReadRequest{path}
-3. Agent stat() the file → send ReadMeta{size, mode, mtime}
-4. Open file, read in chunks (default 32KB) → send ReadOutput{data} per chunk
+1. TaskSignal → agent opens HandleTask stream
+2. Receives ReadRequest{path}
+3. stat() → send ReadMeta{size, mode, mtime}
+4. Read in chunks (32KB) → send ReadOutput{data}
 5. EOF → close stream
 ```
-
-**Error cases:**
-- File not found → gRPC NOT_FOUND
-- Permission denied → gRPC PERMISSION_DENIED
-- Is a directory → gRPC INVALID_ARGUMENT
 
 ### Write
 
 ```
-1. Server sends TaskSignal{task_id, TASK_WRITE}
-2. Agent opens data stream, receives WriteHeader{path, mode}
-3. Create/truncate file with specified mode
-4. Receive WriteInput{data} chunks → write to file
-5. Client closes stream → agent responds WriteResponse{success, bytes_written}
+1. TaskSignal → agent opens HandleTask stream
+2. Receives WriteHeader{path, mode}
+3. Create/truncate file → receive WriteInput{data} chunks
+4. Complete → send WriteResponse{success, bytes_written}
 ```
 
-**Behavior:**
-- Creates parent directories if they don't exist
-- Atomic write: write to temp file, then rename (prevents partial writes)
-- Default mode: 0644
+- Creates parent directories if needed
+- Atomic write: temp file + rename
 
 ### Forward
 
 ```
-1. Server sends TaskSignal{task_id, TASK_FORWARD}
-2. Agent opens data stream, receives TunnelOpen{remote_port}
-3. Agent dials localhost:<remote_port> via TCP
-4. Bidirectional relay:
-   - TunnelData{payload} from server → write to TCP connection
-   - TCP data read → send TunnelData{payload} to server
-5. Either side closes → send TunnelData{close} → clean up
+1. TaskSignal → agent opens HandleTask stream
+2. Receives TunnelOpen{remote_port}
+3. Dial localhost:<remote_port> via TCP
+4. Bidirectional relay: TunnelData ↔ TCP socket
+5. Either side closes → TunnelData{close} → cleanup
 ```
-
-**Error cases:**
-- Cannot connect to target port → gRPC UNAVAILABLE with error detail
-- Connection reset → TunnelData{close}
 
 ## Heartbeat & Node Info
 
 ### Heartbeat
 
-- Agent sends `Heartbeat{timestamp}` every N seconds
-- N is configured by server in `RegisterResponse.heartbeat_interval_seconds`
-- Default: 10 seconds
-- Server marks node offline if no heartbeat received within 3× interval (30s default)
+- Interval configured by server in `RegisterResponse.heartbeat_interval_seconds`
+- Default: 10s
+- Server marks offline if no heartbeat within timeout (default 30s)
 
-### Node Info Reporting
+### Node Info
 
-Agent reports `NodeInfo` (including detailed `OSInfo`: kernel name, kernel version, distribution, distribution version, pretty name) on:
+Agent reports `NodeInfo` (hostname, arch, IP, uptime, agent version, OSInfo) on:
 1. Registration (initial report)
-2. Periodic update (every 5 minutes, or configurable)
-3. On significant change (IP change, OS upgrade, etc.)
+2. Periodic update
 
-OS information is collected using standard system calls:
-- **Linux**: `/etc/os-release` for distribution info, `uname` for kernel
-- **macOS**: `sw_vers` for version, `uname` for kernel
-- **Windows**: `RtlGetVersion` for OS version info
+OS info is collected per-platform:
+- **Linux**: `/etc/os-release` + `uname`
+- **macOS**: `sw_vers` + `uname`
+- **Windows**: `RtlGetVersion`
 
 ## Reconnection
-
-On connection loss:
 
 ```
 Attempt 1: wait 1s    → reconnect
@@ -251,30 +187,13 @@ Attempt N: wait min(2^N, 60)s ± 20% jitter → reconnect
 ```
 
 On successful reconnect:
-- Re-register with existing `node_id` (server recognizes returning node)
+- Re-register with existing `node_id`
 - Resume heartbeat
 - In-flight tasks at disconnect time are considered failed
 
-## Security
-
-### Phase 1 (current)
-
-- Agent runs as whatever user starts it
-- No command filtering, no path restrictions
-- All exec/read/write permissions = agent process user permissions
-- Trust boundary: if you have a valid CLI token bound to a node, you can do anything the agent user can do
-
-### Phase 2 (future)
-
-- Command allowlist/denylist
-- Path restrictions (allowed directories)
-- Resource limits (CPU, memory, time per exec)
-
 ## System Service
 
-Agent should run as a system service for production:
-
-```bash
+```ini
 # systemd example
 [Unit]
 Description=Axon Agent
@@ -285,17 +204,8 @@ ExecStart=/usr/local/bin/axon-agent start --foreground
 Restart=always
 RestartSec=5
 User=axon
+Environment=AXON_CA_CERT=/etc/axon-agent/ca.crt
 
 [Install]
 WantedBy=multi-user.target
 ```
-
-## Command Summary
-
-| Command | Server | Description |
-|---------|:------:|-------------|
-| `start` | ✅ | Start daemon, connect & register |
-| `stop` | ❌ | Stop daemon (graceful) |
-| `status` | ⚠️ | Local + connection health |
-| `config set/get` | ❌ | Local config |
-| `version` | ❌ | Local version |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,5 +1,7 @@
 # Axon Architecture Overview
 
+> [中文版 / Chinese](zh/architecture.md)
+
 ## Components
 
 Axon consists of three components, each built as a single static binary.
@@ -34,8 +36,6 @@ Multiple gRPC streams share a single HTTP/2 TCP connection — no connection exp
 3. Agent reverse connection requires long-lived connection — gRPC bidi stream is native
 4. HTTP would need SSE + WebSocket + chunked transfer — three patches instead of one protocol
 5. Unified tech stack: one proto definition, one TLS config, one codegen pipeline
-
-Future HTTP/REST access (web dashboard, third-party integrations) will be served by a grpc-gateway layer in Phase 3.
 
 ## Connection Model
 
@@ -83,17 +83,64 @@ JWT-based. Server holds the signing key.
 ┌─── CLI Token (JWT) ──┐     ┌─── Agent Token ───────────┐
 │ user_id              │     │ node_id                    │
 │ node_ids: [...]      │     │ server_url                 │
-│ exp                  │     │ (used once at first start) │
-│ iat                  │     └────────────────────────────┘
+│ jti (unique token ID)│     │ (used once at first start) │
+│ exp                  │     └────────────────────────────┘
+│ iat                  │
 └──────────────────────┘
 ```
 
 | Token Type | Scope | Lifetime |
 |------------|-------|----------|
-| CLI Token | Bound to user + allowed node list | Configurable expiry |
-| Agent Token | Bound to node identity | Used at first registration, then session-based |
+| CLI Token | Bound to user + allowed node list | Configurable expiry (default 24h) |
+| Agent Token | Bound to node identity | Used at registration |
 
-CLI Token binds to specific nodes — a token can only operate on its allowed node list.
+### Token Management
+
+- Each issued CLI token gets a unique **JTI** (JWT ID)
+- Tokens are persisted in SQLite — can be listed and revoked
+- Revoked tokens are checked in-memory (O(1) lookup) via gRPC interceptor
+- CLI commands: `axon auth list-tokens`, `axon auth revoke <id>`
+
+### User Management
+
+- Users are stored in SQLite with bcrypt password hashes
+- Bootstrap users from config file are seeded on first start (INSERT OR IGNORE)
+- Full CRUD via gRPC RPCs and CLI: `axon user create/list/update/delete`
+- Users can be disabled without deletion
+
+## Persistence
+
+All persistent state lives in a **single shared SQLite database** (WAL mode):
+
+| Table | Contents |
+|-------|----------|
+| `nodes` | Node registry (ID, name, status, metadata, token hash) |
+| `tokens` | Issued JWT tokens (JTI, kind, user, nodes, timestamps, revoked) |
+| `users` | CLI users (username, password hash, node IDs, timestamps, disabled) |
+| `audit_log` | Operation audit trail (separate SQLite file) |
+
+### Node Identity
+
+Nodes get a stable `node_id` (UUID) on first registration, persisted in the agent's local config. On reconnect, the server identifies returning nodes by `node_id`. Heartbeats are batched (30s flush interval) to reduce write load.
+
+## TLS
+
+### Auto-TLS (Default)
+
+When no explicit TLS certificates are configured, the server auto-generates:
+- **CA**: ECDSA P-256, 10-year validity, stored at `~/.axon-server/tls/ca.crt`
+- **Server cert**: ECDSA P-256, 1-year validity, auto-renewed when expiring within 30 days
+- SANs: always include `localhost` + `127.0.0.1` + configured hostname
+
+The CA certificate must be distributed to agents and CLI clients for TLS verification.
+
+### TLS Modes
+
+| Mode | Server Config | Client/Agent |
+|------|--------------|--------------|
+| Auto-TLS | Default (no cert/key configured) | `--ca-cert ca.crt` |
+| Explicit cert | `tls.cert` + `tls.key` | System CA or `--ca-cert` |
+| No TLS (dev) | `tls.auto: false` | `--tls-insecure` |
 
 ## Node States
 
@@ -110,7 +157,7 @@ Every operation through the Server is logged:
 
 ```json
 {
-  "timestamp": "2026-03-20T11:22:00Z",
+  "timestamp": "2026-03-25T11:22:00Z",
   "user_id": "gary",
   "node_id": "web-1",
   "action": "exec",
@@ -120,7 +167,7 @@ Every operation through the Server is logged:
 }
 ```
 
-Storage: SQLite (Phase 1). Extensible to external stores later.
+Storage: SQLite (async write, non-blocking, buffered channel → background writer).
 
 ## Tech Stack
 
@@ -128,8 +175,9 @@ Storage: SQLite (Phase 1). Extensible to external stores later.
 |------|--------|
 | Language | Go |
 | Communication | gRPC (HTTP/2), full link |
-| Auth | JWT |
+| Auth | JWT (HMAC-SHA256) with JTI + revocation |
 | Serialization | Protocol Buffers |
+| Persistence | SQLite (WAL mode, single shared DB) |
+| TLS | Auto-TLS (ECDSA P-256) or explicit certs |
 | Build | Single binary × 3, cross-platform |
-| Audit storage | SQLite (Phase 1) |
 | Config format | YAML |

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,19 +1,37 @@
-# Axon CLI Design
+# Axon CLI Reference
+
+> [中文版 / Chinese](zh/cli.md)
 
 ## Overview
 
-`axon` is a single stateless binary. It reads local config for server address and token, then talks to axon-server via gRPC.
+`axon` is a single stateless binary. It reads local config (`~/.axon/config.yaml`) for server address and token, then talks to axon-server via gRPC.
+
+## Global Flags
+
+```
+--ca-cert <path>     Path to CA certificate for TLS verification
+--tls-insecure       Skip TLS certificate verification (dev only)
+```
+
+These override values from the config file.
 
 ## Config
 
 Stored at `~/.axon/config.yaml`:
 
 ```yaml
-server: "axon.example.com:443"
+server_addr: "axon.example.com:9090"
 token: "eyJhbGciOiJIUzI1NiIs..."
+output_format: "table"
+ca_cert: "/path/to/ca.crt"
+tls_insecure: false
 ```
 
-## Commands
+See [Configuration Reference](configuration.md) for all fields.
+
+---
+
+## Node Commands
 
 ### `axon node list`
 
@@ -27,12 +45,8 @@ db-1      online   CentOS 9              amd64   10.0.1.20      0.1.0     5s ago
 edge-1    offline  Debian 12             arm64   192.168.1.50   0.1.0     2m ago
 ```
 
-- **Server**: ✅ required
 - **gRPC**: `ManagementService.ListNodes` (unary)
-- **Auth**: JWT token in gRPC metadata
-- **Flags**:
-  - `--json` — JSON output
-  - `--status <online|offline>` — filter by status
+- **Flags**: `--json` — JSON output; `--status <online|offline>` — filter
 
 ### `axon node info <node>`
 
@@ -45,19 +59,14 @@ Status:         online
 OS:             Ubuntu 24.04 LTS (linux 6.8.0-45-generic)
 Arch:           amd64
 IP:             10.0.1.10
-Uptime:         3d 12h 5m
 Agent Version:  0.1.0
-Connected:      2026-03-17 23:15:00 UTC
-Last Heartbeat: 2026-03-20 11:24:58 UTC
 Labels:
   env: production
   role: web
 ```
 
-- **Server**: ✅ required
 - **gRPC**: `ManagementService.GetNode` (unary)
-- **Flags**:
-  - `--json` — JSON output
+- **Flags**: `--json`
 
 ### `axon node remove <node>`
 
@@ -68,9 +77,11 @@ $ axon node remove edge-1
 Node "edge-1" removed.
 ```
 
-- **Server**: ✅ required
 - **gRPC**: `ManagementService.RemoveNode` (unary)
-- **Flags**: none
+
+---
+
+## Core Operations
 
 ### `axon exec <node> <command>`
 
@@ -82,18 +93,15 @@ CONTAINER ID   IMAGE     STATUS
 abc123         nginx     Up 2 hours
 
 $ axon exec web-1 "tail -f /var/log/app.log"
-[2026-03-20 11:25:00] request received...
-[2026-03-20 11:25:01] processing...
+[2026-03-25 11:25:00] request received...
 ^C
 ```
 
-- **Server**: ✅ required
 - **gRPC**: `OperationsService.Exec` (server stream)
 - **Behavior**:
   - stdout → stdout, stderr → stderr (preserves stream separation)
   - Exit code forwarded: `axon exec` exits with the remote command's exit code
   - Ctrl+C sends cancellation to server (gRPC context cancel)
-  - Long-running commands stream until completion or cancellation
 - **Flags**:
   - `--timeout <seconds>` — kill command after timeout (0 = no timeout)
   - `--env KEY=VALUE` — set environment variable (repeatable)
@@ -104,47 +112,23 @@ $ axon exec web-1 "tail -f /var/log/app.log"
 Read a file from a remote node. Content written to stdout.
 
 ```
-$ axon read web-1 /etc/nginx/nginx.conf
-worker_processes auto;
-events { ... }
-...
-
 $ axon read web-1 /etc/nginx/nginx.conf > local-copy.conf
 ```
 
-- **Server**: ✅ required
 - **gRPC**: `OperationsService.Read` (server stream)
-- **Behavior**:
-  - First message: file metadata (size, permissions, modified time)
-  - Subsequent messages: file content in chunks
-  - Binary files supported (raw bytes to stdout)
-- **Flags**:
-  - `--meta` — print file metadata only (size, mode, mtime)
-  - `--json` — output metadata as JSON
+- **Flags**: `--meta` — metadata only; `--json` — JSON metadata
 
 ### `axon write <node> <path>`
 
 Write to a file on a remote node. Content read from stdin.
 
 ```
-$ axon write web-1 /etc/nginx/nginx.conf < nginx.conf
-Written 2048 bytes to /etc/nginx/nginx.conf
-
 $ echo "hello" | axon write web-1 /tmp/hello.txt
 Written 6 bytes to /tmp/hello.txt
-
-$ cat backup.sql | axon write db-1 /tmp/restore.sql
-Written 15728640 bytes to /tmp/restore.sql
 ```
 
-- **Server**: ✅ required
 - **gRPC**: `OperationsService.Write` (client stream)
-- **Behavior**:
-  - First message: header (path, file mode)
-  - Subsequent messages: file content in chunks
-  - Large files streamed without loading into memory
-- **Flags**:
-  - `--mode <perm>` — file permissions (default: 0644)
+- **Flags**: `--mode <perm>` — file permissions (default: 0644)
 
 ### `axon forward <node> <local-port>:<remote-port>`
 
@@ -154,40 +138,28 @@ Forward a remote port to localhost.
 $ axon forward db-1 5432:5432
 Forwarding localhost:5432 → db-1:5432
 Ready. Press Ctrl+C to stop.
-
-# In another terminal:
-$ psql -h localhost -p 5432 -U postgres
 ```
 
-- **Server**: ✅ required
 - **gRPC**: `OperationsService.Forward` (BiDi stream, one per TCP connection)
-- **Behavior**:
-  - CLI listens on `localhost:<local-port>`
-  - Each incoming TCP connection → new gRPC bidi stream
-  - Raw TCP bytes wrapped in `TunnelData` protobuf messages
-  - Bidirectional: data flows both ways until either side closes
-  - Ctrl+C stops the listener and closes all tunnels
-- **Flags**:
-  - `--bind <address>` — bind address (default: `127.0.0.1`)
+- **Flags**: `--bind <address>` — bind address (default: `127.0.0.1`)
+
+---
+
+## Auth Commands
 
 ### `axon auth login`
 
-Authenticate with the server and obtain a JWT token.
+Authenticate and obtain a JWT token.
 
 ```
-$ axon auth login --server axon.example.com:443
+$ axon auth login --server axon.example.com:9090
 Username: gary
 Password: ****
-Login successful. Token saved to ~/.axon/config.yaml
+Login successful. Token saved.
 ```
 
-- **Server**: ✅ required
-- **gRPC**: `ManagementService.Login` (unary)
-- **Behavior**:
-  - Prompts for username/password (Phase 1)
-  - Saves token + server address to `~/.axon/config.yaml`
-- **Flags**:
-  - `--server <address>` — server address (saved to config)
+- **gRPC**: `ManagementService.Login` (unary, no auth required)
+- **Flags**: `--server <address>` — server address (saved to config)
 
 ### `axon auth token`
 
@@ -198,42 +170,119 @@ $ axon auth token
 eyJhbGciOiJIUzI1NiIs...
 ```
 
-- **Server**: ❌ local only
-- **Behavior**: reads and prints token from `~/.axon/config.yaml`
+### `axon auth list-tokens`
+
+List all issued tokens.
+
+```
+$ axon auth list-tokens
+ID                                    KIND   USER    ISSUED              EXPIRES
+550e8400-e29b-41d4-a716-446655440000  cli    gary    2026-03-25 10:00    2026-03-26 10:00
+```
+
+- **gRPC**: `ManagementService.ListTokens` (unary)
+
+### `axon auth revoke <token-id>`
+
+Revoke a token by its JTI.
+
+```
+$ axon auth revoke 550e8400-e29b-41d4-a716-446655440000
+Token revoked.
+```
+
+- **gRPC**: `ManagementService.RevokeToken` (unary)
+
+### `axon auth rotate`
+
+*Not yet implemented.* Placeholder for revoke current + re-login.
+
+---
+
+## User Commands
+
+### `axon user create <username>`
+
+Create a new CLI user. Prompts for password.
+
+```
+$ axon user create deploy-bot --node-ids web-1,web-2
+Password: ****
+User "deploy-bot" created.
+```
+
+- **gRPC**: `ManagementService.CreateUser` (unary)
+- **Flags**: `--node-ids <ids>` — comma-separated allowed node IDs (default: `*`)
+
+### `axon user list`
+
+List all users.
+
+```
+$ axon user list
+USERNAME      NODE IDS      DISABLED   CREATED
+admin         *             no         2026-03-25 09:00:00
+deploy-bot    web-1,web-2   no         2026-03-25 10:30:00
+```
+
+- **gRPC**: `ManagementService.ListUsers` (unary)
+
+### `axon user update <username>`
+
+Update a user's node IDs or password.
+
+```
+$ axon user update deploy-bot --node-ids web-1,web-2,db-1
+User "deploy-bot" updated.
+
+$ axon user update deploy-bot --password
+New password: ****
+User "deploy-bot" updated.
+```
+
+- **gRPC**: `ManagementService.UpdateUser` (unary)
+- **Flags**: `--node-ids <ids>`; `--password` — prompt for new password
+
+### `axon user delete <username>`
+
+Delete a user. Prompts for confirmation.
+
+```
+$ axon user delete deploy-bot
+Are you sure you want to delete user "deploy-bot"? (y/N): y
+User "deploy-bot" deleted.
+```
+
+- **gRPC**: `ManagementService.DeleteUser` (unary)
+- **Flags**: `--force` / `-f` — skip confirmation
+
+---
+
+## Config Commands
 
 ### `axon config set <key> <value>`
 
-Set a config value.
-
 ```
-$ axon config set server axon.example.com:443
+$ axon config set server axon.example.com:9090
 ```
 
-- **Server**: ❌ local only
-- **Supported keys**: `server`, `token`
+Supported keys: `server`, `token`, `output_format`
 
 ### `axon config get <key>`
 
-Get a config value.
-
 ```
 $ axon config get server
-axon.example.com:443
+axon.example.com:9090
 ```
-
-- **Server**: ❌ local only
 
 ### `axon version`
 
-Print version info.
-
 ```
 $ axon version
-axon 0.1.0 (go1.22, linux/amd64)
+axon 0.1.0 (go1.25, darwin/arm64)
 ```
 
-- **Server**: ❌ local only
-- Built-in at compile time via `-ldflags`
+---
 
 ## Command Summary
 
@@ -246,8 +295,15 @@ axon 0.1.0 (go1.22, linux/amd64)
 | `read` | ✅ | server stream | ✅ |
 | `write` | ✅ | client stream | ✅ |
 | `forward` | ✅ | bidi stream | ✅ |
-| `auth login` | ✅ | unary | ❌ (obtaining token) |
+| `auth login` | ✅ | unary | ❌ |
 | `auth token` | ❌ | — | — |
+| `auth list-tokens` | ✅ | unary | ✅ |
+| `auth revoke` | ✅ | unary | ✅ |
+| `auth rotate` | — | — | — |
+| `user create` | ✅ | unary | ✅ |
+| `user list` | ✅ | unary | ✅ |
+| `user update` | ✅ | unary | ✅ |
+| `user delete` | ✅ | unary | ✅ |
 | `config set/get` | ❌ | — | — |
 | `version` | ❌ | — | — |
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,196 @@
+# Configuration Reference
+
+Complete reference for all Axon configuration files and environment variables.
+
+> [中文版 / Chinese](zh/configuration.md)
+
+---
+
+## Server (`axon-server`)
+
+Config file path: passed via `--config` flag (default: `./config.yaml`)
+
+### Full Example
+
+```yaml
+listen: ":9090"
+
+tls:
+  auto: true                              # auto-generate self-signed CA + server cert (default when no cert/key)
+  dir: "/var/lib/axon-server/tls"         # directory for auto-generated certs (default: ~/.axon-server/tls)
+  cert: ""                                # path to explicit TLS certificate (disables auto-TLS)
+  key: ""                                 # path to explicit TLS private key
+
+auth:
+  jwt_signing_key: "${AXON_JWT_SECRET}"   # HMAC-SHA256 signing key (required)
+
+users:                                    # bootstrap users (seeded into DB on first start)
+  - username: admin
+    password_hash: "$2a$10$..."           # bcrypt hash
+    node_ids: ["*"]                       # ["*"] = access to all nodes
+  - username: deploy-agent
+    password_hash: "$2a$10$..."
+    node_ids: ["web-1", "web-2"]          # restricted to specific nodes
+
+heartbeat:
+  interval: "10s"                         # heartbeat interval sent to agents (default: 10s)
+  timeout: "30s"                          # mark offline after no heartbeat (default: 30s)
+
+audit:
+  db_path: "/var/lib/axon-server/audit.db"  # SQLite path for audit log (default: in-memory)
+```
+
+### Fields
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `listen` | string | `:9090` | gRPC listen address |
+| `tls.auto` | bool | `true` (when no cert/key) | Auto-generate self-signed CA + server certificate |
+| `tls.dir` | string | `~/.axon-server/tls` | Directory for auto-generated TLS files |
+| `tls.cert` | string | — | Path to TLS certificate (PEM). Disables auto-TLS |
+| `tls.key` | string | — | Path to TLS private key (PEM) |
+| `auth.jwt_signing_key` | string | — | **Required.** HMAC-SHA256 key for JWT signing |
+| `users[].username` | string | — | Bootstrap user username |
+| `users[].password_hash` | string | — | Bcrypt hash of password |
+| `users[].node_ids` | []string | `["*"]` | Allowed node IDs; `["*"]` = all |
+| `heartbeat.interval` | duration | `10s` | Heartbeat interval for agents |
+| `heartbeat.timeout` | duration | `30s` | Offline threshold |
+| `audit.db_path` | string | `:memory:` | SQLite path for audit log |
+
+### Environment Variables
+
+| Variable | Overrides |
+|----------|-----------|
+| `AXON_JWT_SECRET` | `auth.jwt_signing_key` |
+| `AXON_TLS_CERT` | `tls.cert` |
+| `AXON_TLS_KEY` | `tls.key` |
+| `AXON_TLS_DIR` | `tls.dir` |
+
+### Auto-TLS Details
+
+When `tls.auto` is enabled (or not explicitly disabled) and no `tls.cert`/`tls.key` is provided:
+
+1. Server checks `tls.dir` for existing `ca.crt`
+2. If missing: generates ECDSA P-256 CA (10-year validity) + server cert (1-year validity)
+3. If `ca.crt` exists but `server.crt` is missing or expires within 30 days: regenerates server cert
+4. CA fingerprint is logged for distribution to agents and CLI clients
+
+Generated files:
+
+```
+~/.axon-server/tls/
+├── ca.crt          # CA certificate (distribute to agents/CLI)
+├── ca.key          # CA private key (keep secure, 0600)
+├── server.crt      # Server certificate
+└── server.key      # Server private key (0600)
+```
+
+### Data Persistence
+
+All persistent data (node registry, tokens, users) is stored in a single SQLite database. Currently the path is not configurable via YAML — it defaults to in-memory. Production persistence will be exposed in a future release.
+
+### Bootstrap Users
+
+Users defined in the config file are seeded into the database on startup using `INSERT OR IGNORE` — existing users are not overwritten. After initial bootstrap, manage users via the `axon user` CLI commands or the gRPC `ManagementService` RPCs.
+
+---
+
+## Agent (`axon-agent`)
+
+Config file path: `~/.axon-agent/config.yaml` (auto-created on first `start`)
+
+### Full Example
+
+```yaml
+server: "axon.example.com:9090"
+token: "agent-token-xxx"
+node_id: "a1b2c3d4"              # assigned by server after first registration
+node_name: "web-1"               # user-specified or hostname
+labels:
+  env: production
+  role: web
+ca_cert: "/path/to/ca.crt"       # CA certificate for TLS verification
+tls_insecure: false               # skip TLS verification (dev only)
+```
+
+### Fields
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `server` | string | — | **Required.** Server gRPC address (`host:port`) |
+| `token` | string | — | **Required.** Agent token for registration |
+| `node_id` | string | — | Auto-assigned by server after first registration |
+| `node_name` | string | hostname | Human-readable node name |
+| `labels` | map | — | Key-value labels for grouping |
+| `ca_cert` | string | — | Path to CA certificate for TLS verification |
+| `tls_insecure` | bool | `false` | Skip TLS certificate verification |
+
+### Environment Variables
+
+| Variable | Overrides |
+|----------|-----------|
+| `AXON_SERVER` | `server` |
+| `AXON_TOKEN` | `token` |
+| `AXON_CA_CERT` | `ca_cert` |
+
+### TLS Behavior
+
+The agent uses a 3-way TLS selection:
+
+1. `tls_insecure: true` → no TLS verification (plaintext gRPC)
+2. `ca_cert` set → verify server cert against specified CA
+3. Neither → verify server cert against system CA pool
+
+For auto-TLS setups, copy the server's `ca.crt` to the agent machine and set `ca_cert`.
+
+---
+
+## CLI (`axon`)
+
+Config file path: `~/.axon/config.yaml`
+
+### Full Example
+
+```yaml
+server_addr: "axon.example.com:9090"
+token: "eyJhbGciOiJIUzI1NiIs..."
+output_format: "table"            # "table" or "json"
+ca_cert: "/path/to/ca.crt"       # CA certificate for TLS verification
+tls_insecure: false               # skip TLS verification (dev only)
+```
+
+### Fields
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `server_addr` | string | — | Server gRPC address |
+| `token` | string | — | JWT token (set by `axon auth login`) |
+| `output_format` | string | `table` | Default output format |
+| `ca_cert` | string | — | Path to CA certificate for TLS verification |
+| `tls_insecure` | bool | `false` | Skip TLS certificate verification |
+
+### Environment Variables
+
+| Variable | Overrides |
+|----------|-----------|
+| `AXON_SERVER` | `server_addr` |
+| `AXON_TOKEN` | `token` |
+| `AXON_CA_CERT` | `ca_cert` |
+
+### Global Flags
+
+These flags override config-file values for any command:
+
+```bash
+axon --ca-cert /path/to/ca.crt <command>
+axon --tls-insecure <command>
+```
+
+### Config Commands
+
+```bash
+axon config set server axon.example.com:9090
+axon config get server
+```
+
+Supported keys: `server`, `token`, `output_format`

--- a/docs/project-structure.md
+++ b/docs/project-structure.md
@@ -1,92 +1,108 @@
 # Axon Project Structure
 
+> [中文版 / Chinese](zh/project-structure.md)
+
 ## Directory Layout
 
 ```
 axon/
 ├── cmd/
-│   ├── axon/                    # CLI binary entry point
-│   │   └── main.go
-│   ├── axon-server/             # Server binary entry point
-│   │   └── main.go
-│   └── axon-agent/              # Agent binary entry point
-│       └── main.go
+│   ├── axon/                        # CLI binary
+│   │   ├── main.go                  # Root command + subcommands
+│   │   ├── client.go                # gRPC connection helper (TLS, auth)
+│   │   ├── node.go                  # node list/info/remove
+│   │   ├── exec.go                  # exec command
+│   │   ├── read.go                  # read command
+│   │   ├── write.go                 # write command
+│   │   ├── forward.go               # forward command
+│   │   ├── auth.go                  # auth login/token/list-tokens/revoke/rotate
+│   │   └── user.go                  # user create/list/update/delete
+│   ├── axon-server/                 # Server binary
+│   │   └── main.go                  # Config loading + server start
+│   └── axon-agent/                  # Agent binary
+│       └── main.go                  # Config loading + agent start
 │
-├── proto/                       # Protocol Buffers definitions
-│   ├── control.proto            # Agent ↔ Server control plane
-│   ├── operations.proto         # exec/read/write/forward
-│   └── management.proto         # Node management + auth
+├── proto/                           # Protocol Buffers definitions
+│   ├── control.proto                # Agent ↔ Server control plane
+│   ├── operations.proto             # exec/read/write/forward + AgentOps
+│   └── management.proto             # Node/user/token management + auth
 │
-├── gen/                         # Generated code from proto (gitignored or committed)
+├── gen/                             # Generated code from proto
 │   └── proto/
 │       ├── control/
 │       ├── operations/
 │       └── management/
 │
-├── pkg/                         # Public packages (stable API)
-│   ├── auth/                    # JWT token generation & validation
-│   │   ├── jwt.go
-│   │   └── jwt_test.go
-│   ├── audit/                   # Audit logging
-│   │   ├── logger.go
-│   │   ├── sqlite.go
-│   │   └── logger_test.go
-│   └── config/                  # Shared config loading utilities
-│       └── config.go
+├── pkg/                             # Public packages (stable API)
+│   ├── auth/                        # Authentication & authorization
+│   │   ├── auth.go                  # JWT signing & verification
+│   │   ├── interceptor.go           # gRPC auth interceptors (with revocation check)
+│   │   ├── token_checker.go         # In-memory revoked JTI set
+│   │   ├── token_store.go           # Token persistence (SQLite)
+│   │   └── user_store.go            # User persistence (SQLite CRUD)
+│   ├── audit/                       # Audit logging
+│   │   ├── audit.go                 # Entry types
+│   │   ├── store.go                 # SQLite store
+│   │   └── writer.go                # Async buffered writer
+│   ├── config/                      # Shared config types + loading
+│   │   └── config.go                # ServerConfig, AgentConfig, CLIConfig
+│   ├── display/                     # Output formatting
+│   │   └── display.go               # Table + JSON output helpers
+│   └── tls/                         # TLS certificate management
+│       └── autotls.go               # Auto-TLS: CA + server cert generation
 │
-├── internal/                    # Private packages (implementation details)
-│   ├── server/                  # Server core logic
-│   │   ├── server.go            # gRPC server setup
-│   │   ├── registry.go          # Node registry (in-memory)
-│   │   ├── router.go            # Request routing + stream bridging
-│   │   ├── control.go           # ControlService implementation
-│   │   ├── operations.go        # OperationsService implementation
-│   │   ├── management.go        # ManagementService implementation
-│   │   └── heartbeat.go         # Heartbeat timeout monitor
+├── internal/                        # Private packages
+│   ├── server/                      # Server core logic
+│   │   ├── server.go                # gRPC server setup, DB init, TLS, lifecycle
+│   │   ├── control.go               # ControlService (agent registration + heartbeat)
+│   │   ├── operations.go            # OperationsService (CLI → agent routing)
+│   │   ├── management.go            # ManagementService (node/user/token CRUD)
+│   │   ├── agent_ops.go             # AgentOpsService (agent data plane)
+│   │   ├── router.go                # Request routing + stream bridging
+│   │   ├── bridge.go                # CLI ↔ Agent stream bridge
+│   │   ├── testing.go               # Test helper (bufconn server)
+│   │   └── registry/                # Node registry subsystem
+│   │       ├── registry.go          # In-memory registry + heartbeat timeout
+│   │       ├── store.go             # SQLite backing store (CRUD + upsert)
+│   │       └── heartbeat_batch.go   # Batched heartbeat persistence
 │   │
-│   ├── agent/                   # Agent core logic
-│   │   ├── agent.go             # Main agent loop
-│   │   ├── control.go           # Control plane (register, heartbeat)
-│   │   ├── executor.go          # exec: process spawning + streaming
-│   │   ├── fileio.go            # read/write: file operations
-│   │   ├── tunnel.go            # forward: TCP tunneling
-│   │   └── reconnect.go         # Exponential backoff reconnection
-│   │
-│   └── cli/                     # CLI core logic
-│       ├── root.go              # Root command (cobra)
-│       ├── node.go              # node list/info/remove
-│       ├── exec.go              # exec command
-│       ├── read.go              # read command
-│       ├── write.go             # write command
-│       ├── forward.go           # forward command
-│       ├── auth.go              # auth login/token
-│       ├── config.go            # config set/get
-│       └── output.go            # Output formatting (table, JSON)
+│   └── agent/                       # Agent core logic
+│       ├── agent.go                 # Main loop: connect, register, heartbeat, reconnect
+│       ├── dispatcher.go            # Task dispatch from control stream
+│       ├── exec.go                  # exec: process spawning + streaming
+│       ├── fileio.go                # read/write: file operations
+│       ├── forward.go               # forward: TCP tunneling
+│       ├── sysinfo.go               # System info collection (shared)
+│       ├── sysinfo_linux.go         # Linux-specific (os-release)
+│       ├── sysinfo_darwin.go        # macOS-specific (sw_vers)
+│       ├── sysinfo_windows.go       # Windows-specific (RtlGetVersion)
+│       └── testing.go               # Test helpers
 │
-├── docs/                        # Design documents (English)
-│   ├── architecture.md          # Architecture overview
-│   ├── protocol.md              # Protocol design (proto details)
-│   ├── cli.md                   # CLI design
-│   ├── agent.md                 # Agent design
-│   ├── server.md                # Server design
-│   ├── project-structure.md     # This file
-│   └── zh/                      # Design documents (Chinese)
-│       ├── architecture.md
-│       ├── protocol.md
-│       ├── cli.md
-│       ├── agent.md
-│       ├── server.md
-│       └── project-structure.md
+├── test/
+│   └── integration/                 # End-to-end integration tests
+│       ├── integration_test.go
+│       └── testharness/
+│           └── harness.go           # Test server + agent setup
 │
-├── scripts/                     # Build & dev scripts
-│   ├── build.sh                 # Cross-platform build
-│   ├── proto-gen.sh             # Protobuf code generation
-│   └── dev-setup.sh             # Dev environment setup
+├── docs/                            # Documentation (English)
+│   ├── quickstart.md                # Quick start guide
+│   ├── configuration.md             # Configuration reference
+│   ├── architecture.md              # Architecture overview
+│   ├── protocol.md                  # Protocol design (proto details)
+│   ├── cli.md                       # CLI command reference
+│   ├── server.md                    # Server design
+│   ├── agent.md                     # Agent design
+│   ├── project-structure.md         # This file
+│   ├── phase2-design.md             # Phase 2 design document
+│   ├── data-plane-bridge.md         # Data plane bridge design
+│   ├── tasks-phase1.md              # Phase 1 task breakdown (historical)
+│   └── zh/                          # Documentation (Chinese)
 │
-├── Makefile                     # Build targets
+├── Makefile
 ├── go.mod
 ├── go.sum
 ├── README.md
+├── README_zh.md
 ├── CONTRIBUTING.md
 └── .gitignore
 ```
@@ -94,81 +110,29 @@ axon/
 ## Package Dependency Rules
 
 ```
-cmd/axon        → internal/cli   → gen/proto, pkg/config
-cmd/axon-server → internal/server → gen/proto, pkg/auth, pkg/audit, pkg/config
+cmd/axon        → gen/proto, pkg/config
+cmd/axon-server → internal/server → gen/proto, pkg/auth, pkg/audit, pkg/config, pkg/tls
 cmd/axon-agent  → internal/agent  → gen/proto, pkg/config
 
 pkg/auth    → (standalone, no internal imports)
 pkg/audit   → (standalone, no internal imports)
 pkg/config  → (standalone, no internal imports)
+pkg/tls     → (standalone, no internal imports)
 ```
 
 **Rules:**
-1. `cmd/` only contains `main.go` — all logic in `internal/` or `pkg/`
+1. `cmd/` contains entry points — all logic in `internal/` or `pkg/`
 2. `internal/` packages cannot be imported outside the module
 3. `pkg/` packages are stable APIs shared across components
 4. No circular dependencies
-5. `internal/server`, `internal/agent`, `internal/cli` do not import each other
+5. `internal/server` and `internal/agent` do not import each other
 
 ## Build Targets
 
-```makefile
-# Build all three binaries
-make build
-
-# Build individual
-make build-cli
-make build-server
-make build-agent
-
-# Generate proto
-make proto
-
-# Run tests
-make test
-
-# Cross-compile (linux/darwin × amd64/arm64)
-make release
-
-# Lint
-make lint
-```
-
-## Makefile
-
-```makefile
-VERSION ?= $(shell git describe --tags --always --dirty)
-LDFLAGS := -ldflags "-X main.version=$(VERSION)"
-
-.PHONY: build build-cli build-server build-agent proto test lint clean
-
-build: build-cli build-server build-agent
-
-build-cli:
-	go build $(LDFLAGS) -o bin/axon ./cmd/axon
-
-build-server:
-	go build $(LDFLAGS) -o bin/axon-server ./cmd/axon-server
-
-build-agent:
-	go build $(LDFLAGS) -o bin/axon-agent ./cmd/axon-agent
-
-proto:
-	./scripts/proto-gen.sh
-
-test:
-	go test ./...
-
-lint:
-	golangci-lint run ./...
-
-clean:
-	rm -rf bin/
-
-release:
-	GOOS=linux GOARCH=amd64 go build $(LDFLAGS) -o bin/axon-linux-amd64 ./cmd/axon
-	GOOS=linux GOARCH=arm64 go build $(LDFLAGS) -o bin/axon-linux-arm64 ./cmd/axon
-	GOOS=darwin GOARCH=amd64 go build $(LDFLAGS) -o bin/axon-darwin-amd64 ./cmd/axon
-	GOOS=darwin GOARCH=arm64 go build $(LDFLAGS) -o bin/axon-darwin-arm64 ./cmd/axon
-	# Repeat for axon-server and axon-agent...
+```bash
+make build          # Build all three binaries → bin/
+make test           # Run all tests with race detector
+make lint           # Run golangci-lint
+make proto          # Regenerate protobuf code
+make clean          # Remove bin/
 ```

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -1,91 +1,64 @@
 # Axon Protocol Design
 
+> [中文版 / Chinese](zh/protocol.md)
+
 ## Overview
 
-All communication uses gRPC over HTTP/2 with Protocol Buffers serialization.
+All communication uses gRPC over HTTP/2 with Protocol Buffers serialization. Three proto files define the entire API surface.
 
-Three proto files:
-- `control.proto` — Agent ↔ Server control plane
-- `operations.proto` — CLI ↔ Server ↔ Agent data plane (exec/read/write/forward)
-- `management.proto` — CLI ↔ Server management (node list/info/remove, auth)
+## Proto Files
 
-## 1. Control Plane — `control.proto`
+| File | Package | Services | Purpose |
+|------|---------|----------|---------|
+| `control.proto` | `axon.control` | `ControlService` | Agent ↔ Server control plane |
+| `operations.proto` | `axon.operations` | `OperationsService`, `AgentOpsService` | CLI operations + agent task handling |
+| `management.proto` | `axon.management` | `ManagementService` | Node/user/token management + auth |
 
-Long-lived bidirectional stream between Agent and Server.
+## ControlService (Agent ↔ Server)
+
+Long-lived bidirectional stream for agent lifecycle management.
 
 ```protobuf
-syntax = "proto3";
-package axon.control;
-
 service ControlService {
-  // Agent establishes a persistent control channel on startup.
-  // Server uses this to track liveness and dispatch task signals.
   rpc Connect(stream AgentMessage) returns (stream ServerMessage);
 }
+```
 
-// ─── Agent → Server ───
+### Agent → Server Messages
 
-message AgentMessage {
-  oneof payload {
-    RegisterRequest register = 1;
-    Heartbeat heartbeat = 2;
-    NodeInfo node_info = 3;
-  }
-}
+| Message | Purpose |
+|---------|---------|
+| `RegisterRequest` | Initial registration (token, node_name, node_id, NodeInfo) |
+| `Heartbeat` | Periodic liveness signal (timestamp) |
+| `NodeInfo` | System info update (hostname, arch, IP, uptime, OSInfo) |
 
-message RegisterRequest {
-  string token = 1;           // Agent token (one-time registration)
-  string node_name = 2;       // Desired node name (falls back to hostname)
-  NodeInfo info = 3;          // Initial node info
-}
+`RegisterRequest.node_id` is empty on first connect; non-empty on reconnect (stable identity).
 
-message Heartbeat {
-  int64 timestamp = 1;        // Unix timestamp (ms)
-}
+### Server → Agent Messages
 
-message NodeInfo {
-  string hostname = 1;
-  string arch = 2;            // e.g. "amd64", "arm64"
-  string ip = 3;              // Primary IP
-  int64 uptime_seconds = 4;
-  string agent_version = 5;
-  OSInfo os_info = 6;         // Detailed OS information
-}
+| Message | Purpose |
+|---------|---------|
+| `RegisterResponse` | Registration result (node_id, heartbeat_interval) |
+| `HeartbeatAck` | Heartbeat acknowledgment (server timestamp) |
+| `TaskSignal` | Dispatch a task — agent opens data plane stream |
 
+### OSInfo
+
+Detailed OS information collected per-platform:
+
+```protobuf
 message OSInfo {
-  string os = 1;              // Kernel name: "linux", "darwin", "windows"
-  string os_version = 2;      // Kernel version: "6.8.0-45-generic", "24.3.0"
-  string platform = 3;        // Distribution/platform: "ubuntu", "centos", "debian", "macOS"
-  string platform_version = 4;// Distribution version: "24.04", "9", "14.4"
-  string pretty_name = 5;     // Human-readable: "Ubuntu 24.04 LTS", "macOS 14.4 Sonoma"
+  string os = 1;               // "linux", "darwin", "windows"
+  string os_version = 2;       // kernel version
+  string platform = 3;         // "ubuntu", "centos", "macOS"
+  string platform_version = 4; // "24.04", "9", "14.4"
+  string pretty_name = 5;      // "Ubuntu 24.04 LTS"
 }
+```
 
-// ─── Server → Agent ───
+### TaskType
 
-message ServerMessage {
-  oneof payload {
-    RegisterResponse register_response = 1;
-    HeartbeatAck heartbeat_ack = 2;
-    TaskSignal task_signal = 3;    // Notify agent to open a data plane stream
-  }
-}
-
-message RegisterResponse {
-  bool success = 1;
-  string node_id = 2;         // Server-assigned node ID
-  string error = 3;
-  int32 heartbeat_interval_seconds = 4;  // Server tells agent how often to heartbeat
-}
-
-message HeartbeatAck {
-  int64 server_timestamp = 1;
-}
-
-message TaskSignal {
-  string task_id = 1;         // Agent uses this to open a data plane stream
-  TaskType type = 2;
-}
-
+```protobuf
 enum TaskType {
   TASK_EXEC = 0;
   TASK_READ = 1;
@@ -94,237 +67,180 @@ enum TaskType {
 }
 ```
 
-### Flow
+## OperationsService (CLI → Server)
 
-1. Agent starts → calls `Connect()` → sends `RegisterRequest`
-2. Server validates token → responds `RegisterResponse` with node_id and heartbeat interval
-3. Agent sends `Heartbeat` every N seconds
-4. Server responds `HeartbeatAck`
-5. When CLI sends a request for this node, Server sends `TaskSignal` through control stream
-6. Agent receives `TaskSignal` → opens a new data plane stream with the task_id
-
-## 2. Data Plane — `operations.proto`
-
-Per-task streams for exec, read, write, forward.
+CLI-facing operations. Server routes to the target agent.
 
 ```protobuf
-syntax = "proto3";
-package axon.operations;
-
 service OperationsService {
-  // CLI calls these RPCs. Server routes to the target agent.
-
-  // Execute a command — streams stdout/stderr back
   rpc Exec(ExecRequest) returns (stream ExecOutput);
-
-  // Read a file — streams file content in chunks
   rpc Read(ReadRequest) returns (stream ReadOutput);
-
-  // Write a file — client streams file content in chunks
   rpc Write(stream WriteInput) returns (WriteResponse);
-
-  // Port forward — bidirectional byte stream
   rpc Forward(stream TunnelData) returns (stream TunnelData);
 }
-
-// ─── Exec ───
-
-message ExecRequest {
-  string node_id = 1;
-  string command = 2;
-  map<string, string> env = 3;      // Optional environment variables
-  string working_dir = 4;           // Optional working directory
-  int32 timeout_seconds = 5;        // 0 = no timeout
-}
-
-message ExecOutput {
-  oneof payload {
-    bytes stdout = 1;
-    bytes stderr = 2;
-    ExecExit exit = 3;
-  }
-}
-
-message ExecExit {
-  int32 exit_code = 1;
-  string error = 2;           // Non-empty if agent-level error (not command error)
-}
-
-// ─── Read ───
-
-message ReadRequest {
-  string node_id = 1;
-  string path = 2;
-}
-
-message ReadOutput {
-  oneof payload {
-    bytes data = 1;           // File content chunk
-    ReadMeta meta = 2;        // Sent first: file size, permissions, etc.
-    string error = 3;
-  }
-}
-
-message ReadMeta {
-  int64 size = 1;
-  int32 mode = 2;             // Unix file mode
-  int64 modified_at = 3;      // Unix timestamp
-}
-
-// ─── Write ───
-
-message WriteInput {
-  oneof payload {
-    WriteHeader header = 1;   // Sent first
-    bytes data = 2;           // File content chunks
-  }
-}
-
-message WriteHeader {
-  string node_id = 1;
-  string path = 2;
-  int32 mode = 3;             // Unix file mode (0644 default)
-}
-
-message WriteResponse {
-  bool success = 1;
-  int64 bytes_written = 2;
-  string error = 3;
-}
-
-// ─── Forward (Port Tunneling) ───
-
-message TunnelData {
-  string connection_id = 1;   // Identifies a single TCP connection
-  bytes payload = 2;          // Raw TCP bytes
-  bool close = 3;             // Signal to close this connection
-
-  // Only in first message of a new connection:
-  TunnelOpen open = 4;
-}
-
-message TunnelOpen {
-  string node_id = 1;
-  int32 remote_port = 2;
-}
 ```
 
-### Exec Flow
+### Exec
 
 ```
-CLI                         Server                      Agent
- │── ExecRequest ──────────→│── TaskSignal ────────────→│
- │  {node:web-1, cmd:...}   │                           │── open data stream
- │                           │                           │── run command
- │←─ ExecOutput(stdout) ────│←─ stdout bytes ───────────│
- │←─ ExecOutput(stderr) ────│←─ stderr bytes ───────────│
- │←─ ExecOutput(exit) ──────│←─ exit code ──────────────│
- │  stream closes            │  stream closes            │
+CLI sends ExecRequest{node_id, command, env, workdir, timeout}
+  → Server routes to agent
+  → Agent streams ExecOutput{stdout | stderr | exit}
 ```
 
-### Forward Flow
+### Read
 
 ```
-TCP client      CLI                    Server                  Agent               TCP target
-  │──connect──→│                        │                       │                      │
-  │             │──TunnelData{open}───→│──TaskSignal──────────→│                      │
-  │             │  {node:db-1,port:5432}│                       │──TCP connect────────→│
-  │             │                       │                       │                      │
-  │──data─────→│──TunnelData{payload}─→│──TunnelData{payload}→│──data────────────────→│
-  │←─data──────│←─TunnelData{payload}──│←─TunnelData{payload}─│←─data─────────────────│
-  │   ...       │   ...                 │   ...                 │   ...                 │
-  │──close────→│──TunnelData{close}───→│──TunnelData{close}──→│──TCP close────────────→│
+CLI sends ReadRequest{node_id, path}
+  → Server routes to agent
+  → Agent streams ReadOutput{meta (first), then data chunks}
 ```
 
-Each incoming TCP connection gets its own `connection_id`. Multiple TCP connections can be multiplexed over a single gRPC bidi stream, or each can open a separate stream (implementation choice — we use **one stream per TCP connection** for simplicity in Phase 1).
+### Write
 
-## 3. Management — `management.proto`
+```
+CLI streams WriteInput{header (first), then data chunks}
+  → Server routes to agent
+  → Agent returns WriteResponse{success, bytes_written}
+```
 
-Simple unary RPCs for node management and auth.
+### Forward (Port Tunneling)
+
+```
+CLI ←→ Server ←→ Agent: bidirectional TunnelData{connection_id, payload, close}
+First message includes TunnelOpen{node_id, remote_port}
+```
+
+Each TCP connection gets an independent gRPC bidi stream. Raw TCP bytes are wrapped in `TunnelData` messages.
+
+## AgentOpsService (Agent → Server)
+
+Agent-facing data plane. After receiving a `TaskSignal` on the control stream, the agent opens a `HandleTask` stream.
 
 ```protobuf
-syntax = "proto3";
-package axon.management;
+service AgentOpsService {
+  rpc HandleTask(stream TaskDataUp) returns (stream TaskDataDown);
+}
+```
 
+### Task Data Flow
+
+```
+TaskDataUp (agent → server):
+  task_id + {exec_output | read_output | write_response | tunnel_data}
+
+TaskDataDown (server → agent):
+  task_id + {exec_request | read_request | write_input | tunnel_data}
+```
+
+The server acts as a transparent bridge — relaying between the CLI's `OperationsService` stream and the agent's `HandleTask` stream.
+
+## ManagementService (CLI → Server)
+
+Node management, authentication, token management, and user management.
+
+```protobuf
 service ManagementService {
+  // Node management
   rpc ListNodes(ListNodesRequest) returns (ListNodesResponse);
   rpc GetNode(GetNodeRequest) returns (GetNodeResponse);
   rpc RemoveNode(RemoveNodeRequest) returns (RemoveNodeResponse);
+
+  // Authentication
   rpc Login(LoginRequest) returns (LoginResponse);
-}
 
-// ─── Node Management ───
+  // Token management
+  rpc RevokeToken(RevokeTokenRequest) returns (RevokeTokenResponse);
+  rpc ListTokens(ListTokensRequest) returns (ListTokensResponse);
 
-message ListNodesRequest {}
-
-message ListNodesResponse {
-  repeated NodeSummary nodes = 1;
-}
-
-message NodeSummary {
-  string node_id = 1;
-  string node_name = 2;
-  string status = 3;          // "online" | "offline"
-  string arch = 4;
-  string ip = 5;
-  string agent_version = 6;
-  int64 connected_at = 7;     // Unix timestamp
-  int64 last_heartbeat = 8;   // Unix timestamp
-  OSInfo os_info = 9;         // Detailed OS information
-}
-
-message GetNodeRequest {
-  string node_id = 1;
-}
-
-message GetNodeResponse {
-  NodeSummary summary = 1;
-  int64 uptime_seconds = 2;
-  map<string, string> labels = 3;
-}
-
-message RemoveNodeRequest {
-  string node_id = 1;
-}
-
-message RemoveNodeResponse {
-  bool success = 1;
-  string error = 2;
-}
-
-// ─── Auth ───
-
-message LoginRequest {
-  string username = 1;
-  string password = 2;        // Phase 1: simple username/password
-}
-
-message LoginResponse {
-  string token = 1;           // JWT token
-  int64 expires_at = 2;       // Unix timestamp
-  string error = 3;
+  // User management
+  rpc CreateUser(CreateUserRequest) returns (CreateUserResponse);
+  rpc UpdateUser(UpdateUserRequest) returns (UpdateUserResponse);
+  rpc DeleteUser(DeleteUserRequest) returns (DeleteUserResponse);
+  rpc ListUsers(ListUsersRequest) returns (ListUsersResponse);
 }
 ```
 
-## Error Handling
+### Node Management
 
-All RPCs use standard gRPC status codes:
+| RPC | Input | Output | Auth |
+|-----|-------|--------|------|
+| `ListNodes` | — | `repeated NodeSummary` | JWT |
+| `GetNode` | `node_id` | `NodeSummary + labels + uptime` | JWT |
+| `RemoveNode` | `node_id` | `success/error` | JWT |
 
-| Scenario | gRPC Status Code |
-|----------|-----------------|
-| Node not found | `NOT_FOUND` |
-| Node offline | `UNAVAILABLE` |
-| Auth failed / token expired | `UNAUTHENTICATED` |
-| Token doesn't cover target node | `PERMISSION_DENIED` |
-| File not found (read) | `NOT_FOUND` |
-| Command timeout (exec) | `DEADLINE_EXCEEDED` |
-| Agent internal error | `INTERNAL` |
-| Invalid request | `INVALID_ARGUMENT` |
+### Authentication
 
-## TLS
+| RPC | Input | Output | Auth |
+|-----|-------|--------|------|
+| `Login` | `username, password` | `token, expires_at` | **None** (public endpoint) |
 
-All gRPC connections use TLS:
-- CLI → Server: standard TLS (server cert)
-- Agent → Server: standard TLS (server cert) + Agent token for identity
+Login validates credentials against the user store (SQLite). On success, issues a JWT with a unique JTI. The token is also persisted to the token store for listing/revocation.
 
-Phase 1: Server uses a single TLS cert. mTLS is a Phase 2 consideration.
+### Token Management
+
+| RPC | Input | Output | Auth |
+|-----|-------|--------|------|
+| `RevokeToken` | `token_id (jti)` | `success/error` | JWT |
+| `ListTokens` | `kind (optional)` | `repeated TokenInfo` | JWT |
+
+`TokenInfo` includes: `id (jti)`, `kind`, `user_id`, `issued_at`, `expires_at`.
+
+Revoked tokens are loaded into an in-memory set on startup and checked in the gRPC interceptor (O(1) per request).
+
+### User Management
+
+| RPC | Input | Output | Auth |
+|-----|-------|--------|------|
+| `CreateUser` | `username, password, node_ids` | `success/error` | JWT |
+| `UpdateUser` | `username, password?, node_ids?` | `success/error` | JWT |
+| `DeleteUser` | `username` | `success/error` | JWT |
+| `ListUsers` | — | `repeated UserInfo` | JWT |
+
+`UserInfo` includes: `username`, `node_ids`, `created_at`, `updated_at`, `disabled`.
+
+Update semantics:
+- `password` empty → leave unchanged
+- `node_ids` nil → leave unchanged
+- `node_ids` empty list → clear all node access
+
+## Authentication Flow
+
+### JWT Structure
+
+```
+Header: {"alg": "HS256", "typ": "JWT"}
+Payload: {
+  "sub": "gary",           // username
+  "node_ids": ["*"],       // allowed nodes
+  "jti": "uuid-...",       // unique token ID
+  "exp": 1234567890,       // expiry
+  "iat": 1234567890        // issued at
+}
+```
+
+### gRPC Interceptor
+
+All authenticated RPCs pass through a unary/stream interceptor that:
+
+1. Extracts `authorization: Bearer <token>` from gRPC metadata
+2. Verifies JWT signature (HMAC-SHA256)
+3. Checks expiry
+4. Checks if JTI is in the revoked set → `UNAUTHENTICATED`
+5. Injects claims into context
+
+**Bypass exceptions:**
+- `ManagementService/Login` — no auth required
+- `ControlService/Connect` — agent token validated in handler
+
+## Wire Patterns
+
+| Operation | CLI → Server | Server → Agent | Streaming |
+|-----------|-------------|----------------|-----------|
+| `exec` | Unary request → server stream | TaskSignal + HandleTask bidi | stdout/stderr chunks |
+| `read` | Unary request → server stream | TaskSignal + HandleTask bidi | file chunks |
+| `write` | Client stream → unary response | TaskSignal + HandleTask bidi | file chunks |
+| `forward` | Bidi stream | TaskSignal + HandleTask bidi | raw TCP bytes |
+| `node list` | Unary | — | — |
+| `login` | Unary | — | — |
+| `user create` | Unary | — | — |

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,0 +1,169 @@
+# Quick Start Guide
+
+Get Axon running in under 5 minutes: a server, an agent, and your first remote command.
+
+> [中文版 / Chinese](zh/quickstart.md)
+
+## Prerequisites
+
+- Go 1.25+ installed
+- Two machines (or two terminals on the same machine for testing)
+
+## 1. Build
+
+```bash
+git clone https://github.com/garysng/axon.git
+cd axon
+make build
+```
+
+This produces three binaries in `bin/`:
+
+| Binary | Purpose |
+|--------|---------|
+| `axon` | CLI for humans and AI agents |
+| `axon-server` | Central control plane |
+| `axon-agent` | Daemon on each target machine |
+
+## 2. Start the Server
+
+Create a minimal config file:
+
+```yaml
+# server.yaml
+listen: ":9090"
+
+auth:
+  jwt_signing_key: "your-secret-key-change-me"
+
+users:
+  - username: admin
+    password_hash: "$2a$10$..."   # bcrypt hash of your password
+    node_ids: ["*"]               # access to all nodes
+```
+
+Generate a bcrypt hash for your password:
+
+```bash
+# Using htpasswd (Apache utils)
+htpasswd -nbBC 10 "" your-password | cut -d: -f2
+
+# Or using Python
+python3 -c "import bcrypt; print(bcrypt.hashpw(b'your-password', bcrypt.gensalt()).decode())"
+```
+
+Start the server:
+
+```bash
+./bin/axon-server --config server.yaml
+```
+
+You should see:
+
+```
+server: auto-TLS: generated CA cert ~/.axon-server/tls/ca.crt (SHA-256: AA:BB:CC:...)
+server: gRPC listening on :9090 (TLS)
+```
+
+**Auto-TLS** generates a self-signed CA and server certificate automatically. No manual cert setup needed for getting started.
+
+## 3. Connect an Agent
+
+On the target machine (or another terminal), start the agent:
+
+```bash
+./bin/axon-agent start \
+  --server localhost:9090 \
+  --token your-agent-token \
+  --name my-node \
+  --tls-insecure    # for testing with self-signed certs
+```
+
+Or use the CA certificate for proper TLS verification:
+
+```bash
+./bin/axon-agent start \
+  --server localhost:9090 \
+  --token your-agent-token \
+  --name my-node \
+  --ca-cert ~/.axon-server/tls/ca.crt
+```
+
+The agent connects to the server and registers itself.
+
+## 4. CLI Login
+
+```bash
+# Point CLI at the server
+./bin/axon config set server localhost:9090
+
+# Login (prompts for username/password)
+./bin/axon auth login --tls-insecure
+```
+
+Or with the CA certificate:
+
+```bash
+./bin/axon auth login --ca-cert ~/.axon-server/tls/ca.crt
+```
+
+## 5. Run Commands
+
+```bash
+# List connected nodes
+axon node list
+
+# Execute a command on a remote node
+axon exec my-node "hostname"
+axon exec my-node "ls -la /tmp"
+
+# Read a file
+axon read my-node /etc/hostname
+
+# Write a file
+echo "hello from axon" | axon write my-node /tmp/hello.txt
+
+# Port forward
+axon forward my-node 8080:80
+# Now localhost:8080 → my-node:80
+```
+
+## 6. Manage Users (Optional)
+
+```bash
+# Create a new user
+axon user create deploy-bot --node-ids web-1,web-2
+
+# List users
+axon user list
+
+# Update node access
+axon user update deploy-bot --node-ids web-1,web-2,db-1
+
+# Delete a user
+axon user delete deploy-bot
+```
+
+## 7. Manage Tokens (Optional)
+
+```bash
+# List issued tokens
+axon auth list-tokens
+
+# Revoke a token
+axon auth revoke <token-id>
+```
+
+## TLS Options
+
+| Scenario | Server Config | Client/Agent Flag |
+|----------|--------------|-------------------|
+| Auto-TLS (default) | No `tls.cert`/`tls.key` → auto-generates | `--ca-cert ~/.axon-server/tls/ca.crt` |
+| Bring your own cert | `tls.cert` + `tls.key` in config | System CA pool or `--ca-cert` |
+| Disable TLS (dev only) | `tls.auto: false` (no cert/key) | `--tls-insecure` |
+
+## What's Next?
+
+- [Configuration Reference](configuration.md) — all config options for server, agent, and CLI
+- [Architecture Overview](architecture.md) — how the components fit together
+- [CLI Reference](cli.md) — full command reference

--- a/docs/server.md
+++ b/docs/server.md
@@ -1,8 +1,10 @@
 # Axon Server Design
 
+> [中文版 / Chinese](zh/server.md)
+
 ## Overview
 
-`axon-server` is the central control plane. Single binary, self-hosted. Manages node registration, authentication, request routing, and audit logging.
+`axon-server` is the central control plane. Single binary, self-hosted. Manages node registration, authentication, request routing, persistence, TLS, and audit logging.
 
 **All traffic flows through the server. CLI and Agent never communicate directly.**
 
@@ -22,12 +24,13 @@
 │  └────┬───────────────────────────┬───────┘  │
 │       │                           │          │
 │  ┌────▼─────┐             ┌──────▼───────┐  │
-│  │ Registry │             │ Auth (JWT)   │  │
-│  │          │             │              │  │
-│  │ node_id  │             │ sign/verify  │  │
-│  │ status   │             │ token scope  │  │
-│  │ streams  │             └──────────────┘  │
-│  └────┬─────┘                                │
+│  │ Registry │             │ Auth         │  │
+│  │ (SQLite) │             │ JWT + Users  │  │
+│  │          │             │ + Tokens     │  │
+│  │ node_id  │             │              │  │
+│  │ status   │             │ sign/verify  │  │
+│  │ streams  │             │ revocation   │  │
+│  └────┬─────┘             └──────────────┘  │
 │       │                                      │
 │  ┌────▼─────┐                                │
 │  │ Audit    │                                │
@@ -40,52 +43,48 @@
 
 ### 1. gRPC API Layer
 
-Exposes three gRPC services (see [protocol.md](protocol.md)):
+Single gRPC server on one port. All three services registered on the same server.
 
 | Service | Source | Description |
 |---------|--------|-------------|
-| `ControlService` | Agent | Agent registration, heartbeat, task dispatch |
+| `ControlService` | Agent | Registration, heartbeat, task dispatch |
 | `OperationsService` | CLI | exec, read, write, forward |
-| `ManagementService` | CLI | node list/info/remove, auth login |
+| `ManagementService` | CLI | Node/user/token management, auth login |
 
-Single gRPC server on one port (default: 443). All three services registered on the same server.
+### 2. Node Registry (SQLite-backed)
 
-### 2. Node Registry
+Persistent registry of all known nodes.
 
-In-memory registry of all known nodes.
-
-```go
-type NodeEntry struct {
-    NodeID        string
-    NodeName      string
-    Status        string            // "online" | "offline"
-    Info          NodeInfo          // hostname, arch, IP, version, uptime, OS info
-    Labels        map[string]string
-    ControlStream grpc.BidiStream   // Reference to active control stream
-    ConnectedAt   time.Time
-    LastHeartbeat time.Time
-    RegisteredAt  time.Time
-}
+```sql
+CREATE TABLE nodes (
+    node_id      TEXT PRIMARY KEY,
+    node_name    TEXT NOT NULL,
+    status       TEXT NOT NULL DEFAULT 'offline',
+    token_hash   TEXT NOT NULL,
+    info_json    TEXT,
+    labels_json  TEXT,
+    connected_at INTEGER,
+    last_heartbeat INTEGER,
+    registered_at INTEGER NOT NULL
+);
+CREATE UNIQUE INDEX idx_nodes_name ON nodes(node_name);
 ```
 
 **Operations:**
 
 | Operation | Trigger | Description |
 |-----------|---------|-------------|
-| Register | Agent connects | Add/update node entry, set status = online |
-| Heartbeat update | Agent heartbeat | Update `LastHeartbeat` |
-| Mark offline | Heartbeat timeout | Set status = offline, clear ControlStream ref |
-| Remove | `axon node remove` | Delete entry entirely, disconnect agent |
+| Register | Agent connects | Upsert node entry, set status = online |
+| Heartbeat update | Agent heartbeat | Batched updates (30s flush interval) |
+| Mark offline | Heartbeat timeout | Set status = offline, clear stream ref |
+| Remove | `axon node remove` | Delete entry, disconnect agent |
 | List | `axon node list` | Return all entries |
-| Lookup | Any CLI operation | Find node by name or ID |
 
-**Persistence:**
-- Phase 1: in-memory only. Nodes re-register on server restart.
-- Phase 2: persist to SQLite for fast recovery.
+**Stable Node Identity:** Nodes get a UUID `node_id` on first registration, persisted in the agent's local config. On reconnect, server recognizes returning nodes by `node_id`.
 
-**Heartbeat timeout detection:**
-- Background goroutine checks every 5 seconds
-- If `time.Now() - LastHeartbeat > 3 × heartbeat_interval` → mark offline
+**Heartbeat Batching:** Heartbeat timestamps are batched in memory and flushed to SQLite every 30 seconds (plus graceful-shutdown flush) to reduce write pressure.
+
+**Startup Behavior:** On server start, all persisted nodes are loaded and marked `offline`. They return to `online` when agents reconnect.
 
 ### 3. Router
 
@@ -96,89 +95,86 @@ CLI request (exec web-1 "ls")
     │
     ▼
 Router:
-    1. Authenticate: verify JWT token from gRPC metadata
-    2. Authorize: check token.node_ids contains "web-1"
-    3. Lookup: find "web-1" in Registry
-    4. Check status: if offline → return UNAVAILABLE
+    1. Authenticate: verify JWT token (interceptor)
+    2. Authorize: check token.node_ids contains target
+    3. Lookup: find node in Registry
+    4. Check status: if offline → UNAVAILABLE
     5. Dispatch: send TaskSignal via control stream
     6. Bridge: proxy data between CLI stream and Agent data stream
 ```
 
-**Stream bridging for operations:**
-
-```
-CLI gRPC stream ←──→ Server (bridge) ←──→ Agent gRPC stream
-```
-
-Server acts as a transparent proxy:
-- exec: forward ExecOutput from Agent stream to CLI stream
-- read: forward ReadOutput from Agent stream to CLI stream
-- write: forward WriteInput from CLI stream to Agent stream
-- forward: bidirectional relay of TunnelData between CLI and Agent streams
-
 ### 4. Auth Module
 
-JWT-based authentication.
+JWT-based authentication with token lifecycle management.
 
 **Token types:**
 
-| Type | Issued to | Contains | Used for |
-|------|-----------|----------|----------|
-| CLI Token | Users/agents | `user_id`, `node_ids[]`, `exp`, `iat` | CLI → Server auth |
-| Agent Token | Nodes | `node_id`, `exp` | Agent registration (one-time) |
+| Type | Contains | Lifetime |
+|------|----------|----------|
+| CLI Token | `sub` (username), `node_ids`, `jti`, `exp`, `iat` | Default 24h |
+| Agent Token | `node_id` | Registration |
 
-**Server-side:**
+**gRPC Interceptor:**
 
-```go
-type AuthConfig struct {
-    JWTSigningKey string        // HMAC-SHA256 key
-    TokenExpiry   time.Duration // Default: 24h for CLI tokens
-}
-```
-
-**Token validation flow:**
-
-```
-1. Extract token from gRPC metadata ("authorization: Bearer <token>")
-2. Verify JWT signature
+All RPCs (except `Login` and `Connect`) pass through interceptors that:
+1. Extract bearer token from gRPC metadata
+2. Verify HMAC-SHA256 signature
 3. Check expiry
-4. For CLI tokens: extract node_ids, pass to Router for authorization
-5. For Agent tokens: extract node_id, pass to Registry for registration
+4. Check JTI against revoked set (O(1) in-memory lookup)
+5. Inject claims into context
+
+**Token Store (SQLite):**
+
+```sql
+CREATE TABLE tokens (
+    id         TEXT PRIMARY KEY,    -- JTI
+    kind       TEXT NOT NULL,       -- "cli" or "agent"
+    user_id    TEXT,
+    node_ids   TEXT,                -- JSON array
+    issued_at  INTEGER NOT NULL,
+    expires_at INTEGER NOT NULL,
+    revoked    INTEGER NOT NULL DEFAULT 0
+);
 ```
 
-**Login flow (Phase 1):**
+On Login, the issued token is persisted. On startup, revoked JTIs are loaded into an in-memory set.
 
-```
-CLI sends LoginRequest{username, password}
-    │
-    ▼
-Server validates against local user store (config file or SQLite)
-    │
-    ▼
-Server signs JWT with user_id + allowed node_ids
-    │
-    ▼
-Returns LoginResponse{token, expires_at}
-```
+### 5. User Store (SQLite)
 
-**User store (Phase 1):**
+Persistent user management replacing the config-file-only approach.
 
-```yaml
-# axon-server config
-users:
-  - username: gary
-    password_hash: "$2a$10$..."   # bcrypt
-    node_ids: ["*"]               # Access to all nodes
-  - username: deploy-agent
-    password_hash: "$2a$10$..."
-    node_ids: ["web-1", "web-2"]  # Restricted access
+```sql
+CREATE TABLE users (
+    username      TEXT PRIMARY KEY,
+    password_hash TEXT NOT NULL,     -- bcrypt
+    node_ids      TEXT NOT NULL,     -- JSON array
+    created_at    INTEGER NOT NULL,
+    updated_at    INTEGER NOT NULL,
+    disabled      INTEGER NOT NULL DEFAULT 0
+);
 ```
 
-### 5. Audit Logger
+**Bootstrap:** Users defined in the config YAML are seeded on startup via `INSERT OR IGNORE` — existing DB users are not overwritten. After bootstrap, users are managed via gRPC RPCs (`CreateUser`, `UpdateUser`, `DeleteUser`, `ListUsers`).
 
-Logs every operation that passes through the server.
+**Login flow:** Server looks up user in SQLite, checks `disabled` flag, verifies bcrypt password, signs JWT with JTI, persists token to store.
 
-**Log entry:**
+### 6. TLS
+
+**Auto-TLS (default):** When no explicit `tls.cert`/`tls.key` is configured:
+
+1. Check `tls.dir` (default `~/.axon-server/tls/`) for `ca.crt`
+2. If missing: generate ECDSA P-256 CA (10-year) + server cert (1-year)
+3. If `ca.crt` exists but `server.crt` missing or expires within 30 days: regenerate server cert
+4. Log CA path + SHA-256 fingerprint
+5. SANs: always `localhost` + `127.0.0.1` + listen address hostname
+
+**Explicit TLS:** Set `tls.cert` and `tls.key` to use your own certificates.
+
+**Disable TLS:** Set `tls.auto: false` with no cert/key. Server logs a warning.
+
+### 7. Audit Logger
+
+Logs every operation through the server.
 
 ```go
 type AuditEntry struct {
@@ -186,96 +182,64 @@ type AuditEntry struct {
     UserID     string
     NodeID     string
     Action     string    // "exec", "read", "write", "forward", "node.remove"
-    Detail     string    // Command string, file path, or port mapping
+    Detail     string    // command, path, or port
     Result     string    // "success", "error", "timeout"
     DurationMs int64
-    Error      string    // Error message if failed
+    Error      string
 }
 ```
 
-**Storage (Phase 1):** SQLite
+- Storage: SQLite (separate file from data DB)
+- Async write: buffered channel → background writer
+- Non-blocking: audit failure does not block operations
 
-```sql
-CREATE TABLE audit_log (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
-    timestamp TEXT NOT NULL,
-    user_id TEXT NOT NULL,
-    node_id TEXT NOT NULL,
-    action TEXT NOT NULL,
-    detail TEXT,
-    result TEXT NOT NULL,
-    duration_ms INTEGER,
-    error TEXT
-);
+### 8. Shared Database
 
-CREATE INDEX idx_audit_timestamp ON audit_log(timestamp);
-CREATE INDEX idx_audit_node ON audit_log(node_id);
-CREATE INDEX idx_audit_user ON audit_log(user_id);
+All persistent state (except audit) lives in a **single SQLite database** with WAL mode:
+
+```go
+db, err := sql.Open("sqlite", dataDBPath)
+db.Exec("PRAGMA journal_mode=WAL")
+
+registryStore := registry.NewSQLiteStoreFromDB(db)
+tokenStore    := auth.NewTokenStoreFromDB(db)
+userStore     := auth.NewUserStoreFromDB(db)
 ```
 
-**Behavior:**
-- Async write (buffered channel → background writer)
-- Non-blocking: audit failure should not block operations
-- Retention: configurable, default keep all (Phase 1)
+Each store creates its own tables via `CREATE TABLE IF NOT EXISTS`. The shared connection is closed last in `GracefulStop` after all stores are shut down.
 
 ## Server Config
 
-```yaml
-# /etc/axon-server/config.yaml
-
-listen: ":443"
-
-tls:
-  cert: "/etc/axon-server/tls/server.crt"
-  key: "/etc/axon-server/tls/server.key"
-
-auth:
-  jwt_signing_key: "${AXON_JWT_KEY}"      # From environment variable
-  token_expiry: "24h"
-
-users:
-  - username: gary
-    password_hash: "$2a$10$..."
-    node_ids: ["*"]
-
-heartbeat:
-  interval_seconds: 10       # Sent to agents
-  timeout_multiplier: 3      # offline after 3× missed heartbeats
-
-audit:
-  db_path: "/var/lib/axon-server/audit.db"
-
-agent_tokens:
-  - token: "${AXON_AGENT_TOKEN_1}"
-    allowed_node_name: "web-1"    # Optional: restrict which name this token can register
-  - token: "${AXON_AGENT_TOKEN_2}"
-    allowed_node_name: ""         # Empty = any name
-```
+See [Configuration Reference](configuration.md) for the full YAML spec.
 
 ## Startup Sequence
 
 ```
 1. Load config (file + env vars)
-2. Initialize SQLite (audit log)
-3. Initialize node registry (empty)
-4. Initialize auth module (load signing key, user store)
-5. Start gRPC server (TLS)
-   - Register ControlService
-   - Register OperationsService
-   - Register ManagementService
-6. Start heartbeat monitor (background goroutine)
-7. Ready
+2. Open shared SQLite database (WAL mode)
+3. Initialize registry store → load all nodes (mark offline)
+4. Initialize token store → load revoked JTIs into memory
+5. Initialize token checker
+6. Initialize user store → bootstrap config users (INSERT OR IGNORE)
+7. Auto-TLS: generate or load certificates
+8. Build gRPC server with auth interceptors
+9. Initialize audit store + writer
+10. Register all gRPC services
+11. Start heartbeat monitor (background goroutine)
+12. Serve
 ```
 
 ## Graceful Shutdown
 
 ```
 1. Stop accepting new connections
-2. Wait for in-flight RPCs to complete (with timeout)
-3. Close all agent control streams (agents will reconnect)
-4. Flush audit log buffer
-5. Close SQLite
-6. Exit
+2. GracefulStop gRPC (wait for in-flight RPCs)
+3. Close audit writer (flush buffer)
+4. Close user store
+5. Close token store
+6. Close registry (flush heartbeat batch)
+7. Close shared database
+8. Exit
 ```
 
 ## Command
@@ -284,19 +248,15 @@ agent_tokens:
 
 ```
 $ axon-server start --config /etc/axon-server/config.yaml
-[INFO] loading config from /etc/axon-server/config.yaml
-[INFO] audit database initialized at /var/lib/axon-server/audit.db
-[INFO] gRPC server listening on :443 (TLS)
-[INFO] ready
+[INFO] server: auto-TLS: generated CA cert ~/.axon-server/tls/ca.crt (SHA-256: AA:BB:...)
+[INFO] server: gRPC listening on :9090 (TLS)
 ```
 
-- **Flags**:
-  - `--config <path>` — config file path (default: `./config.yaml`)
-  - `--foreground` — run in foreground
+- **Flags**: `--config <path>` — config file path (default: `./config.yaml`)
 
 ### `axon-server version`
 
 ```
 $ axon-server version
-axon-server 0.1.0 (go1.22, linux/amd64)
+axon-server 0.1.0 (go1.25, darwin/arm64)
 ```

--- a/docs/zh/agent.md
+++ b/docs/zh/agent.md
@@ -1,12 +1,14 @@
 # Axon Agent 设计
 
+> [English Version](../agent.md)
+
 ## 概述
 
-`axon-agent` 是安装在每台目标机器上的轻量 daemon。它反向连接 axon-server，注册自身，维持心跳，响应 Server 派发的任务。
+`axon-agent` 是安装在目标机器上的轻量守护进程。反向连接 axon-server，注册自身，维持心跳，响应 Server 分发的任务。
 
-**Agent 不主动发起操作。它只响应 Server 下发的任务。**
+**Agent 不主动发起操作，只响应 Server 分发的任务。**
 
-## Agent 生命周期
+## 生命周期
 
 ```
 安装二进制
@@ -16,266 +18,83 @@ axon-agent start --server <addr> --token <token> [--name <name>]
     │
     ├── 首次运行：
     │   1. 保存配置到 ~/.axon-agent/config.yaml
-    │   2. 连接 Server（gRPC TLS）
-    │   3. 发送 RegisterRequest（token + 节点信息）
+    │   2. 连接 Server（gRPC + TLS）
+    │   3. 发送 RegisterRequest（token + 节点名 + 系统信息）
     │   4. 收到 RegisterResponse（node_id + 心跳间隔）
-    │   5. 开始心跳循环
+    │   5. 保存 node_id（稳定身份）
     │
     ├── 后续运行：
-    │   1. 从 ~/.axon-agent/config.yaml 读取配置
+    │   1. 读取本地配置
     │   2. 连接 Server
-    │   3. 重新注册（Server 通过 node_id 识别回归节点）
-    │   4. 开始心跳循环
+    │   3. 用已有 node_id 重新注册
     │
     ▼
 运行中（等待任务）
-    ├── 每 N 秒发送心跳（N 由 Server 配置）
-    ├── 定期上报节点信息（或变更时上报）
-    ├── 执行任务（按需）
-    │
-    ├── 连接断开 → 指数退避重连
-    │   初始：1s，最大：60s，抖动：±20%
-    │
-    ▼
-停止
-    ├── axon-agent stop → 优雅关闭
-    │   - 完成进行中的任务（有超时）
-    │   - 关闭 gRPC stream
-    │   - 退出
-    └── kill -9 → Server 通过心跳超时检测 → 标记 offline
+    ├── 定时心跳
+    ├── 系统信息上报
+    ├── 任务执行（按需）
+    ├── 断线重连（指数退避：1s → 2s → 4s → ... → 60s）
 ```
 
 ## 配置
 
-存储在 `~/.axon-agent/config.yaml`：
+`~/.axon-agent/config.yaml`：
 
 ```yaml
-server: "axon.example.com:443"
+server: "axon.example.com:9090"
 token: "agent-token-xxx"
-node_id: "a1b2c3d4"           # 首次注册后由 Server 分配
-node_name: "web-1"            # 用户指定或使用 hostname
+node_id: "a1b2c3d4"           # Server 分配的稳定 ID
+node_name: "web-1"
 labels:
   env: production
   role: web
+ca_cert: "/path/to/ca.crt"    # TLS 验证用的 CA 证书
+tls_insecure: false
 ```
 
-- `token`：用于初始注册，由 Server 验证
-- `node_id`：首次注册后持久化，用于重连时的身份识别
-- `node_name`：未指定时默认使用 hostname
-- `labels`：可选的键值对，便于节点分组
+详见 [配置参考](configuration.md)。
 
-## 命令
+## TLS
 
-### `axon-agent start`
+Agent 的 TLS 三路选择：
 
-启动 Agent daemon。
+| 优先级 | 条件 | 行为 |
+|--------|------|------|
+| 1 | `tls_insecure: true` | 不验证 TLS |
+| 2 | `ca_cert` 已设置 | 用指定 CA 验证服务端证书 |
+| 3 | 都未设置 | 用系统 CA 池验证 |
 
-```
-$ axon-agent start --server axon.example.com:443 --token <token>
-[INFO] connecting to axon.example.com:443...
-[INFO] registered as node "web-1" (id: a1b2c3d4)
-[INFO] heartbeat interval: 10s
-[INFO] ready, waiting for tasks
-
-# 后续启动（配置已保存）：
-$ axon-agent start
-[INFO] connecting to axon.example.com:443...
-[INFO] reconnected as node "web-1" (id: a1b2c3d4)
-[INFO] ready, waiting for tasks
-```
-
-- **Server**：✅ 需要
-- **参数**：
-  - `--server <address>` — Server 地址（首次运行时，保存到配置）
-  - `--token <token>` — Agent token（首次运行时，保存到配置）
-  - `--name <name>` — 节点名（可选，默认用 hostname）
-  - `--labels key=value` — 标签（可重复）
-  - `--foreground` — 前台运行（默认：守护进程）
-
-### `axon-agent stop`
-
-停止 Agent daemon。
-
-```
-$ axon-agent stop
-[INFO] shutting down...
-[INFO] completing 2 in-flight tasks...
-[INFO] stopped
-```
-
-- **Server**：❌ 仅本地
-- **行为**：向 daemon 进程发送 SIGTERM，等待优雅关闭
-
-### `axon-agent status`
-
-显示 Agent 状态。
-
-```
-$ axon-agent status
-Status:      running
-Server:      axon.example.com:443
-Connection:  connected
-Node ID:     a1b2c3d4
-Node Name:   web-1
-Uptime:      3d 12h 5m
-Last Heartbeat: 2s ago
-Active Tasks: 0
-```
-
-- **Server**：本地进程检查 + 连接健康 ping
-- **参数**：
-  - `--json` — JSON 输出
-
-### `axon-agent config set/get`
-
-管理本地配置。
-
-```
-$ axon-agent config set labels.env staging
-$ axon-agent config get server
-axon.example.com:443
-```
-
-- **Server**：❌ 仅本地
-
-### `axon-agent version`
-
-```
-$ axon-agent version
-axon-agent 0.1.0 (go1.22, linux/amd64)
-```
-
-- **Server**：❌ 仅本地
+**Auto-TLS 场景下**：将 Server 的 `~/.axon-server/tls/ca.crt` 复制到 Agent 机器，配置 `ca_cert`。
 
 ## 任务执行
 
-Agent 通过控制面 stream 接收任务信号，然后开操作面 stream 执行任务。
+### exec
 
-### Exec
+收到 TaskSignal → 开 HandleTask stream → 收到命令 → 创建子进程 → 流式输出 stdout/stderr → 发送退出码
 
-```
-1. Server 通过控制 stream 发送 TaskSignal{task_id, TASK_EXEC}
-2. Agent 开操作面 stream，接收 ExecRequest{command, env, workdir, timeout}
-3. Agent 启动本地进程：
-   - os/exec.Command(shell, "-c", command)
-   - 管道 stdout/stderr
-   - 设置环境变量
-   - 设置工作目录
-4. 流式回传 stdout/stderr 块作为 ExecOutput 消息
-5. 进程退出 → 发送 ExecExit{exit_code} → 关闭 stream
-```
+### read
 
-**进程管理：**
-- 每个 exec 作为 Agent 的子进程运行
-- Agent 继承启动用户的权限（Phase 1 不做沙箱）
-- 超时：Agent 先发 SIGTERM，5 秒后 SIGKILL
-- 取消：gRPC context cancel → SIGTERM → SIGKILL
+收到 TaskSignal → 开 HandleTask stream → stat 文件 → 发送元数据 → 分块读取（32KB）→ 流式发送
 
-### Read
+### write
 
-```
-1. Server 发送 TaskSignal{task_id, TASK_READ}
-2. Agent 开操作面 stream，接收 ReadRequest{path}
-3. Agent stat() 文件 → 发送 ReadMeta{size, mode, mtime}
-4. 打开文件，分块读取（默认 32KB）→ 每块发送 ReadOutput{data}
-5. EOF → 关闭 stream
-```
+收到 TaskSignal → 开 HandleTask stream → 收到文件头 → 创建文件 → 接收数据块 → 原子写入（临时文件 + rename）
 
-**错误情况：**
-- 文件不存在 → gRPC NOT_FOUND
-- 权限不足 → gRPC PERMISSION_DENIED
-- 是目录 → gRPC INVALID_ARGUMENT
+### forward
 
-### Write
+收到 TaskSignal → 开 HandleTask stream → 连接本地端口 → 双向中继 TunnelData ↔ TCP
 
-```
-1. Server 发送 TaskSignal{task_id, TASK_WRITE}
-2. Agent 开操作面 stream，接收 WriteHeader{path, mode}
-3. 创建/截断文件，设置指定权限
-4. 接收 WriteInput{data} 块 → 写入文件
-5. 客户端关闭 stream → Agent 返回 WriteResponse{success, bytes_written}
-```
+## 系统信息采集
 
-**行为：**
-- 父目录不存在时自动创建
-- 原子写入：先写临时文件，再 rename（防止写入一半失败）
-- 默认权限：0644
+Agent 上报 `NodeInfo`（主机名、架构、IP、运行时间、Agent 版本、OS 详情）：
 
-### Forward
+- **Linux**：`/etc/os-release` + `uname`
+- **macOS**：`sw_vers` + `uname`
+- **Windows**：`RtlGetVersion`
 
-```
-1. Server 发送 TaskSignal{task_id, TASK_FORWARD}
-2. Agent 开操作面 stream，接收 TunnelOpen{remote_port}
-3. Agent 连接 localhost:<remote_port>（TCP）
-4. 双向中继：
-   - Server 来的 TunnelData{payload} → 写入 TCP 连接
-   - TCP 连接读取的数据 → 发送 TunnelData{payload} 给 Server
-5. 任一端关闭 → 发送 TunnelData{close} → 清理
-```
+## systemd 示例
 
-**错误情况：**
-- 无法连接目标端口 → gRPC UNAVAILABLE 并附错误详情
-- 连接重置 → TunnelData{close}
-
-## 心跳与节点信息
-
-### 心跳
-
-- Agent 每 N 秒发送 `Heartbeat{timestamp}`
-- N 由 Server 在 `RegisterResponse.heartbeat_interval_seconds` 中配置
-- 默认：10 秒
-- Server 在 3 倍间隔（默认 30 秒）内未收到心跳 → 标记节点 offline
-
-### 节点信息上报
-
-Agent 在以下时机上报 `NodeInfo`（包含详细的 `OSInfo`：内核名称、内核版本、发行版、发行版版本、可读名称）：
-1. 注册时（初始上报）
-2. 定期更新（每 5 分钟，或可配置）
-3. 发生重要变更时（如 IP 变化、OS 升级等）
-
-OS 信息通过标准系统调用采集：
-- **Linux**：`/etc/os-release` 获取发行版信息，`uname` 获取内核信息
-- **macOS**：`sw_vers` 获取版本，`uname` 获取内核信息
-- **Windows**：`RtlGetVersion` 获取 OS 版本信息
-
-## 重连
-
-连接断开时：
-
-```
-第 1 次：等 1s    → 重连
-第 2 次：等 2s    → 重连
-第 3 次：等 4s    → 重连
-...
-第 N 次：等 min(2^N, 60)s ± 20% 抖动 → 重连
-```
-
-重连成功后：
-- 用已有的 `node_id` 重新注册（Server 识别回归节点）
-- 恢复心跳
-- 断连时进行中的任务视为失败
-
-## 安全
-
-### Phase 1（当前）
-
-- Agent 以启动它的用户身份运行
-- 不过滤命令，不限制路径
-- 所有 exec/read/write 权限 = Agent 进程用户权限
-- 信任边界：如果你有绑定到某节点的有效 CLI token，你可以做该 Agent 用户能做的任何事
-
-### Phase 2（未来）
-
-- 命令白名单/黑名单
-- 路径限制（允许的目录）
-- 资源限制（CPU、内存、每个 exec 的时间限制）
-
-## 系统服务
-
-生产环境中 Agent 应作为系统服务运行：
-
-```bash
-# systemd 示例
+```ini
 [Unit]
 Description=Axon Agent
 After=network.target
@@ -285,17 +104,8 @@ ExecStart=/usr/local/bin/axon-agent start --foreground
 Restart=always
 RestartSec=5
 User=axon
+Environment=AXON_CA_CERT=/etc/axon-agent/ca.crt
 
 [Install]
 WantedBy=multi-user.target
 ```
-
-## 命令总表
-
-| 命令 | 需要 Server | 说明 |
-|------|:----------:|------|
-| `start` | ✅ | 启动 daemon，连接并注册 |
-| `stop` | ❌ | 停止 daemon（优雅关闭） |
-| `status` | ⚠️ | 本地 + 连接健康检查 |
-| `config set/get` | ❌ | 本地配置 |
-| `version` | ❌ | 本地版本 |

--- a/docs/zh/architecture.md
+++ b/docs/zh/architecture.md
@@ -1,19 +1,21 @@
-# Axon 架构总览
+# Axon 架构概览
+
+> [English Version](../architecture.md)
 
 ## 组件
 
-Axon 由三个组件组成，每个构建为单一静态二进制文件。
+Axon 由三个组件组成，每个都是单一静态二进制文件。
 
 ```
 axon-cli ── gRPC ──→ axon-server ←── gRPC ── axon-agent
                      (控制面)              (反向连接)
 ```
 
-| 组件 | 二进制文件 | 职责 |
-|------|-----------|------|
-| **axon-cli** | `axon` | 用户/Agent 操作接口。无状态。通过 gRPC 与 Server 通信。 |
-| **axon-server** | `axon-server` | 中央控制面。节点注册、认证、路由、审计。 |
-| **axon-agent** | `axon-agent` | 目标机器上的轻量 daemon。反向连接 Server。 |
+| 组件 | 二进制 | 角色 |
+|------|--------|------|
+| **axon-cli** | `axon` | 用户/Agent 接口，无状态，通过 gRPC 与 Server 通信 |
+| **axon-server** | `axon-server` | 中心控制面，节点注册、认证、路由、审计 |
+| **axon-agent** | `axon-agent` | 目标机器上的轻量守护进程，反向连接 Server |
 
 ## 通信
 
@@ -21,50 +23,31 @@ axon-cli ── gRPC ──→ axon-server ←── gRPC ── axon-agent
 
 | 链路 | 协议 | 模式 | 原因 |
 |------|------|------|------|
-| CLI → Server | gRPC | unary + server/client/bidi stream | exec 需要流式输出；forward 需要双向流 |
-| Agent → Server（控制面） | gRPC | BiDi stream（长连接） | 心跳、注册、节点信息上报 |
-| Agent → Server（操作面） | gRPC | 按需 stream | exec/read/write/forward 每个任务独立 stream |
-
-多个 gRPC stream 共享一条 HTTP/2 TCP 连接 —— 不会连接爆炸。
-
-### 为什么全部用 gRPC？
-
-1. `exec` 需要流式输出 stdout/stderr —— gRPC server stream 原生支持
-2. `forward` 需要双向数据流 —— gRPC bidi stream 原生支持
-3. Agent 反向连接需要长连接 —— gRPC bidi stream 原生支持
-4. 用 HTTP 需要 SSE + WebSocket + chunked transfer 三种补丁 —— 不如统一一套协议
-5. 统一技术栈：一套 proto 定义、一套 TLS 配置、一套代码生成
-
-未来的 HTTP/REST 接入（Web 控制台、第三方集成）通过 grpc-gateway 层实现，Phase 3 再做。
+| CLI → Server | gRPC | unary + 各种 stream | exec 需要流式，forward 需要双向 |
+| Agent → Server（控制面）| gRPC | BiDi stream（长连接）| 心跳、注册、节点信息 |
+| Agent → Server（数据面）| gRPC | 按任务独立 stream | exec/read/write/forward 各自独立 |
 
 ## 连接模型
 
-Agent **主动外连** Server。节点上不需要开入站端口。
+Agent **主动外连** Server，节点不需要开放入站端口。
 
 ```
-axon-agent ──── 主动 gRPC 外连 ────→ axon-server ←──── gRPC ──── axon-cli
-   (NAT/防火墙后面)                    (公网)              (任何位置)
+axon-agent ──── 主动 gRPC ────→ axon-server ←──── gRPC ──── axon-cli
+   (NAT/防火墙后)                 (公网)             (任意位置)
 ```
 
-这意味着：
-- 不需要暴露 SSH 端口
-- NAT 后面、企业防火墙后面、边缘网络都能用
-- 云主机、本地服务器、边缘设备 —— 全部一样
-
-## 控制面 vs 操作面
-
-Agent 在同一条 HTTP/2 连接上维护两个逻辑通道：
+## 控制面 vs 数据面
 
 ```
 ┌─────────── HTTP/2 连接 ─────────────┐
 │                                      │
-│  控制面（1 条长连接 stream）           │
-│  ├── 注册（连接时）                   │
-│  ├── 心跳（定时）                     │
-│  └── 节点信息上报（定时）              │
+│  控制面（1 个长连接 stream）           │
+│  ├── 注册                            │
+│  ├── 心跳                            │
+│  └── 节点信息上报                     │
 │                                      │
-│  操作面（按需 stream）                │
-│  ├── exec stream（每个命令）          │
+│  数据面（按需 stream）                │
+│  ├── exec stream（每条命令）          │
 │  ├── read stream（每个文件）          │
 │  ├── write stream（每个文件）         │
 │  └── forward stream（每个 TCP 连接）  │
@@ -72,64 +55,82 @@ Agent 在同一条 HTTP/2 连接上维护两个逻辑通道：
 └──────────────────────────────────────┘
 ```
 
-控制面 stream 生命周期 = Agent 进程生命周期。
-操作面 stream 生命周期 = 单个任务生命周期。
-
 ## 认证
 
-基于 JWT。Server 持有签名密钥。
-
-```
-┌─── CLI Token (JWT) ──┐     ┌─── Agent Token ───────────┐
-│ user_id              │     │ node_id                    │
-│ node_ids: [...]      │     │ server_url                 │
-│ exp                  │     │ (首次启动时使用)             │
-│ iat                  │     └────────────────────────────┘
-└──────────────────────┘
-```
+基于 JWT，Server 持有签名密钥。
 
 | Token 类型 | 作用域 | 生命周期 |
 |-----------|--------|---------|
-| CLI Token | 绑定用户 + 允许的节点列表 | 可配置过期时间 |
-| Agent Token | 绑定节点身份 | 首次注册时使用，之后基于会话 |
+| CLI Token | 绑定用户 + 允许的节点列表 | 可配置（默认 24h） |
+| Agent Token | 绑定节点身份 | 注册时使用 |
 
-CLI Token 绑定特定节点 —— 一个 token 只能操作其允许的节点列表。
+### Token 管理
+
+- 每个 CLI Token 有唯一 **JTI**（JWT ID）
+- Token 持久化到 SQLite，可列表和吊销
+- 吊销的 Token 在内存中 O(1) 检查（gRPC 拦截器）
+- CLI 命令：`axon auth list-tokens`、`axon auth revoke <id>`
+
+### 用户管理
+
+- 用户存储在 SQLite，bcrypt 密码哈希
+- 配置文件中的引导用户在首次启动时写入（INSERT OR IGNORE）
+- 完整 CRUD：`axon user create/list/update/delete`
+
+## 持久化
+
+所有持久状态存储在**单一共享 SQLite 数据库**（WAL 模式）：
+
+| 表 | 内容 |
+|-----|------|
+| `nodes` | 节点注册表（ID、名称、状态、元数据、token hash） |
+| `tokens` | 已签发的 JWT Token（JTI、类型、用户、节点、时间戳、吊销状态） |
+| `users` | CLI 用户（用户名、密码哈希、节点权限、时间戳、禁用状态） |
+| `audit_log` | 操作审计（独立 SQLite 文件） |
+
+### 节点身份
+
+节点首次注册获得稳定的 `node_id`（UUID），保存在 Agent 本地配置。重连时 Server 通过 `node_id` 识别返回的节点。心跳批量持久化（30s 刷新间隔）。
+
+## TLS
+
+### Auto-TLS（默认）
+
+未配置显式证书时，Server 自动生成：
+- **CA**：ECDSA P-256，10 年有效期
+- **服务端证书**：ECDSA P-256，1 年有效期，30 天内过期自动续签
+- SAN：始终包含 `localhost` + `127.0.0.1` + 配置的主机名
+
+CA 证书需要分发给 Agent 和 CLI 客户端。
+
+### TLS 模式
+
+| 模式 | Server 配置 | 客户端/Agent |
+|------|-----------|------------|
+| Auto-TLS | 默认（不配 cert/key） | `--ca-cert ca.crt` |
+| 自带证书 | `tls.cert` + `tls.key` | 系统 CA 或 `--ca-cert` |
+| 禁用 TLS（开发） | `tls.auto: false` | `--tls-insecure` |
 
 ## 节点状态
 
 | 状态 | 含义 |
 |------|------|
-| **online** | Agent 连接正常，心跳健康 |
+| **online** | Agent 已连接，心跳正常 |
 | **offline** | 心跳超时或连接断开 |
-
-CLI 请求 offline 节点直接返回错误。不排队，不等待。
 
 ## 审计日志
 
-所有经过 Server 的操作都会记录：
-
-```json
-{
-  "timestamp": "2026-03-20T11:22:00Z",
-  "user_id": "gary",
-  "node_id": "web-1",
-  "action": "exec",
-  "command": "docker ps",
-  "result": "success",
-  "duration_ms": 120
-}
-```
-
-存储：SQLite（Phase 1）。后续可扩展到外部存储。
+Server 记录每一个操作：时间戳、调用者、节点、操作、结果、耗时。SQLite 存储，异步写入，不阻塞业务。
 
 ## 技术栈
 
-| 项目 | 选型 |
+| 项目 | 选择 |
 |------|------|
 | 语言 | Go |
-| 通信 | gRPC (HTTP/2)，全链路 |
-| 认证 | JWT |
+| 通信 | gRPC（HTTP/2），全链路 |
+| 认证 | JWT（HMAC-SHA256）+ JTI + 吊销 |
 | 序列化 | Protocol Buffers |
-| 构建 | 单二进制 × 3，跨平台 |
-| 审计存储 | SQLite (Phase 1) |
-| 配置格式 | YAML |
+| 持久化 | SQLite（WAL 模式，单一共享 DB） |
+| TLS | Auto-TLS（ECDSA P-256）或自带证书 |
+| 构建 | 单一二进制 × 3，跨平台 |
+| 配置 | YAML |

--- a/docs/zh/cli.md
+++ b/docs/zh/cli.md
@@ -1,240 +1,112 @@
-# Axon CLI 设计
+# Axon CLI 参考
+
+> [English Version](../cli.md)
 
 ## 概述
 
-`axon` 是一个无状态的单二进制文件。从本地配置中读取 Server 地址和 token，通过 gRPC 与 axon-server 通信。
+`axon` 是一个无状态的单一二进制文件。读取本地配置 `~/.axon/config.yaml` 获取 Server 地址和 Token，通过 gRPC 与 Server 通信。
 
-## 配置
-
-存储在 `~/.axon/config.yaml`：
-
-```yaml
-server: "axon.example.com:443"
-token: "eyJhbGciOiJIUzI1NiIs..."
-```
-
-## 命令
-
-### `axon node list`
-
-列出所有已注册节点。
+## 全局参数
 
 ```
-$ axon node list
-NAME      STATUS   OS                    ARCH    IP             VERSION   LAST SEEN
-web-1     online   Ubuntu 24.04 LTS      amd64   10.0.1.10      0.1.0     2s ago
-db-1      online   CentOS 9              amd64   10.0.1.20      0.1.0     5s ago
-edge-1    offline  Debian 12             arm64   192.168.1.50   0.1.0     2m ago
+--ca-cert <path>     TLS 验证用的 CA 证书路径
+--tls-insecure       跳过 TLS 验证（仅开发用）
 ```
 
-- **Server**：✅ 需要
-- **gRPC**：`ManagementService.ListNodes`（unary）
-- **认证**：gRPC metadata 中的 JWT token
-- **参数**：
-  - `--json` — JSON 输出
-  - `--status <online|offline>` — 按状态过滤
+---
 
-### `axon node info <node>`
+## 节点命令
 
-查看节点详细信息。
+| 命令 | 说明 |
+|------|------|
+| `axon node list` | 列出所有注册节点 |
+| `axon node info <node>` | 查看节点详情 |
+| `axon node remove <node>` | 移除节点 |
 
-```
-$ axon node info web-1
-Name:           web-1
-Status:         online
-OS:             Ubuntu 24.04 LTS (linux 6.8.0-45-generic)
-Arch:           amd64
-IP:             10.0.1.10
-Uptime:         3d 12h 5m
-Agent Version:  0.1.0
-Connected:      2026-03-17 23:15:00 UTC
-Last Heartbeat: 2026-03-20 11:24:58 UTC
-Labels:
-  env: production
-  role: web
-```
+---
 
-- **Server**：✅ 需要
-- **gRPC**：`ManagementService.GetNode`（unary）
-- **参数**：
-  - `--json` — JSON 输出
-
-### `axon node remove <node>`
-
-从注册中心移除节点。如果在线会断开连接。
-
-```
-$ axon node remove edge-1
-Node "edge-1" removed.
-```
-
-- **Server**：✅ 需要
-- **gRPC**：`ManagementService.RemoveNode`（unary）
+## 核心操作
 
 ### `axon exec <node> <command>`
 
-在远程节点上执行命令。stdout/stderr 实时流式返回。
+在远程节点执行命令，实时流式输出 stdout/stderr。
 
-```
-$ axon exec web-1 "docker ps"
-CONTAINER ID   IMAGE     STATUS
-abc123         nginx     Up 2 hours
-
-$ axon exec web-1 "tail -f /var/log/app.log"
-[2026-03-20 11:25:00] request received...
-[2026-03-20 11:25:01] processing...
-^C
+```bash
+axon exec web-1 "docker ps"
+axon exec web-1 "tail -f /var/log/app.log"   # Ctrl+C 停止
 ```
 
-- **Server**：✅ 需要
-- **gRPC**：`OperationsService.Exec`（server stream）
-- **行为**：
-  - stdout → 本地 stdout，stderr → 本地 stderr（保持流分离）
-  - Exit code 原样转发：`axon exec` 的退出码 = 远程命令的退出码
-  - Ctrl+C 向 Server 发送取消（gRPC context cancel）
-  - 长运行命令持续流式输出直到完成或取消
-- **参数**：
-  - `--timeout <seconds>` — 超时后终止命令（0 = 不超时）
-  - `--env KEY=VALUE` — 设置环境变量（可重复）
-  - `--workdir <path>` — 设置工作目录
+参数：`--timeout <seconds>`、`--env KEY=VALUE`、`--workdir <path>`
 
 ### `axon read <node> <path>`
 
-从远程节点读取文件。内容输出到 stdout。
+读取远程文件，输出到 stdout。
 
+```bash
+axon read web-1 /etc/nginx/nginx.conf > local-copy.conf
 ```
-$ axon read web-1 /etc/nginx/nginx.conf
-worker_processes auto;
-events { ... }
-...
-
-$ axon read web-1 /etc/nginx/nginx.conf > local-copy.conf
-```
-
-- **Server**：✅ 需要
-- **gRPC**：`OperationsService.Read`（server stream）
-- **行为**：
-  - 首条消息：文件元信息（大小、权限、修改时间）
-  - 后续消息：文件内容分块传输
-  - 支持二进制文件（原始字节到 stdout）
-- **参数**：
-  - `--meta` — 仅打印文件元信息（大小、权限、修改时间）
-  - `--json` — 元信息以 JSON 格式输出
 
 ### `axon write <node> <path>`
 
-写文件到远程节点。从 stdin 读取内容。
+从 stdin 写入远程文件。
 
-```
-$ axon write web-1 /etc/nginx/nginx.conf < nginx.conf
-Written 2048 bytes to /etc/nginx/nginx.conf
-
-$ echo "hello" | axon write web-1 /tmp/hello.txt
-Written 6 bytes to /tmp/hello.txt
-
-$ cat backup.sql | axon write db-1 /tmp/restore.sql
-Written 15728640 bytes to /tmp/restore.sql
+```bash
+echo "hello" | axon write web-1 /tmp/hello.txt
 ```
 
-- **Server**：✅ 需要
-- **gRPC**：`OperationsService.Write`（client stream）
-- **行为**：
-  - 首条消息：header（路径、文件权限）
-  - 后续消息：文件内容分块传输
-  - 大文件流式传输，不需要全部加载到内存
-- **参数**：
-  - `--mode <perm>` — 文件权限（默认：0644）
+参数：`--mode <perm>`（默认 0644）
 
 ### `axon forward <node> <local-port>:<remote-port>`
 
-将远程端口转发到本地。
+端口转发。
 
-```
-$ axon forward db-1 5432:5432
-Forwarding localhost:5432 → db-1:5432
-Ready. Press Ctrl+C to stop.
-
-# 在另一个终端：
-$ psql -h localhost -p 5432 -U postgres
+```bash
+axon forward db-1 5432:5432
+# localhost:5432 → db-1:5432
 ```
 
-- **Server**：✅ 需要
-- **gRPC**：`OperationsService.Forward`（BiDi stream，每个 TCP 连接一个）
-- **行为**：
-  - CLI 在 `localhost:<local-port>` 上监听
-  - 每个 TCP 连接进来 → 开一个新的 gRPC bidi stream
-  - 原始 TCP 字节封装在 `TunnelData` protobuf 消息中
-  - 双向传输：数据双向流动直到任一端关闭
-  - Ctrl+C 停止监听并关闭所有隧道
-- **参数**：
-  - `--bind <address>` — 绑定地址（默认：`127.0.0.1`）
+参数：`--bind <address>`（默认 127.0.0.1）
 
-### `axon auth login`
+---
 
-向 Server 认证并获取 JWT token。
+## 认证命令
 
-```
-$ axon auth login --server axon.example.com:443
-Username: gary
-Password: ****
-Login successful. Token saved to ~/.axon/config.yaml
-```
+| 命令 | 说明 |
+|------|------|
+| `axon auth login` | 登录获取 JWT Token |
+| `axon auth token` | 显示当前 Token |
+| `axon auth list-tokens` | 列出所有已签发的 Token |
+| `axon auth revoke <id>` | 吊销指定 Token |
+| `axon auth rotate` | \[未实现\] 吊销当前 Token + 重新登录 |
 
-- **Server**：✅ 需要
-- **gRPC**：`ManagementService.Login`（unary）
-- **行为**：
-  - 提示输入用户名/密码（Phase 1）
-  - 保存 token + Server 地址到 `~/.axon/config.yaml`
-- **参数**：
-  - `--server <address>` — Server 地址（保存到配置）
+---
 
-### `axon auth token`
+## 用户命令
 
-显示当前 token。
+| 命令 | 说明 |
+|------|------|
+| `axon user create <username>` | 创建用户（提示输入密码） |
+| `axon user list` | 列出所有用户 |
+| `axon user update <username>` | 更新用户的节点权限或密码 |
+| `axon user delete <username>` | 删除用户（有确认提示） |
 
-```
-$ axon auth token
-eyJhbGciOiJIUzI1NiIs...
-```
+`create` 参数：`--node-ids <ids>`（逗号分隔，默认 `*`）
+`update` 参数：`--node-ids <ids>`、`--password`
+`delete` 参数：`--force` / `-f`（跳过确认）
 
-- **Server**：❌ 仅本地
-- **行为**：读取并打印 `~/.axon/config.yaml` 中的 token
+---
 
-### `axon config set <key> <value>`
+## 配置命令
 
-设置配置项。
-
-```
-$ axon config set server axon.example.com:443
+```bash
+axon config set server axon.example.com:9090
+axon config get server
+axon version
 ```
 
-- **Server**：❌ 仅本地
-- **支持的 key**：`server`、`token`
+---
 
-### `axon config get <key>`
-
-获取配置项。
-
-```
-$ axon config get server
-axon.example.com:443
-```
-
-- **Server**：❌ 仅本地
-
-### `axon version`
-
-打印版本信息。
-
-```
-$ axon version
-axon 0.1.0 (go1.22, linux/amd64)
-```
-
-- **Server**：❌ 仅本地
-- 编译时通过 `-ldflags` 注入
-
-## 命令总表
+## 命令总览
 
 | 命令 | 需要 Server | gRPC 模式 | 需要认证 |
 |------|:----------:|-----------|:-------:|
@@ -245,17 +117,22 @@ axon 0.1.0 (go1.22, linux/amd64)
 | `read` | ✅ | server stream | ✅ |
 | `write` | ✅ | client stream | ✅ |
 | `forward` | ✅ | bidi stream | ✅ |
-| `auth login` | ✅ | unary | ❌（正在获取 token） |
-| `auth token` | ❌ | — | — |
+| `auth login` | ✅ | unary | ❌ |
+| `auth list-tokens` | ✅ | unary | ✅ |
+| `auth revoke` | ✅ | unary | ✅ |
+| `user create` | ✅ | unary | ✅ |
+| `user list` | ✅ | unary | ✅ |
+| `user update` | ✅ | unary | ✅ |
+| `user delete` | ✅ | unary | ✅ |
 | `config set/get` | ❌ | — | — |
 | `version` | ❌ | — | — |
 
 ## 退出码
 
-| 退出码 | 含义 |
-|-------|------|
+| 码 | 含义 |
+|-----|------|
 | 0 | 成功 |
-| 1 | 一般错误（连接失败、Server 错误） |
-| 2 | 认证错误（无效/过期 token） |
-| 3 | 节点错误（不存在、离线） |
-| N | `exec` 命令：转发远程命令的退出码 |
+| 1 | 通用错误 |
+| 2 | 认证错误 |
+| 3 | 节点错误（未找到/离线） |
+| N | `exec` 时转发远程命令的退出码 |

--- a/docs/zh/configuration.md
+++ b/docs/zh/configuration.md
@@ -1,0 +1,181 @@
+# 配置参考
+
+Axon 所有配置文件和环境变量的完整参考。
+
+> [English Version](../configuration.md)
+
+---
+
+## Server（`axon-server`）
+
+配置文件路径：通过 `--config` 参数指定（默认：`./config.yaml`）
+
+### 完整示例
+
+```yaml
+listen: ":9090"
+
+tls:
+  auto: true                              # 自动生成自签 CA + 服务端证书（无 cert/key 时默认开启）
+  dir: "/var/lib/axon-server/tls"         # 自动生成证书的目录（默认：~/.axon-server/tls）
+  cert: ""                                # 显式 TLS 证书路径（禁用 auto-TLS）
+  key: ""                                 # 显式 TLS 私钥路径
+
+auth:
+  jwt_signing_key: "${AXON_JWT_SECRET}"   # HMAC-SHA256 签名密钥（必填）
+
+users:                                    # 引导用户（首次启动时写入数据库）
+  - username: admin
+    password_hash: "$2a$10$..."           # bcrypt 哈希
+    node_ids: ["*"]                       # ["*"] = 可访问所有节点
+  - username: deploy-agent
+    password_hash: "$2a$10$..."
+    node_ids: ["web-1", "web-2"]          # 限制到指定节点
+
+heartbeat:
+  interval: "10s"                         # 心跳间隔（默认：10s）
+  timeout: "30s"                          # 超时标记离线（默认：30s）
+
+audit:
+  db_path: "/var/lib/axon-server/audit.db"  # 审计日志 SQLite 路径（默认：内存）
+```
+
+### 字段说明
+
+| 字段 | 类型 | 默认值 | 说明 |
+|------|------|--------|------|
+| `listen` | string | `:9090` | gRPC 监听地址 |
+| `tls.auto` | bool | `true`（无 cert/key 时） | 自动生成自签 CA + 服务端证书 |
+| `tls.dir` | string | `~/.axon-server/tls` | 自动生成证书的目录 |
+| `tls.cert` | string | — | TLS 证书路径（PEM），设置后禁用 auto-TLS |
+| `tls.key` | string | — | TLS 私钥路径（PEM） |
+| `auth.jwt_signing_key` | string | — | **必填。** JWT 签名密钥 |
+| `users[].username` | string | — | 引导用户名 |
+| `users[].password_hash` | string | — | bcrypt 密码哈希 |
+| `users[].node_ids` | []string | `["*"]` | 允许访问的节点 |
+| `heartbeat.interval` | duration | `10s` | Agent 心跳间隔 |
+| `heartbeat.timeout` | duration | `30s` | 离线阈值 |
+| `audit.db_path` | string | `:memory:` | 审计日志 SQLite 路径 |
+
+### 环境变量
+
+| 变量 | 覆盖 |
+|------|------|
+| `AXON_JWT_SECRET` | `auth.jwt_signing_key` |
+| `AXON_TLS_CERT` | `tls.cert` |
+| `AXON_TLS_KEY` | `tls.key` |
+| `AXON_TLS_DIR` | `tls.dir` |
+
+### Auto-TLS 细节
+
+当 `tls.auto` 启用（或未显式禁用）且未配置 `tls.cert`/`tls.key` 时：
+
+1. 检查 `tls.dir` 下是否有 `ca.crt`
+2. 如果没有：生成 ECDSA P-256 CA（10 年有效期）+ 服务端证书（1 年有效期）
+3. 如果 `ca.crt` 存在但 `server.crt` 缺失或 30 天内过期：重新生成服务端证书
+4. 日志输出 CA 指纹，方便分发给 Agent/CLI
+
+生成的文件：
+
+```
+~/.axon-server/tls/
+├── ca.crt          # CA 证书（分发给 Agent 和 CLI）
+├── ca.key          # CA 私钥（保密，权限 0600）
+├── server.crt      # 服务端证书
+└── server.key      # 服务端私钥（权限 0600）
+```
+
+### 引导用户
+
+配置文件中的用户在启动时通过 `INSERT OR IGNORE` 写入数据库——已存在的用户不会被覆盖。初始引导后，通过 `axon user` CLI 命令或 gRPC RPC 管理用户。
+
+---
+
+## Agent（`axon-agent`）
+
+配置文件路径：`~/.axon-agent/config.yaml`（首次 `start` 时自动创建）
+
+### 完整示例
+
+```yaml
+server: "axon.example.com:9090"
+token: "agent-token-xxx"
+node_id: "a1b2c3d4"              # 首次注册后由 Server 分配
+node_name: "web-1"               # 用户指定或使用主机名
+labels:
+  env: production
+  role: web
+ca_cert: "/path/to/ca.crt"       # TLS 验证用的 CA 证书
+tls_insecure: false               # 跳过 TLS 验证（仅开发用）
+```
+
+### 字段说明
+
+| 字段 | 类型 | 默认值 | 说明 |
+|------|------|--------|------|
+| `server` | string | — | **必填。** Server gRPC 地址 |
+| `token` | string | — | **必填。** Agent 注册 Token |
+| `node_id` | string | — | Server 分配的稳定节点 ID |
+| `node_name` | string | 主机名 | 节点名称 |
+| `labels` | map | — | 键值标签 |
+| `ca_cert` | string | — | CA 证书路径 |
+| `tls_insecure` | bool | `false` | 跳过 TLS 验证 |
+
+### 环境变量
+
+| 变量 | 覆盖 |
+|------|------|
+| `AXON_SERVER` | `server` |
+| `AXON_TOKEN` | `token` |
+| `AXON_CA_CERT` | `ca_cert` |
+
+### TLS 行为
+
+Agent 的 TLS 三路选择：
+
+1. `tls_insecure: true` → 不验证 TLS（明文 gRPC）
+2. `ca_cert` 已设置 → 用指定 CA 验证服务端证书
+3. 都未设置 → 用系统 CA 池验证
+
+---
+
+## CLI（`axon`）
+
+配置文件路径：`~/.axon/config.yaml`
+
+### 完整示例
+
+```yaml
+server_addr: "axon.example.com:9090"
+token: "eyJhbGciOiJIUzI1NiIs..."
+output_format: "table"            # "table" 或 "json"
+ca_cert: "/path/to/ca.crt"       # TLS 验证用的 CA 证书
+tls_insecure: false               # 跳过 TLS 验证
+```
+
+### 字段说明
+
+| 字段 | 类型 | 默认值 | 说明 |
+|------|------|--------|------|
+| `server_addr` | string | — | Server gRPC 地址 |
+| `token` | string | — | JWT Token（`axon auth login` 设置） |
+| `output_format` | string | `table` | 默认输出格式 |
+| `ca_cert` | string | — | CA 证书路径 |
+| `tls_insecure` | bool | `false` | 跳过 TLS 验证 |
+
+### 环境变量
+
+| 变量 | 覆盖 |
+|------|------|
+| `AXON_SERVER` | `server_addr` |
+| `AXON_TOKEN` | `token` |
+| `AXON_CA_CERT` | `ca_cert` |
+
+### 全局参数
+
+这些参数覆盖配置文件的值：
+
+```bash
+axon --ca-cert /path/to/ca.crt <command>
+axon --tls-insecure <command>
+```

--- a/docs/zh/project-structure.md
+++ b/docs/zh/project-structure.md
@@ -1,174 +1,88 @@
 # Axon 项目结构
 
+> [English Version](../project-structure.md)
+
 ## 目录布局
 
 ```
 axon/
 ├── cmd/
-│   ├── axon/                    # CLI 二进制入口
-│   │   └── main.go
-│   ├── axon-server/             # Server 二进制入口
-│   │   └── main.go
-│   └── axon-agent/              # Agent 二进制入口
-│       └── main.go
+│   ├── axon/                        # CLI 二进制
+│   │   ├── main.go                  # 根命令 + 子命令
+│   │   ├── client.go                # gRPC 连接（TLS、认证）
+│   │   ├── node.go                  # node list/info/remove
+│   │   ├── exec.go / read.go / write.go / forward.go
+│   │   ├── auth.go                  # auth login/token/list-tokens/revoke/rotate
+│   │   └── user.go                  # user create/list/update/delete
+│   ├── axon-server/main.go          # Server 入口
+│   └── axon-agent/main.go           # Agent 入口
 │
-├── proto/                       # Protocol Buffers 定义
-│   ├── control.proto            # Agent ↔ Server 控制面
-│   ├── operations.proto         # exec/read/write/forward
-│   └── management.proto         # 节点管理 + 认证
+├── proto/                           # Protocol Buffers 定义
+│   ├── control.proto                # Agent ↔ Server 控制面
+│   ├── operations.proto             # 操作 + Agent 数据面
+│   └── management.proto             # 节点/用户/Token 管理
 │
-├── gen/                         # proto 生成的代码（可 gitignore 或提交）
-│   └── proto/
-│       ├── control/
-│       ├── operations/
-│       └── management/
+├── gen/proto/                       # 生成代码
 │
-├── pkg/                         # 公共包（稳定 API）
-│   ├── auth/                    # JWT token 生成与验证
-│   │   ├── jwt.go
-│   │   └── jwt_test.go
-│   ├── audit/                   # 审计日志
-│   │   ├── logger.go
-│   │   ├── sqlite.go
-│   │   └── logger_test.go
-│   └── config/                  # 共享配置加载工具
-│       └── config.go
+├── pkg/                             # 公共包（稳定 API）
+│   ├── auth/                        # 认证 & 授权
+│   │   ├── auth.go                  # JWT 签发 & 验证
+│   │   ├── interceptor.go           # gRPC 拦截器（含吊销检查）
+│   │   ├── token_checker.go         # 内存吊销 JTI 集合
+│   │   ├── token_store.go           # Token SQLite 持久化
+│   │   └── user_store.go            # 用户 SQLite CRUD
+│   ├── audit/                       # 审计日志
+│   │   ├── audit.go / store.go / writer.go
+│   ├── config/config.go             # 共享配置类型
+│   ├── display/display.go           # 输出格式化
+│   └── tls/autotls.go               # Auto-TLS 证书管理
 │
-├── internal/                    # 私有包（实现细节）
-│   ├── server/                  # Server 核心逻辑
-│   │   ├── server.go            # gRPC server 启动
-│   │   ├── registry.go          # 节点注册中心（内存）
-│   │   ├── router.go            # 请求路由 + stream 桥接
-│   │   ├── control.go           # ControlService 实现
-│   │   ├── operations.go        # OperationsService 实现
-│   │   ├── management.go        # ManagementService 实现
-│   │   └── heartbeat.go         # 心跳超时监控
+├── internal/                        # 私有包
+│   ├── server/                      # Server 核心
+│   │   ├── server.go                # 服务启动、DB 初始化、TLS
+│   │   ├── control.go               # ControlService
+│   │   ├── operations.go            # OperationsService
+│   │   ├── management.go            # ManagementService（节点/用户/Token CRUD）
+│   │   ├── agent_ops.go             # AgentOpsService
+│   │   ├── router.go / bridge.go    # 路由 + 流桥接
+│   │   └── registry/                # 节点注册表
+│   │       ├── registry.go          # 内存注册 + 心跳超时
+│   │       ├── store.go             # SQLite 存储
+│   │       └── heartbeat_batch.go   # 心跳批量持久化
 │   │
-│   ├── agent/                   # Agent 核心逻辑
-│   │   ├── agent.go             # Agent 主循环
-│   │   ├── control.go           # 控制面（注册、心跳）
-│   │   ├── executor.go          # exec：进程启动 + 流式输出
-│   │   ├── fileio.go            # read/write：文件操作
-│   │   ├── tunnel.go            # forward：TCP 隧道
-│   │   └── reconnect.go         # 指数退避重连
-│   │
-│   └── cli/                     # CLI 核心逻辑
-│       ├── root.go              # 根命令（cobra）
-│       ├── node.go              # node list/info/remove
-│       ├── exec.go              # exec 命令
-│       ├── read.go              # read 命令
-│       ├── write.go             # write 命令
-│       ├── forward.go           # forward 命令
-│       ├── auth.go              # auth login/token
-│       ├── config.go            # config set/get
-│       └── output.go            # 输出格式化（表格、JSON）
+│   └── agent/                       # Agent 核心
+│       ├── agent.go                 # 主循环：连接、注册、心跳、重连
+│       ├── dispatcher.go            # 任务分发
+│       ├── exec.go / fileio.go / forward.go
+│       └── sysinfo*.go              # 系统信息采集（各平台）
 │
-├── docs/                        # 设计文档（英文）
-│   ├── architecture.md
-│   ├── protocol.md
-│   ├── cli.md
-│   ├── agent.md
-│   ├── server.md
-│   ├── project-structure.md
-│   └── zh/                      # 设计文档（中文）
-│       ├── architecture.md
-│       ├── protocol.md
-│       ├── cli.md
-│       ├── agent.md
-│       ├── server.md
-│       └── project-structure.md
-│
-├── scripts/                     # 构建和开发脚本
-│   ├── build.sh                 # 跨平台构建
-│   ├── proto-gen.sh             # Protobuf 代码生成
-│   └── dev-setup.sh             # 开发环境配置
-│
-├── Makefile                     # 构建目标
-├── go.mod
-├── go.sum
-├── README.md
-├── CONTRIBUTING.md
-└── .gitignore
+├── test/integration/                # 端到端集成测试
+├── docs/                            # 文档（英文 + 中文）
+├── Makefile
+├── README.md / README_zh.md
+└── CONTRIBUTING.md
 ```
 
 ## 包依赖规则
 
 ```
-cmd/axon        → internal/cli   → gen/proto, pkg/config
-cmd/axon-server → internal/server → gen/proto, pkg/auth, pkg/audit, pkg/config
+cmd/axon        → gen/proto, pkg/config
+cmd/axon-server → internal/server → gen/proto, pkg/auth, pkg/audit, pkg/config, pkg/tls
 cmd/axon-agent  → internal/agent  → gen/proto, pkg/config
-
-pkg/auth    → （独立，不依赖 internal）
-pkg/audit   → （独立，不依赖 internal）
-pkg/config  → （独立，不依赖 internal）
 ```
 
-**规则：**
-1. `cmd/` 只放 `main.go` —— 所有逻辑在 `internal/` 或 `pkg/` 中
-2. `internal/` 包不能被模块外部导入
-3. `pkg/` 包是稳定 API，跨组件共享
-4. 禁止循环依赖
-5. `internal/server`、`internal/agent`、`internal/cli` 互不导入
+规则：
+1. `cmd/` 只有入口点，逻辑在 `internal/` 或 `pkg/`
+2. `internal/` 不可被外部模块导入
+3. `pkg/` 是稳定 API
+4. 无循环依赖
+5. `internal/server` 和 `internal/agent` 互不导入
 
-## 构建目标
+## 构建
 
-```makefile
-# 构建全部三个二进制
-make build
-
-# 单独构建
-make build-cli
-make build-server
-make build-agent
-
-# 生成 proto 代码
-make proto
-
-# 运行测试
-make test
-
-# 跨平台编译（linux/darwin × amd64/arm64）
-make release
-
-# 代码检查
-make lint
-```
-
-## Makefile
-
-```makefile
-VERSION ?= $(shell git describe --tags --always --dirty)
-LDFLAGS := -ldflags "-X main.version=$(VERSION)"
-
-.PHONY: build build-cli build-server build-agent proto test lint clean
-
-build: build-cli build-server build-agent
-
-build-cli:
-	go build $(LDFLAGS) -o bin/axon ./cmd/axon
-
-build-server:
-	go build $(LDFLAGS) -o bin/axon-server ./cmd/axon-server
-
-build-agent:
-	go build $(LDFLAGS) -o bin/axon-agent ./cmd/axon-agent
-
-proto:
-	./scripts/proto-gen.sh
-
-test:
-	go test ./...
-
-lint:
-	golangci-lint run ./...
-
-clean:
-	rm -rf bin/
-
-release:
-	GOOS=linux GOARCH=amd64 go build $(LDFLAGS) -o bin/axon-linux-amd64 ./cmd/axon
-	GOOS=linux GOARCH=arm64 go build $(LDFLAGS) -o bin/axon-linux-arm64 ./cmd/axon
-	GOOS=darwin GOARCH=amd64 go build $(LDFLAGS) -o bin/axon-darwin-amd64 ./cmd/axon
-	GOOS=darwin GOARCH=arm64 go build $(LDFLAGS) -o bin/axon-darwin-arm64 ./cmd/axon
-	# axon-server 和 axon-agent 同理...
+```bash
+make build          # 编译三个二进制 → bin/
+make test           # 运行所有测试（含 race detector）
+make lint           # golangci-lint
+make proto          # 重新生成 protobuf
 ```

--- a/docs/zh/protocol.md
+++ b/docs/zh/protocol.md
@@ -1,330 +1,115 @@
 # Axon 协议设计
 
+> [English Version](../protocol.md)
+
 ## 概述
 
-全链路通信使用 gRPC over HTTP/2，Protocol Buffers 序列化。
+全链路 gRPC over HTTP/2，Protocol Buffers 序列化。三个 proto 文件定义全部 API。
 
-三个 proto 文件：
-- `control.proto` — Agent ↔ Server 控制面
-- `operations.proto` — CLI ↔ Server ↔ Agent 操作面（exec/read/write/forward）
-- `management.proto` — CLI ↔ Server 管理面（节点管理、认证）
+## Proto 文件
 
-## 1. 控制面 — `control.proto`
+| 文件 | 包 | 服务 | 用途 |
+|------|-----|------|------|
+| `control.proto` | `axon.control` | `ControlService` | Agent ↔ Server 控制面 |
+| `operations.proto` | `axon.operations` | `OperationsService`、`AgentOpsService` | CLI 操作 + Agent 任务处理 |
+| `management.proto` | `axon.management` | `ManagementService` | 节点/用户/Token 管理 + 认证 |
 
-Agent 与 Server 之间的长连接双向 stream。
+## ControlService（Agent ↔ Server）
+
+长连接双向流，管理 Agent 生命周期。
 
 ```protobuf
-syntax = "proto3";
-package axon.control;
-
 service ControlService {
-  // Agent 启动时建立持久控制通道。
-  // Server 通过此通道追踪存活状态并派发任务信号。
   rpc Connect(stream AgentMessage) returns (stream ServerMessage);
 }
-
-// ─── Agent → Server ───
-
-message AgentMessage {
-  oneof payload {
-    RegisterRequest register = 1;
-    Heartbeat heartbeat = 2;
-    NodeInfo node_info = 3;
-  }
-}
-
-message RegisterRequest {
-  string token = 1;           // Agent token（一次性注册用）
-  string node_name = 2;       // 期望的节点名（不填则用 hostname）
-  NodeInfo info = 3;          // 初始节点信息
-}
-
-message Heartbeat {
-  int64 timestamp = 1;        // Unix 时间戳（毫秒）
-}
-
-message NodeInfo {
-  string hostname = 1;
-  string arch = 2;            // 例如 "amd64", "arm64"
-  string ip = 3;              // 主 IP
-  int64 uptime_seconds = 4;
-  string agent_version = 5;
-  OSInfo os_info = 6;         // 详细 OS 信息
-}
-
-message OSInfo {
-  string os = 1;              // 内核名称："linux", "darwin", "windows"
-  string os_version = 2;      // 内核版本："6.8.0-45-generic", "24.3.0"
-  string platform = 3;        // 发行版/平台："ubuntu", "centos", "debian", "macOS"
-  string platform_version = 4;// 发行版版本："24.04", "9", "14.4"
-  string pretty_name = 5;     // 可读名称："Ubuntu 24.04 LTS", "macOS 14.4 Sonoma"
-}
-
-// ─── Server → Agent ───
-
-message ServerMessage {
-  oneof payload {
-    RegisterResponse register_response = 1;
-    HeartbeatAck heartbeat_ack = 2;
-    TaskSignal task_signal = 3;    // 通知 Agent 开新的操作面 stream
-  }
-}
-
-message RegisterResponse {
-  bool success = 1;
-  string node_id = 2;         // Server 分配的节点 ID
-  string error = 3;
-  int32 heartbeat_interval_seconds = 4;  // Server 告诉 Agent 心跳间隔
-}
-
-message HeartbeatAck {
-  int64 server_timestamp = 1;
-}
-
-message TaskSignal {
-  string task_id = 1;         // Agent 用此 ID 开操作面 stream
-  TaskType type = 2;
-}
-
-enum TaskType {
-  TASK_EXEC = 0;
-  TASK_READ = 1;
-  TASK_WRITE = 2;
-  TASK_FORWARD = 3;
-}
 ```
 
-### 流程
+Agent → Server：`RegisterRequest`、`Heartbeat`、`NodeInfo`
+Server → Agent：`RegisterResponse`、`HeartbeatAck`、`TaskSignal`
 
-1. Agent 启动 → 调用 `Connect()` → 发送 `RegisterRequest`
-2. Server 验证 token → 返回 `RegisterResponse`（含 node_id 和心跳间隔）
-3. Agent 每 N 秒发送 `Heartbeat`
-4. Server 回复 `HeartbeatAck`
-5. CLI 发起请求时，Server 通过控制 stream 发送 `TaskSignal`
-6. Agent 收到 `TaskSignal` → 开新的操作面 stream（带 task_id）
+## OperationsService（CLI → Server）
 
-## 2. 操作面 — `operations.proto`
-
-每个任务独立 stream。
+CLI 端操作，Server 路由到目标 Agent。
 
 ```protobuf
-syntax = "proto3";
-package axon.operations;
-
 service OperationsService {
-  // CLI 调用这些 RPC。Server 路由到目标 Agent。
-
-  // 执行命令 — 流式返回 stdout/stderr
   rpc Exec(ExecRequest) returns (stream ExecOutput);
-
-  // 读文件 — 流式返回文件内容
   rpc Read(ReadRequest) returns (stream ReadOutput);
-
-  // 写文件 — 客户端流式上传内容
   rpc Write(stream WriteInput) returns (WriteResponse);
-
-  // 端口转发 — 双向字节流
   rpc Forward(stream TunnelData) returns (stream TunnelData);
 }
-
-// ─── Exec ───
-
-message ExecRequest {
-  string node_id = 1;
-  string command = 2;
-  map<string, string> env = 3;      // 可选环境变量
-  string working_dir = 4;           // 可选工作目录
-  int32 timeout_seconds = 5;        // 0 = 不超时
-}
-
-message ExecOutput {
-  oneof payload {
-    bytes stdout = 1;
-    bytes stderr = 2;
-    ExecExit exit = 3;
-  }
-}
-
-message ExecExit {
-  int32 exit_code = 1;
-  string error = 2;           // Agent 层面错误时非空（非命令本身错误）
-}
-
-// ─── Read ───
-
-message ReadRequest {
-  string node_id = 1;
-  string path = 2;
-}
-
-message ReadOutput {
-  oneof payload {
-    bytes data = 1;           // 文件内容块
-    ReadMeta meta = 2;        // 首条消息：文件大小、权限等
-    string error = 3;
-  }
-}
-
-message ReadMeta {
-  int64 size = 1;
-  int32 mode = 2;             // Unix 文件权限
-  int64 modified_at = 3;      // Unix 时间戳
-}
-
-// ─── Write ───
-
-message WriteInput {
-  oneof payload {
-    WriteHeader header = 1;   // 首条消息
-    bytes data = 2;           // 文件内容块
-  }
-}
-
-message WriteHeader {
-  string node_id = 1;
-  string path = 2;
-  int32 mode = 3;             // Unix 文件权限（默认 0644）
-}
-
-message WriteResponse {
-  bool success = 1;
-  int64 bytes_written = 2;
-  string error = 3;
-}
-
-// ─── Forward（端口隧道） ───
-
-message TunnelData {
-  string connection_id = 1;   // 标识单个 TCP 连接
-  bytes payload = 2;          // 原始 TCP 字节
-  bool close = 3;             // 关闭此连接的信号
-
-  // 仅在新连接的首条消息中：
-  TunnelOpen open = 4;
-}
-
-message TunnelOpen {
-  string node_id = 1;
-  int32 remote_port = 2;
-}
 ```
 
-### Exec 流程
+## AgentOpsService（Agent → Server）
 
-```
-CLI                         Server                      Agent
- │── ExecRequest ──────────→│── TaskSignal ────────────→│
- │  {node:web-1, cmd:...}   │                           │── 开操作面 stream
- │                           │                           │── 执行命令
- │←─ ExecOutput(stdout) ────│←─ stdout 字节 ────────────│
- │←─ ExecOutput(stderr) ────│←─ stderr 字节 ────────────│
- │←─ ExecOutput(exit) ──────│←─ exit code ──────────────│
- │  stream 关闭              │  stream 关闭              │
-```
-
-### Forward 流程
-
-```
-TCP 客户端    CLI                    Server                  Agent               TCP 目标
-  │──连接───→│                        │                       │                      │
-  │           │──TunnelData{open}───→│──TaskSignal──────────→│                      │
-  │           │  {node:db-1,port:5432}│                       │──TCP 连接───────────→│
-  │           │                       │                       │                      │
-  │──数据───→│──TunnelData{payload}─→│──TunnelData{payload}→│──数据────────────────→│
-  │←─数据────│←─TunnelData{payload}──│←─TunnelData{payload}─│←─数据─────────────────│
-  │   ...     │   ...                 │   ...                 │   ...                 │
-  │──关闭───→│──TunnelData{close}───→│──TunnelData{close}──→│──TCP 关闭────────────→│
-```
-
-每个 TCP 连接有自己的 `connection_id`。Phase 1 采用 **每个 TCP 连接一个独立 gRPC stream** 的方案，简单清晰。gRPC/HTTP2 多路复用保证不会连接爆炸。
-
-## 3. 管理面 — `management.proto`
-
-简单的 unary RPC，用于节点管理和认证。
+Agent 端数据面。收到 `TaskSignal` 后开启 `HandleTask` stream。
 
 ```protobuf
-syntax = "proto3";
-package axon.management;
+service AgentOpsService {
+  rpc HandleTask(stream TaskDataUp) returns (stream TaskDataDown);
+}
+```
 
+Server 作为透明桥接：CLI 的 `OperationsService` stream ↔ Agent 的 `HandleTask` stream。
+
+## ManagementService（CLI → Server）
+
+```protobuf
 service ManagementService {
+  // 节点管理
   rpc ListNodes(ListNodesRequest) returns (ListNodesResponse);
   rpc GetNode(GetNodeRequest) returns (GetNodeResponse);
   rpc RemoveNode(RemoveNodeRequest) returns (RemoveNodeResponse);
+
+  // 认证
   rpc Login(LoginRequest) returns (LoginResponse);
-}
 
-// ─── 节点管理 ───
+  // Token 管理
+  rpc RevokeToken(RevokeTokenRequest) returns (RevokeTokenResponse);
+  rpc ListTokens(ListTokensRequest) returns (ListTokensResponse);
 
-message ListNodesRequest {}
-
-message ListNodesResponse {
-  repeated NodeSummary nodes = 1;
-}
-
-message NodeSummary {
-  string node_id = 1;
-  string node_name = 2;
-  string status = 3;          // "online" | "offline"
-  string arch = 4;
-  string ip = 5;
-  string agent_version = 6;
-  int64 connected_at = 7;     // Unix 时间戳
-  int64 last_heartbeat = 8;   // Unix 时间戳
-  OSInfo os_info = 9;         // 详细 OS 信息
-}
-
-message GetNodeRequest {
-  string node_id = 1;
-}
-
-message GetNodeResponse {
-  NodeSummary summary = 1;
-  int64 uptime_seconds = 2;
-  map<string, string> labels = 3;
-}
-
-message RemoveNodeRequest {
-  string node_id = 1;
-}
-
-message RemoveNodeResponse {
-  bool success = 1;
-  string error = 2;
-}
-
-// ─── 认证 ───
-
-message LoginRequest {
-  string username = 1;
-  string password = 2;        // Phase 1：用户名/密码
-}
-
-message LoginResponse {
-  string token = 1;           // JWT token
-  int64 expires_at = 2;       // Unix 时间戳
-  string error = 3;
+  // 用户管理
+  rpc CreateUser(CreateUserRequest) returns (CreateUserResponse);
+  rpc UpdateUser(UpdateUserRequest) returns (UpdateUserResponse);
+  rpc DeleteUser(DeleteUserRequest) returns (DeleteUserResponse);
+  rpc ListUsers(ListUsersRequest) returns (ListUsersResponse);
 }
 ```
 
-## 错误处理
+### 认证相关
 
-所有 RPC 使用标准 gRPC 状态码：
+- `Login`：无需认证，验证用户名密码，返回带 JTI 的 JWT
+- `RevokeToken`/`ListTokens`：需要 JWT 认证
+- 吊销的 Token 在内存 set 中 O(1) 检查
 
-| 场景 | gRPC 状态码 |
-|------|------------|
-| 节点不存在 | `NOT_FOUND` |
-| 节点离线 | `UNAVAILABLE` |
-| 认证失败 / token 过期 | `UNAUTHENTICATED` |
-| Token 无权访问目标节点 | `PERMISSION_DENIED` |
-| 文件不存在（read） | `NOT_FOUND` |
-| 命令超时（exec） | `DEADLINE_EXCEEDED` |
-| Agent 内部错误 | `INTERNAL` |
-| 无效请求 | `INVALID_ARGUMENT` |
+### 用户管理
 
-## TLS
+- `CreateUser`：用户名 + 密码 + 节点权限
+- `UpdateUser`：密码为空 = 不改；node_ids 为 nil = 不改
+- `DeleteUser`：按用户名删除
+- `ListUsers`：返回所有用户信息（不含密码哈希）
 
-全链路 gRPC 连接使用 TLS：
-- CLI → Server：标准 TLS（Server 证书）
-- Agent → Server：标准 TLS（Server 证书）+ Agent token 身份验证
+## 认证流程
 
-Phase 1：Server 使用单一 TLS 证书。mTLS 是 Phase 2 的考虑事项。
+### JWT 结构
+
+```
+Header: {"alg": "HS256", "typ": "JWT"}
+Payload: {
+  "sub": "gary",           // 用户名
+  "node_ids": ["*"],       // 允许的节点
+  "jti": "uuid-...",       // 唯一 Token ID
+  "exp": 1234567890,       // 过期时间
+  "iat": 1234567890        // 签发时间
+}
+```
+
+### gRPC 拦截器
+
+1. 从 gRPC metadata 提取 `authorization: Bearer <token>`
+2. 验证 HMAC-SHA256 签名
+3. 检查过期
+4. 检查 JTI 是否已吊销 → `UNAUTHENTICATED`
+5. 注入 claims 到 context
+
+**豁免**：`ManagementService/Login`（无需认证）、`ControlService/Connect`（Handler 内验证）

--- a/docs/zh/quickstart.md
+++ b/docs/zh/quickstart.md
@@ -1,0 +1,169 @@
+# 快速开始
+
+5 分钟内跑通 Axon：启动 Server、连接 Agent、执行第一条远程命令。
+
+> [English Version](../quickstart.md)
+
+## 前置条件
+
+- Go 1.25+ 已安装
+- 两台机器（或同一台机器上的两个终端用于测试）
+
+## 1. 编译
+
+```bash
+git clone https://github.com/garysng/axon.git
+cd axon
+make build
+```
+
+产出三个二进制文件在 `bin/` 下：
+
+| 二进制 | 用途 |
+|--------|------|
+| `axon` | CLI，人和 AI agent 的操作接口 |
+| `axon-server` | 中心控制面 |
+| `axon-agent` | 目标机器上的守护进程 |
+
+## 2. 启动 Server
+
+创建最小配置文件：
+
+```yaml
+# server.yaml
+listen: ":9090"
+
+auth:
+  jwt_signing_key: "your-secret-key-change-me"
+
+users:
+  - username: admin
+    password_hash: "$2a$10$..."   # 密码的 bcrypt 哈希
+    node_ids: ["*"]               # 可访问所有节点
+```
+
+生成密码的 bcrypt 哈希：
+
+```bash
+# 使用 htpasswd（Apache 工具）
+htpasswd -nbBC 10 "" your-password | cut -d: -f2
+
+# 或使用 Python
+python3 -c "import bcrypt; print(bcrypt.hashpw(b'your-password', bcrypt.gensalt()).decode())"
+```
+
+启动 Server：
+
+```bash
+./bin/axon-server --config server.yaml
+```
+
+你会看到：
+
+```
+server: auto-TLS: generated CA cert ~/.axon-server/tls/ca.crt (SHA-256: AA:BB:CC:...)
+server: gRPC listening on :9090 (TLS)
+```
+
+**Auto-TLS** 会自动生成自签 CA 和服务端证书，无需手动配置证书。
+
+## 3. 连接 Agent
+
+在目标机器上（或另一个终端）启动 Agent：
+
+```bash
+./bin/axon-agent start \
+  --server localhost:9090 \
+  --token your-agent-token \
+  --name my-node \
+  --tls-insecure    # 测试环境使用自签证书
+```
+
+或使用 CA 证书做正式 TLS 验证：
+
+```bash
+./bin/axon-agent start \
+  --server localhost:9090 \
+  --token your-agent-token \
+  --name my-node \
+  --ca-cert ~/.axon-server/tls/ca.crt
+```
+
+Agent 连接 Server 后自动注册。
+
+## 4. CLI 登录
+
+```bash
+# 配置 Server 地址
+./bin/axon config set server localhost:9090
+
+# 登录（提示输入用户名/密码）
+./bin/axon auth login --tls-insecure
+```
+
+或使用 CA 证书：
+
+```bash
+./bin/axon auth login --ca-cert ~/.axon-server/tls/ca.crt
+```
+
+## 5. 执行操作
+
+```bash
+# 列出已连接的节点
+axon node list
+
+# 在远程节点上执行命令
+axon exec my-node "hostname"
+axon exec my-node "ls -la /tmp"
+
+# 读取文件
+axon read my-node /etc/hostname
+
+# 写入文件
+echo "hello from axon" | axon write my-node /tmp/hello.txt
+
+# 端口转发
+axon forward my-node 8080:80
+# 现在 localhost:8080 → my-node:80
+```
+
+## 6. 用户管理（可选）
+
+```bash
+# 创建新用户
+axon user create deploy-bot --node-ids web-1,web-2
+
+# 列出用户
+axon user list
+
+# 更新节点权限
+axon user update deploy-bot --node-ids web-1,web-2,db-1
+
+# 删除用户
+axon user delete deploy-bot
+```
+
+## 7. Token 管理（可选）
+
+```bash
+# 列出已签发的 Token
+axon auth list-tokens
+
+# 吊销 Token
+axon auth revoke <token-id>
+```
+
+## TLS 选项
+
+| 场景 | Server 配置 | 客户端/Agent 参数 |
+|------|-----------|-----------------|
+| Auto-TLS（默认） | 不配 `tls.cert`/`tls.key` → 自动生成 | `--ca-cert ~/.axon-server/tls/ca.crt` |
+| 自带证书 | 配置 `tls.cert` + `tls.key` | 系统 CA 或 `--ca-cert` |
+| 禁用 TLS（仅开发） | `tls.auto: false`（不配证书） | `--tls-insecure` |
+
+## 下一步
+
+- [配置参考](configuration.md) — Server、Agent、CLI 的全部配置选项
+- [架构概览](architecture.md) — 组件如何协作
+- [CLI 参考](cli.md) — 完整命令参考

--- a/docs/zh/server.md
+++ b/docs/zh/server.md
@@ -1,302 +1,128 @@
 # Axon Server 设计
 
+> [English Version](../server.md)
+
 ## 概述
 
-`axon-server` 是中央控制面。单二进制，用户自部署。管理节点注册、认证、请求路由和审计日志。
+`axon-server` 是中心控制面。单一二进制，自托管。管理节点注册、认证、请求路由、持久化、TLS 和审计日志。
 
 **所有流量经过 Server。CLI 和 Agent 不直接通信。**
-
-## 架构
-
-```
-┌──────────────── axon-server ────────────────┐
-│                                              │
-│  ┌──────────┐  ┌──────────┐  ┌───────────┐  │
-│  │ gRPC API │  │ gRPC API │  │ gRPC API  │  │
-│  │ 管理面    │  │ 操作面    │  │ 控制面     │  │
-│  └────┬─────┘  └────┬─────┘  └─────┬─────┘  │
-│       │              │              │         │
-│  ┌────▼──────────────▼──────────────▼─────┐  │
-│  │              路由层                      │  │
-│  │  CLI 请求 → 查找节点 → 派发任务          │  │
-│  └────┬───────────────────────────┬───────┘  │
-│       │                           │          │
-│  ┌────▼─────┐             ┌──────▼───────┐  │
-│  │ 注册中心  │             │ 认证 (JWT)   │  │
-│  │          │             │              │  │
-│  │ node_id  │             │ 签发/校验     │  │
-│  │ 状态     │             │ token 作用域  │  │
-│  │ stream   │             └──────────────┘  │
-│  └────┬─────┘                                │
-│       │                                      │
-│  ┌────▼─────┐                                │
-│  │ 审计日志  │                                │
-│  │          │                                │
-│  └──────────┘                                │
-└──────────────────────────────────────────────┘
-```
 
 ## 子模块
 
 ### 1. gRPC API 层
 
-暴露三个 gRPC 服务（详见 [protocol.md](../protocol.md)）：
+单一 gRPC 服务端，同一端口注册三个服务：
 
-| 服务 | 调用方 | 说明 |
-|------|--------|------|
-| `ControlService` | Agent | Agent 注册、心跳、任务派发 |
-| `OperationsService` | CLI | exec、read、write、forward |
-| `ManagementService` | CLI | node list/info/remove、auth login |
-
-单个 gRPC server 监听一个端口（默认：443）。三个服务注册在同一个 server 上。
-
-### 2. 节点注册中心
-
-所有已知节点的内存注册表。
-
-```go
-type NodeEntry struct {
-    NodeID        string
-    NodeName      string
-    Status        string            // "online" | "offline"
-    Info          NodeInfo          // hostname, arch, IP, version, uptime, OS 信息
-    Labels        map[string]string
-    ControlStream grpc.BidiStream   // 活跃的控制 stream 引用
-    ConnectedAt   time.Time
-    LastHeartbeat time.Time
-    RegisteredAt  time.Time
-}
-```
-
-**操作：**
-
-| 操作 | 触发 | 说明 |
+| 服务 | 来源 | 说明 |
 |------|------|------|
-| 注册 | Agent 连接 | 添加/更新节点条目，状态设为 online |
-| 心跳更新 | Agent 心跳 | 更新 `LastHeartbeat` |
-| 标记离线 | 心跳超时 | 状态设为 offline，清除 ControlStream 引用 |
-| 移除 | `axon node remove` | 删除条目，断开 Agent 连接 |
-| 列表 | `axon node list` | 返回所有条目 |
-| 查找 | 任何 CLI 操作 | 按名称或 ID 查找节点 |
+| `ControlService` | Agent | 注册、心跳、任务分发 |
+| `OperationsService` | CLI | exec、read、write、forward |
+| `ManagementService` | CLI | 节点/用户/Token 管理、登录 |
 
-**持久化：**
-- Phase 1：仅内存。Server 重启后节点重新注册。
-- Phase 2：持久化到 SQLite，加快恢复速度。
+### 2. 节点注册表（SQLite 持久化）
 
-**心跳超时检测：**
-- 后台 goroutine 每 5 秒检查一次
-- 如果 `当前时间 - LastHeartbeat > 3 × 心跳间隔` → 标记 offline
-
-### 3. 路由层
-
-将 CLI 请求路由到正确的 Agent。
-
-```
-CLI 请求 (exec web-1 "ls")
-    │
-    ▼
-路由层：
-    1. 认证：验证 gRPC metadata 中的 JWT token
-    2. 授权：检查 token.node_ids 包含 "web-1"
-    3. 查找：在注册中心找到 "web-1"
-    4. 检查状态：如果 offline → 返回 UNAVAILABLE
-    5. 派发：通过控制 stream 发送 TaskSignal
-    6. 桥接：在 CLI stream 和 Agent 操作 stream 之间代理数据
+```sql
+CREATE TABLE nodes (
+    node_id      TEXT PRIMARY KEY,
+    node_name    TEXT NOT NULL,
+    status       TEXT NOT NULL DEFAULT 'offline',
+    token_hash   TEXT NOT NULL,
+    info_json    TEXT,
+    labels_json  TEXT,
+    connected_at INTEGER,
+    last_heartbeat INTEGER,
+    registered_at INTEGER NOT NULL
+);
 ```
 
-**操作的 Stream 桥接：**
+- **稳定节点 ID**：首次注册分配 UUID，Agent 本地持久化
+- **心跳批量持久化**：内存中攒 30s 后批量刷盘
+- **启动行为**：加载所有节点，全部标记 offline，Agent 重连后回到 online
+
+### 3. 路由器
 
 ```
-CLI gRPC stream ←──→ Server（桥接）←──→ Agent gRPC stream
+CLI 请求 → 认证（JWT 拦截器）→ 鉴权（检查 node_ids）→ 查找节点
+  → 离线？返回 UNAVAILABLE
+  → 在线？发 TaskSignal → 桥接 CLI stream ↔ Agent stream
 ```
-
-Server 作为透明代理：
-- exec：将 Agent stream 的 ExecOutput 转发到 CLI stream
-- read：将 Agent stream 的 ReadOutput 转发到 CLI stream
-- write：将 CLI stream 的 WriteInput 转发到 Agent stream
-- forward：在 CLI 和 Agent stream 之间双向中继 TunnelData
 
 ### 4. 认证模块
 
-基于 JWT 的认证。
+- **JWT Token**：HMAC-SHA256，含 JTI（唯一 ID）
+- **Token 持久化**：SQLite，Login 时自动 Insert
+- **吊销检查**：启动时加载已吊销 JTI 到内存 set，O(1) 拦截
+- **gRPC 拦截器**：除 Login 和 Connect 外所有 RPC 都需认证
 
-**Token 类型：**
-
-| 类型 | 签发给 | 包含 | 用途 |
-|------|--------|------|------|
-| CLI Token | 用户/Agent | `user_id`、`node_ids[]`、`exp`、`iat` | CLI → Server 认证 |
-| Agent Token | 节点 | `node_id`、`exp` | Agent 注册（一次性） |
-
-**Server 端：**
-
-```go
-type AuthConfig struct {
-    JWTSigningKey string        // HMAC-SHA256 密钥
-    TokenExpiry   time.Duration // 默认：CLI token 24 小时
-}
-```
-
-**Token 验证流程：**
-
-```
-1. 从 gRPC metadata 提取 token（"authorization: Bearer <token>"）
-2. 验证 JWT 签名
-3. 检查过期时间
-4. CLI Token：提取 node_ids，传给路由层做授权
-5. Agent Token：提取 node_id，传给注册中心做注册
-```
-
-**登录流程（Phase 1）：**
-
-```
-CLI 发送 LoginRequest{username, password}
-    │
-    ▼
-Server 对比本地用户存储（配置文件或 SQLite）
-    │
-    ▼
-Server 签发 JWT（含 user_id + 允许的 node_ids）
-    │
-    ▼
-返回 LoginResponse{token, expires_at}
-```
-
-**用户存储（Phase 1）：**
-
-```yaml
-# axon-server 配置
-users:
-  - username: gary
-    password_hash: "$2a$10$..."   # bcrypt
-    node_ids: ["*"]               # 可访问所有节点
-  - username: deploy-agent
-    password_hash: "$2a$10$..."
-    node_ids: ["web-1", "web-2"]  # 受限访问
-```
-
-### 5. 审计日志
-
-记录所有经过 Server 的操作。
-
-**日志条目：**
-
-```go
-type AuditEntry struct {
-    Timestamp  time.Time
-    UserID     string
-    NodeID     string
-    Action     string    // "exec", "read", "write", "forward", "node.remove"
-    Detail     string    // 命令字符串、文件路径或端口映射
-    Result     string    // "success", "error", "timeout"
-    DurationMs int64
-    Error      string    // 失败时的错误信息
-}
-```
-
-**存储（Phase 1）：** SQLite
+### 5. 用户存储（SQLite）
 
 ```sql
-CREATE TABLE audit_log (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
-    timestamp TEXT NOT NULL,
-    user_id TEXT NOT NULL,
-    node_id TEXT NOT NULL,
-    action TEXT NOT NULL,
-    detail TEXT,
-    result TEXT NOT NULL,
-    duration_ms INTEGER,
-    error TEXT
+CREATE TABLE users (
+    username      TEXT PRIMARY KEY,
+    password_hash TEXT NOT NULL,     -- bcrypt
+    node_ids      TEXT NOT NULL,     -- JSON 数组
+    created_at    INTEGER NOT NULL,
+    updated_at    INTEGER NOT NULL,
+    disabled      INTEGER NOT NULL DEFAULT 0
 );
-
-CREATE INDEX idx_audit_timestamp ON audit_log(timestamp);
-CREATE INDEX idx_audit_node ON audit_log(node_id);
-CREATE INDEX idx_audit_user ON audit_log(user_id);
 ```
 
-**行为：**
-- 异步写入（带缓冲的 channel → 后台写入 goroutine）
-- 非阻塞：审计失败不应阻塞业务操作
-- 保留策略：可配置，Phase 1 默认保留全部
+- **引导**：配置文件用户通过 `INSERT OR IGNORE` 写入
+- **登录流程**：SQLite 查找用户 → 检查 disabled → 验证 bcrypt → 签发 JWT + 持久化 Token
 
-## Server 配置
+### 6. TLS
 
-```yaml
-# /etc/axon-server/config.yaml
+- **Auto-TLS（默认）**：ECDSA P-256 CA（10 年）+ 服务端证书（1 年），30 天内过期自动续签
+- **自带证书**：配置 `tls.cert` + `tls.key`
+- **禁用 TLS**：`tls.auto: false`，打印警告
 
-listen: ":443"
+### 7. 审计日志
 
-tls:
-  cert: "/etc/axon-server/tls/server.crt"
-  key: "/etc/axon-server/tls/server.key"
+SQLite 存储，异步缓冲写入，不阻塞业务。记录每个操作的时间、用户、节点、动作、结果、耗时。
 
-auth:
-  jwt_signing_key: "${AXON_JWT_KEY}"      # 从环境变量读取
-  token_expiry: "24h"
+### 8. 共享数据库
 
-users:
-  - username: gary
-    password_hash: "$2a$10$..."
-    node_ids: ["*"]
+所有持久状态（审计除外）在**单一 SQLite 数据库**（WAL 模式）：
 
-heartbeat:
-  interval_seconds: 10       # 发送给 Agent
-  timeout_multiplier: 3      # 3 倍间隔未收到心跳 → offline
+```go
+db, err := sql.Open("sqlite", dataDBPath)
+db.Exec("PRAGMA journal_mode=WAL")
 
-audit:
-  db_path: "/var/lib/axon-server/audit.db"
-
-agent_tokens:
-  - token: "${AXON_AGENT_TOKEN_1}"
-    allowed_node_name: "web-1"    # 可选：限制此 token 可注册的名称
-  - token: "${AXON_AGENT_TOKEN_2}"
-    allowed_node_name: ""         # 空 = 任意名称
+registryStore := registry.NewSQLiteStoreFromDB(db)
+tokenStore    := auth.NewTokenStoreFromDB(db)
+userStore     := auth.NewUserStoreFromDB(db)
 ```
 
-## 启动序列
+## 启动流程
 
 ```
-1. 加载配置（配置文件 + 环境变量）
-2. 初始化 SQLite（审计日志）
-3. 初始化节点注册中心（空）
-4. 初始化认证模块（加载签名密钥、用户存储）
-5. 启动 gRPC server（TLS）
-   - 注册 ControlService
-   - 注册 OperationsService
-   - 注册 ManagementService
-6. 启动心跳监控（后台 goroutine）
-7. 就绪
+1. 加载配置（文件 + 环境变量）
+2. 打开共享 SQLite（WAL 模式）
+3. 初始化注册表 → 加载节点（标记 offline）
+4. 初始化 Token 存储 → 加载已吊销 JTI
+5. 初始化用户存储 → 引导配置用户
+6. Auto-TLS：生成或加载证书
+7. 构建 gRPC 服务（含认证拦截器）
+8. 初始化审计
+9. 注册所有 gRPC 服务
+10. 启动心跳监控
+11. 开始服务
 ```
 
 ## 优雅关闭
 
 ```
-1. 停止接受新连接
-2. 等待进行中的 RPC 完成（有超时）
-3. 关闭所有 Agent 控制 stream（Agent 会自动重连）
-4. 刷新审计日志缓冲
-5. 关闭 SQLite
-6. 退出
+1. 停止接收新连接
+2. GracefulStop gRPC
+3. 关闭审计（刷新缓冲区）
+4. 关闭用户存储
+5. 关闭 Token 存储
+6. 关闭注册表（刷新心跳批次）
+7. 关闭共享数据库
+8. 退出
 ```
 
-## 命令
+## 配置
 
-### `axon-server start`
-
-```
-$ axon-server start --config /etc/axon-server/config.yaml
-[INFO] loading config from /etc/axon-server/config.yaml
-[INFO] audit database initialized at /var/lib/axon-server/audit.db
-[INFO] gRPC server listening on :443 (TLS)
-[INFO] ready
-```
-
-- **参数**：
-  - `--config <path>` — 配置文件路径（默认：`./config.yaml`）
-  - `--foreground` — 前台运行
-
-### `axon-server version`
-
-```
-$ axon-server version
-axon-server 0.1.0 (go1.22, linux/amd64)
-```
+详见 [配置参考](configuration.md)。


### PR DESCRIPTION
## Summary

Complete documentation overhaul to reflect Phase 2 completion (P2-1 through P2-4).

### Updated docs
- **architecture.md** — added persistence, TLS, token/user management, shared SQLite
- **protocol.md** — added Token/User CRUD RPCs, full ManagementService spec
- **cli.md** — added `auth list-tokens/revoke/rotate`, `user create/list/update/delete`, TLS flags
- **server.md** — added SQLite persistence, auto-TLS, user store, shared DB, updated startup/shutdown
- **agent.md** — added TLS config (3-way selection), CA cert support
- **project-structure.md** — reflects actual file layout with all Phase 2 additions
- **README.md** — Phase 1 marked complete, Phase 2 progress updated, docs links added

### New docs
- **quickstart.md** — end-to-end getting started (server + agent + CLI in 5 minutes)
- **configuration.md** — complete config reference for server, agent, and CLI (YAML fields, env vars, defaults)

### Not changed
- `phase2-design.md` — kept as-is (design spec, still accurate)
- `data-plane-bridge.md` — kept as-is (Phase 1 historical)
- `tasks-phase1.md` — kept as-is (historical)
- `docs/zh/` — Chinese translations not updated in this PR (separate task)