### PR TITLE
fix(server): improve UX for init/start/status commands

### DIFF
--- a/cmd/axon-server/init.go
+++ b/cmd/axon-server/init.go
@@ -46,7 +46,7 @@ func initCmd() *cobra.Command {
 			configPath := filepath.Join(flagDataDir, "config.yaml")
 
 			if _, err := os.Stat(configPath); err == nil && !flagForce {
-				return fmt.Errorf("config already exists at %s; use --force to overwrite", configPath)
+				return fmt.Errorf("config already exists at %s; use --force to overwrite\nTo view join tokens after starting the server, run: axon token list", configPath)
 			}
 
 			if flagAdmin == "" {

--- a/cmd/axon-server/main.go
+++ b/cmd/axon-server/main.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"runtime"
 	"strings"
 	"syscall"
@@ -22,6 +23,7 @@ var version = "dev"
 
 func main() {
 	if err := rootCmd().Execute(); err != nil {
+		_, _ = fmt.Fprintln(os.Stderr, "Error:", err)
 		os.Exit(1)
 	}
 }
@@ -33,7 +35,7 @@ func rootCmd() *cobra.Command {
 		SilenceUsage:  true,
 		SilenceErrors: true,
 	}
-	root.AddCommand(startCmd(), initCmd(), versionCmd())
+	root.AddCommand(startCmd(), initCmd(), versionCmd(), statusCmd())
 	return root
 }
 
@@ -46,6 +48,14 @@ func startCmd() *cobra.Command {
 		Use:   "start",
 		Short: "Start the Axon server",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if configPath == "" {
+				home, err := os.UserHomeDir()
+				if err != nil {
+					return fmt.Errorf("get home dir: %w", err)
+				}
+				configPath = filepath.Join(home, ".axon-server", "config.yaml")
+			}
+
 			cfg, err := loadServerConfig(configPath)
 			if err != nil {
 				return fmt.Errorf("load config: %w", err)
@@ -55,7 +65,8 @@ func startCmd() *cobra.Command {
 				syscall.SIGINT, syscall.SIGTERM)
 			defer cancel()
 
-			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "axon-server %s starting on %s\n", version, cfg.ListenAddr)
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "axon-server %s listening on %s (pid %d)\n",
+				version, cfg.ListenAddr, os.Getpid())
 
 			srv := server.NewServer(*cfg)
 			if err := srv.Start(ctx); err != nil && !errors.Is(err, context.Canceled) {
@@ -65,7 +76,7 @@ func startCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVar(&configPath, "config", "./config.yaml", "config file path")
+	cmd.Flags().StringVar(&configPath, "config", "", "config file path (default: ~/.axon-server/config.yaml)")
 	return cmd
 }
 

--- a/cmd/axon-server/status.go
+++ b/cmd/axon-server/status.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+func statusCmd() *cobra.Command {
+	var configPath string
+
+	cmd := &cobra.Command{
+		Use:   "status",
+		Short: "Check if the Axon server is running",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if configPath == "" {
+				home, err := os.UserHomeDir()
+				if err != nil {
+					return fmt.Errorf("get home dir: %w", err)
+				}
+				configPath = filepath.Join(home, ".axon-server", "config.yaml")
+			}
+
+			cfg, err := loadServerConfig(configPath)
+			if err != nil {
+				return fmt.Errorf("load config: %w", err)
+			}
+
+			addr := cfg.ListenAddr
+			conn, err := net.DialTimeout("tcp", addr, 2*time.Second)
+			if err != nil {
+				_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Server is not running (cannot reach %s)\n", addr)
+				return nil
+			}
+			_ = conn.Close()
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Server is running on %s\n", addr)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&configPath, "config", "", "config file path (default: ~/.axon-server/config.yaml)")
+	return cmd
+}


### PR DESCRIPTION
## What

Fix multiple UX issues found during real-world server deployment testing.

## Issues Fixed

1. **Errors not visible** — `SilenceErrors: true` + `os.Exit(1)` meant users saw zero error output. Now prints `Error: <msg>` to stderr.

2. **`axon-server start` can't find config** — Default was `./config.yaml` but `init` writes to `~/.axon-server/config.yaml`. Now both use the same default path.

3. **Missing `axon-server status`** — New command that TCP dials the configured listen address to check if server is reachable.

4. **Startup message improved** — Shows PID for easier process management: `axon-server v0.1.0 listening on :9090 (pid 12345)`

5. **Re-init error more helpful** — When config already exists, now hints about `axon token list`.

## Changes

- `cmd/axon-server/main.go`: error printing, config default, startup message, add statusCmd
- `cmd/axon-server/init.go`: improved error message
- `cmd/axon-server/status.go`: new status command (TCP dial check)

## Testing

- `go build ./...` ✅
- `go vet ./...` ✅  
- `go test ./cmd/axon-server/` — all 8 tests pass ✅