### PR TITLE
ci(cd): add release workflow for automated binary builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,42 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+env:
+  GO_VERSION_FILE: go.mod
+
+jobs:
+  release:
+    name: Build & Release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: ${{ env.GO_VERSION_FILE }}
+
+      - name: Run tests
+        run: go test ./... -race -cover
+
+      - name: Build release binaries
+        run: make release
+
+      - name: Generate checksums
+        working-directory: dist
+        run: sha256sum * > checksums.txt
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+          files: |
+            dist/*


### PR DESCRIPTION
## Summary

Add a CD workflow (`release.yml`) that automates binary release on version tags.

## What it does

- **Trigger**: Push a version tag (`v*`) to create a release
- **Build**: Cross-compile all 3 binaries (axon, axon-server, axon-agent) for:
  - linux/amd64, linux/arm64
  - darwin/amd64, darwin/arm64
- **Test**: Run full test suite with race detection before building
- **Checksum**: Generate SHA256 checksums for all artifacts
- **Release**: Auto-create GitHub Release with auto-generated release notes

## Usage

```bash
# Tag and push to trigger a release
git tag v0.1.0
git push origin v0.1.0
```

This creates a GitHub Release at `https://github.com/garysng/axon/releases/tag/v0.1.0` with all binaries attached.

## Files changed

- `.github/workflows/release.yml` (new)