### PR TITLE
fix: batch UX fixes from deployment testing (#38 #39 #40 #41 #42)

### DIFF
--- a/cmd/axon-agent/join.go
+++ b/cmd/axon-agent/join.go
@@ -72,7 +72,9 @@ exits with an error. Use 'axon-agent start' to reconnect an enrolled node.`,
 			case flagTLSInsecure:
 				transportCreds = grpc.WithTransportCredentials(insecure.NewCredentials())
 			default:
-				transportCreds = grpc.WithTransportCredentials(credentials.NewTLS(&tls.Config{}))
+				// TOFU: join is the trust-establishment step. The server returns
+				// ca_cert_pem which the agent saves for subsequent connections.
+				transportCreds = grpc.WithTransportCredentials(credentials.NewTLS(&tls.Config{InsecureSkipVerify: true})) //nolint:gosec
 			}
 
 			conn, err := grpc.NewClient(serverAddr, transportCreds)

--- a/cmd/axon-agent/main.go
+++ b/cmd/axon-agent/main.go
@@ -169,9 +169,19 @@ func startCmd() *cobra.Command {
 			}
 
 			cfgPath := config.DefaultAgentConfigPath()
+
+			// Check if agent is enrolled (config file exists with a node_id from a successful join).
+			if _, statErr := os.Stat(cfgPath); os.IsNotExist(statErr) {
+				return fmt.Errorf("not enrolled — run \"axon-agent join <server-addr> <token>\" first")
+			}
+
 			cfg, err := config.LoadAgentConfig(cfgPath)
 			if err != nil {
 				return fmt.Errorf("load config: %w", err)
+			}
+
+			if cfg.NodeID == "" {
+				return fmt.Errorf("not enrolled — run \"axon-agent join <server-addr> <token>\" first")
 			}
 
 			// Apply flag overrides only when the flag was explicitly set.

--- a/cmd/axon-agent/main.go
+++ b/cmd/axon-agent/main.go
@@ -27,6 +27,7 @@ var version = "dev"
 
 func main() {
 	if err := rootCmd().Execute(); err != nil {
+		_, _ = fmt.Fprintln(os.Stderr, "Error:", err)
 		var ee *exitError
 		if errors.As(err, &ee) {
 			os.Exit(ee.code)

--- a/cmd/axon-server/init.go
+++ b/cmd/axon-server/init.go
@@ -46,7 +46,7 @@ func initCmd() *cobra.Command {
 			configPath := filepath.Join(flagDataDir, "config.yaml")
 
 			if _, err := os.Stat(configPath); err == nil && !flagForce {
-				return fmt.Errorf("config already exists at %s; use --force to overwrite\nTo view join tokens after starting the server, run: axon token list", configPath)
+				return fmt.Errorf("config already exists at %s\nTo regenerate, use --force. To manage tokens after starting the server, use the CLI: axon token list", configPath)
 			}
 
 			if flagAdmin == "" {

--- a/cmd/axon/auth.go
+++ b/cmd/axon/auth.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bufio"
 	"context"
+	"crypto/tls"
 	"fmt"
 	"os"
 	"os/signal"
@@ -16,7 +17,7 @@ import (
 	managementpb "github.com/garysng/axon/gen/proto/management"
 	"github.com/garysng/axon/pkg/config"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/credentials"
 )
 
 func authCmd() *cobra.Command {
@@ -71,9 +72,20 @@ func authLoginCmd() *cobra.Command {
 			password := string(passwordBytes)
 
 			// Connect without auth — Login RPC is unauthenticated.
-			conn, err := grpc.NewClient(cfg.ServerAddr,
-				grpc.WithTransportCredentials(insecure.NewCredentials()),
-			)
+			// Use TLS with skip-verify by default (self-signed CA is the default server config).
+			var loginOpt grpc.DialOption
+			switch {
+			case cfg.CACert != "":
+				creds, err := credentials.NewClientTLSFromFile(cfg.CACert, "")
+				if err != nil {
+					return fmt.Errorf("load CA cert %q: %w", cfg.CACert, err)
+				}
+				loginOpt = grpc.WithTransportCredentials(creds)
+			default:
+				loginOpt = grpc.WithTransportCredentials(credentials.NewTLS(&tls.Config{InsecureSkipVerify: true})) //nolint:gosec
+			}
+
+			conn, err := grpc.NewClient(cfg.ServerAddr, loginOpt)
 			if err != nil {
 				return fmt.Errorf("connect to server %q: %w", cfg.ServerAddr, err)
 			}

--- a/cmd/axon/client.go
+++ b/cmd/axon/client.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
 
 	managementpb "github.com/garysng/axon/gen/proto/management"
@@ -9,7 +10,6 @@ import (
 	"github.com/garysng/axon/pkg/config"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
-	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/metadata"
 )
 
@@ -49,7 +49,10 @@ func dialConn(withAuth bool) (*grpc.ClientConn, func(), error) {
 		}
 		transportOpt = grpc.WithTransportCredentials(creds)
 	default:
-		transportOpt = grpc.WithTransportCredentials(insecure.NewCredentials())
+		// Default: TLS with skip-verify. The default server deployment uses
+		// auto-TLS with a self-signed CA, so strict verification would fail.
+		// Users who need strict verification should set ca_cert in config.
+		transportOpt = grpc.WithTransportCredentials(credentials.NewTLS(&tls.Config{InsecureSkipVerify: true})) //nolint:gosec
 	}
 
 	opts := []grpc.DialOption{transportOpt}

--- a/cmd/axon/main.go
+++ b/cmd/axon/main.go
@@ -17,6 +17,7 @@ var version = "dev"
 
 func main() {
 	if err := rootCmd().Execute(); err != nil {
+		_, _ = fmt.Fprintln(os.Stderr, "Error:", err)
 		var ee *exitError
 		if errors.As(err, &ee) {
 			os.Exit(ee.code)

--- a/internal/server/control.go
+++ b/internal/server/control.go
@@ -107,6 +107,7 @@ func (cs *ControlService) Connect(stream controlpb.ControlService_ConnectServer)
 
 	// Mark node offline on disconnect (regardless of reason).
 	defer func() {
+		log.Printf("server: node %q (id=%s) disconnected", req.NodeName, nodeID)
 		if err := cs.reg.MarkOffline(nodeID); err != nil {
 			log.Printf("control: mark offline %s: %v", nodeID, err)
 		}
@@ -128,6 +129,8 @@ func (cs *ControlService) Connect(stream controlpb.ControlService_ConnectServer)
 	}); err != nil {
 		return status.Errorf(codes.Internal, "control: send register response: %v", err)
 	}
+
+	log.Printf("server: node %q (id=%s) connected", req.NodeName, nodeID)
 
 	// ── Step 2: message loop ───────────────────────────────────────────────────
 	for {

--- a/internal/server/management.go
+++ b/internal/server/management.go
@@ -118,6 +118,8 @@ func (s *ManagementService) Login(_ context.Context, req *managementpb.LoginRequ
 			ExpiresAt: now.Add(tokenExpiry).Unix(),
 		})
 	}
+	log.Printf("server: user %q logged in", req.GetUsername())
+
 	return &managementpb.LoginResponse{
 		Token:     tok,
 		ExpiresAt: now.Add(tokenExpiry).Unix(),
@@ -355,6 +357,8 @@ func (s *ManagementService) JoinAgent(_ context.Context, req *managementpb.JoinA
 	if hbSeconds == 0 {
 		hbSeconds = 10
 	}
+
+	log.Printf("server: node %q (id=%s) enrolled via join-token", nodeName, nodeID)
 
 	return &managementpb.JoinAgentResponse{
 		Success:                  true,


### PR DESCRIPTION
## Summary

Batch fix for all UX issues found during real-world deployment testing.

## Issues Fixed

### #38 — Print errors to stderr for axon-agent and axon CLI
Both binaries had `SilenceErrors: true` + `os.Exit(1)` without printing. All command errors were silently swallowed.

### #39 — Agent join defaults to TLS skip-verify
`axon-agent join` now uses TOFU (Trust On First Use) model — same as SSH first connect. The join token IS the trust establishment; server returns `ca_cert_pem` for subsequent connections.

### #40 — CLI TLS works out-of-box with self-signed cert servers
Default changed from plaintext to TLS with skip-verify. The default server uses auto-TLS self-signed CA, so strict verification fails. Also fixed `axon auth login` which hardcoded plaintext.

### #41 — Agent start without enrollment fails clearly
Previously `axon-agent start` before `join` silently connected to 127.0.0.1:50051 and entered infinite reconnect loop. Now checks for config file + node_id and shows: `Error: not enrolled — run "axon-agent join <server-addr> <token>" first`

### #42 — Server operational logging
Added `log.Printf` for: node enrollment, connection, disconnection, user login. Previously server produced zero output after startup.

### Init error message improvement
Clearer message when config already exists.

## Testing

- `go build ./...` ✅
- `go vet ./...` ✅
- All tests pass ✅ (11 packages)