### PR TITLE
fix: TLS config-driven + agent auth retry (#44 #45)

### DIFF
--- a/cmd/axon-agent/join.go
+++ b/cmd/axon-agent/join.go
@@ -22,10 +22,8 @@ import (
 
 func joinCmd() *cobra.Command {
 	var (
-		flagName       string
-		flagLabels     []string
-		flagCACert     string
-		flagTLSInsecure bool
+		flagName   string
+		flagLabels []string
 	)
 
 	cmd := &cobra.Command{
@@ -38,7 +36,10 @@ and saves the configuration to ~/.axon-agent/config.yaml. Then starts the
 agent control-plane loop in the foreground.
 
 If the node is already enrolled (node_id is present in config), this command
-exits with an error. Use 'axon-agent start' to reconnect an enrolled node.`,
+exits with an error. Use 'axon-agent start' to reconnect an enrolled node.
+
+TLS is controlled via config (axon-agent config set tls_insecure true).
+For non-TLS servers (default), no extra config is needed.`,
 		Args: cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			serverAddr := args[0]
@@ -46,9 +47,12 @@ exits with an error. Use 'axon-agent start' to reconnect an enrolled node.`,
 
 			cfgPath := config.DefaultAgentConfigPath()
 
+			// Load existing config for TLS settings (may not exist yet — defaults are fine).
+			existingCfg, _ := config.LoadAgentConfig(cfgPath)
+
 			// Refuse to re-enroll an already-enrolled node.
-			if existing, err := config.LoadAgentConfig(cfgPath); err == nil && existing.NodeID != "" {
-				return fmt.Errorf("node already enrolled (node_id=%s); use 'axon-agent start' to connect", existing.NodeID)
+			if existingCfg != nil && existingCfg.NodeID != "" {
+				return fmt.Errorf("node already enrolled (node_id=%s); use 'axon-agent start' to connect", existingCfg.NodeID)
 			}
 
 			// Collect system information for the enrollment request.
@@ -59,22 +63,20 @@ exits with an error. Use 'axon-agent start' to reconnect an enrolled node.`,
 				nodeName = info.Hostname
 			}
 
-			// Build transport credentials: custom CA → TLS from file;
-			// --tls-insecure → plaintext; default → system TLS.
+			// Build transport credentials from agent config.
+			// Priority: ca_cert > tls_insecure > plaintext (default).
 			var transportCreds grpc.DialOption
 			switch {
-			case flagCACert != "":
-				creds, err := credentials.NewClientTLSFromFile(flagCACert, "")
+			case existingCfg != nil && existingCfg.CACert != "":
+				creds, err := credentials.NewClientTLSFromFile(existingCfg.CACert, "")
 				if err != nil {
-					return fmt.Errorf("load CA cert %q: %w", flagCACert, err)
+					return fmt.Errorf("load CA cert %q: %w", existingCfg.CACert, err)
 				}
 				transportCreds = grpc.WithTransportCredentials(creds)
-			case flagTLSInsecure:
-				transportCreds = grpc.WithTransportCredentials(insecure.NewCredentials())
-			default:
-				// TOFU: join is the trust-establishment step. The server returns
-				// ca_cert_pem which the agent saves for subsequent connections.
+			case existingCfg != nil && existingCfg.TLSInsecure:
 				transportCreds = grpc.WithTransportCredentials(credentials.NewTLS(&tls.Config{InsecureSkipVerify: true})) //nolint:gosec
+			default:
+				transportCreds = grpc.WithTransportCredentials(insecure.NewCredentials())
 			}
 
 			conn, err := grpc.NewClient(serverAddr, transportCreds)
@@ -157,7 +159,5 @@ exits with an error. Use 'axon-agent start' to reconnect an enrolled node.`,
 
 	cmd.Flags().StringVar(&flagName, "name", "", "node name (default: hostname)")
 	cmd.Flags().StringArrayVar(&flagLabels, "labels", nil, "label as key=value (repeatable)")
-	cmd.Flags().StringVar(&flagCACert, "ca-cert", "", "path to CA certificate for TLS verification")
-	cmd.Flags().BoolVar(&flagTLSInsecure, "tls-insecure", false, "disable TLS certificate verification")
 	return cmd
 }

--- a/cmd/axon-agent/main.go
+++ b/cmd/axon-agent/main.go
@@ -416,7 +416,7 @@ func agentConfigGetCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "get <key>",
 		Short: "Get a config value",
-		Long:  "Supported keys: server, token, name",
+		Long:  "Supported keys: server, token, name, tls_insecure, ca_cert",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cfg, err := config.LoadAgentConfig(config.DefaultAgentConfigPath())
@@ -430,8 +430,12 @@ func agentConfigGetCmd() *cobra.Command {
 				_, _ = fmt.Fprintln(os.Stdout, display.MaskToken(cfg.Token))
 			case "name":
 				_, _ = fmt.Fprintln(os.Stdout, cfg.NodeName)
+			case "tls_insecure":
+				_, _ = fmt.Fprintln(os.Stdout, cfg.TLSInsecure)
+			case "ca_cert":
+				_, _ = fmt.Fprintln(os.Stdout, cfg.CACert)
 			default:
-				return fmt.Errorf("unknown config key: %s (supported: server, token, name)", args[0])
+				return fmt.Errorf("unknown config key: %s (supported: server, token, name, tls_insecure, ca_cert)", args[0])
 			}
 			return nil
 		},
@@ -442,7 +446,7 @@ func agentConfigSetCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "set <key> <value>",
 		Short: "Set a config value",
-		Long:  "Supported keys: server, token, name",
+		Long:  "Supported keys: server, token, name, tls_insecure, ca_cert",
 		Args:  cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cfgPath := config.DefaultAgentConfigPath()
@@ -458,8 +462,12 @@ func agentConfigSetCmd() *cobra.Command {
 				cfg.Token = value
 			case "name":
 				cfg.NodeName = value
+			case "tls_insecure":
+				cfg.TLSInsecure = value == "true" || value == "1"
+			case "ca_cert":
+				cfg.CACert = value
 			default:
-				return fmt.Errorf("unknown config key: %s (supported: server, token, name)", key)
+				return fmt.Errorf("unknown config key: %s (supported: server, token, name, tls_insecure, ca_cert)", key)
 			}
 			if err := config.SaveAgentConfig(cfgPath, cfg); err != nil {
 				return fmt.Errorf("save config: %w", err)

--- a/cmd/axon-server/init.go
+++ b/cmd/axon-server/init.go
@@ -173,17 +173,28 @@ func initCmd() *cobra.Command {
 			_, _ = fmt.Fprintf(out, "   Config:     %s\n", configPath)
 			_, _ = fmt.Fprintf(out, "   Database:   %s\n", dbPath)
 			_, _ = fmt.Fprintf(out, "   Listen:     %s\n", flagListen)
+			if flagTLS {
+				_, _ = fmt.Fprintf(out, "   TLS:        enabled (auto-TLS)\n")
+			} else {
+				_, _ = fmt.Fprintf(out, "   TLS:        disabled\n")
+			}
 			_, _ = fmt.Fprintf(out, "   Admin user: %s\n", flagAdmin)
 			_, _ = fmt.Fprintln(out)
 			_, _ = fmt.Fprintln(out, "Start the server:")
-			_, _ = fmt.Fprintf(out, "   axon-server start --config %s\n", configPath)
+			_, _ = fmt.Fprintf(out, "   axon-server start\n")
 			_, _ = fmt.Fprintln(out)
 			_, _ = fmt.Fprintln(out, "Join a node:")
+			if flagTLS {
+				_, _ = fmt.Fprintf(out, "   axon-agent config set tls_insecure true\n")
+			}
 			_, _ = fmt.Fprintf(out, "   axon-agent join <SERVER_IP>%s %s\n", flagListen, joinToken)
 			_, _ = fmt.Fprintln(out)
 			_, _ = fmt.Fprintln(out, "Use CLI:")
 			_, _ = fmt.Fprintf(out, "   axon config set server <SERVER_IP>%s\n", flagListen)
-			_, _ = fmt.Fprintln(out, "   axon auth login")
+			if flagTLS {
+				_, _ = fmt.Fprintf(out, "   axon config set tls_insecure true\n")
+			}
+			_, _ = fmt.Fprintf(out, "   axon auth login -u %s -p <password>\n", flagAdmin)
 			return nil
 		},
 	}

--- a/cmd/axon/auth.go
+++ b/cmd/axon/auth.go
@@ -3,7 +3,6 @@ package main
 import (
 	"bufio"
 	"context"
-	"crypto/tls"
 	"fmt"
 	"os"
 	"os/signal"
@@ -17,7 +16,6 @@ import (
 	managementpb "github.com/garysng/axon/gen/proto/management"
 	"github.com/garysng/axon/pkg/config"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials"
 )
 
 func authCmd() *cobra.Command {
@@ -32,12 +30,16 @@ func authCmd() *cobra.Command {
 // ── auth login ─────────────────────────────────────────────────────────────
 
 func authLoginCmd() *cobra.Command {
-	var serverAddr string
+	var (
+		serverAddr string
+		flagUser   string
+		flagPass   string
+	)
 
 	cmd := &cobra.Command{
 		Use:   "login",
 		Short: "Authenticate with the Axon server",
-		Long:  "Prompts for username and password, then requests a JWT token from the server.",
+		Long:  "Authenticates with username and password, then saves a JWT token.\nUse -u and -p for non-interactive mode, or omit for interactive prompts.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cfgPath := config.DefaultCLIConfigPath()
 			cfg, err := config.LoadCLIConfig(cfgPath)
@@ -53,39 +55,36 @@ func authLoginCmd() *cobra.Command {
 				return fmt.Errorf("server address not configured; use --server flag or run: axon config set server <addr>")
 			}
 
-			// Prompt for username.
-			reader := bufio.NewReader(os.Stdin)
-			_, _ = fmt.Fprint(cmd.OutOrStdout(), "Username: ")
-			username, err := reader.ReadString('\n')
-			if err != nil {
-				return fmt.Errorf("read username: %w", err)
-			}
-			username = strings.TrimSpace(username)
+			username := flagUser
+			password := flagPass
 
-			// Prompt for password (hide input).
-			_, _ = fmt.Fprint(cmd.OutOrStdout(), "Password: ")
-			passwordBytes, err := term.ReadPassword(int(os.Stdin.Fd()))
-			_, _ = fmt.Fprintln(cmd.OutOrStdout()) // newline after hidden input
-			if err != nil {
-				return fmt.Errorf("read password: %w", err)
+			// Interactive prompts when flags are not provided.
+			if username == "" {
+				reader := bufio.NewReader(os.Stdin)
+				_, _ = fmt.Fprint(cmd.OutOrStdout(), "Username: ")
+				username, err = reader.ReadString('\n')
+				if err != nil {
+					return fmt.Errorf("read username: %w", err)
+				}
+				username = strings.TrimSpace(username)
 			}
-			password := string(passwordBytes)
+			if password == "" {
+				_, _ = fmt.Fprint(cmd.OutOrStdout(), "Password: ")
+				passwordBytes, err := term.ReadPassword(int(os.Stdin.Fd()))
+				_, _ = fmt.Fprintln(cmd.OutOrStdout()) // newline after hidden input
+				if err != nil {
+					return fmt.Errorf("read password: %w", err)
+				}
+				password = string(passwordBytes)
+			}
 
 			// Connect without auth — Login RPC is unauthenticated.
-			// Use TLS with skip-verify by default (self-signed CA is the default server config).
-			var loginOpt grpc.DialOption
-			switch {
-			case cfg.CACert != "":
-				creds, err := credentials.NewClientTLSFromFile(cfg.CACert, "")
-				if err != nil {
-					return fmt.Errorf("load CA cert %q: %w", cfg.CACert, err)
-				}
-				loginOpt = grpc.WithTransportCredentials(creds)
-			default:
-				loginOpt = grpc.WithTransportCredentials(credentials.NewTLS(&tls.Config{InsecureSkipVerify: true})) //nolint:gosec
+			transportOpt, err := cliTransport(cfg)
+			if err != nil {
+				return err
 			}
 
-			conn, err := grpc.NewClient(cfg.ServerAddr, loginOpt)
+			conn, err := grpc.NewClient(cfg.ServerAddr, transportOpt)
 			if err != nil {
 				return fmt.Errorf("connect to server %q: %w", cfg.ServerAddr, err)
 			}
@@ -117,6 +116,8 @@ func authLoginCmd() *cobra.Command {
 	}
 
 	cmd.Flags().StringVar(&serverAddr, "server", "", "server address (saved to config)")
+	cmd.Flags().StringVarP(&flagUser, "username", "u", "", "username (non-interactive)")
+	cmd.Flags().StringVarP(&flagPass, "password", "p", "", "password (non-interactive)")
 	return cmd
 }
 

--- a/cmd/axon/client.go
+++ b/cmd/axon/client.go
@@ -10,15 +10,26 @@ import (
 	"github.com/garysng/axon/pkg/config"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/metadata"
 )
 
-// globalCACert and globalTLSInsecure are set by persistent root flags (--ca-cert,
-// --tls-insecure) and override values read from the CLI config file.
-var (
-	globalCACert      string
-	globalTLSInsecure bool
-)
+// cliTransport returns a gRPC dial option based on CLI config TLS settings.
+// Priority: ca_cert (strict TLS) > tls_insecure (TLS skip-verify) > plaintext.
+func cliTransport(cfg *config.CLIConfig) (grpc.DialOption, error) {
+	switch {
+	case cfg.CACert != "":
+		creds, err := credentials.NewClientTLSFromFile(cfg.CACert, "")
+		if err != nil {
+			return nil, fmt.Errorf("load CA cert %q: %w", cfg.CACert, err)
+		}
+		return grpc.WithTransportCredentials(creds), nil
+	case cfg.TLSInsecure:
+		return grpc.WithTransportCredentials(credentials.NewTLS(&tls.Config{InsecureSkipVerify: true})), nil //nolint:gosec
+	default:
+		return grpc.WithTransportCredentials(insecure.NewCredentials()), nil
+	}
+}
 
 // dialConn creates a gRPC connection to the Axon server using CLI config.
 // If withAuth is true, the connection includes the JWT token as bearer metadata.
@@ -32,27 +43,9 @@ func dialConn(withAuth bool) (*grpc.ClientConn, func(), error) {
 		return nil, nil, fmt.Errorf("server address not configured; run: axon config set server <addr>")
 	}
 
-	// Flags override config-file values.
-	if globalCACert != "" {
-		cfg.CACert = globalCACert
-	}
-	if globalTLSInsecure {
-		cfg.TLSInsecure = true
-	}
-
-	var transportOpt grpc.DialOption
-	switch {
-	case cfg.CACert != "":
-		creds, err := credentials.NewClientTLSFromFile(cfg.CACert, "")
-		if err != nil {
-			return nil, nil, fmt.Errorf("load CA cert %q: %w", cfg.CACert, err)
-		}
-		transportOpt = grpc.WithTransportCredentials(creds)
-	default:
-		// Default: TLS with skip-verify. The default server deployment uses
-		// auto-TLS with a self-signed CA, so strict verification would fail.
-		// Users who need strict verification should set ca_cert in config.
-		transportOpt = grpc.WithTransportCredentials(credentials.NewTLS(&tls.Config{InsecureSkipVerify: true})) //nolint:gosec
+	transportOpt, err := cliTransport(cfg)
+	if err != nil {
+		return nil, nil, err
 	}
 
 	opts := []grpc.DialOption{transportOpt}

--- a/cmd/axon/main.go
+++ b/cmd/axon/main.go
@@ -35,9 +35,6 @@ func rootCmd() *cobra.Command {
 		SilenceErrors: true,
 	}
 
-	root.PersistentFlags().StringVar(&globalCACert, "ca-cert", "", "path to CA certificate for TLS verification")
-	root.PersistentFlags().BoolVar(&globalTLSInsecure, "tls-insecure", false, "skip TLS certificate verification (insecure)")
-
 	root.AddCommand(
 		versionCmd(),
 		configCmd(),

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -8,12 +8,15 @@ import (
 	"log"
 	"math"
 	"math/rand/v2"
+	"strings"
 	"sync"
 	"time"
 
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
 
 	controlpb "github.com/garysng/axon/gen/proto/control"
 	"github.com/garysng/axon/pkg/config"
@@ -74,16 +77,60 @@ func (a *Agent) EnableDataPlane() {
 	a.dataPlane = true
 }
 
+// isPermanentAuthError returns true if the error indicates a permanent
+// authentication failure that will not resolve with retries.
+func isPermanentAuthError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	// Check for known permanent error patterns.
+	for _, pattern := range []string{
+		"invalid token",
+		"registration failed",
+		"Unauthenticated",
+		"PermissionDenied",
+		"token mismatch",
+	} {
+		if strings.Contains(msg, pattern) {
+			return true
+		}
+	}
+	// Check gRPC status codes.
+	if st, ok := status.FromError(err); ok {
+		switch st.Code() {
+		case codes.Unauthenticated, codes.PermissionDenied:
+			return true
+		}
+	}
+	return false
+}
+
 // Run connects to the server and enters the main control loop. It reconnects
 // with exponential backoff on connection failures. Run blocks until ctx is
-// cancelled.
+// cancelled. Permanent auth errors (invalid token, etc.) stop after 3 attempts.
 func (a *Agent) Run(ctx context.Context) error {
 	var attempt int
+	var authFailures int
+	const maxAuthFailures = 3
+
 	for {
 		err := a.runOnce(ctx)
 		if ctx.Err() != nil {
 			return ctx.Err()
 		}
+
+		if isPermanentAuthError(err) {
+			authFailures++
+			if authFailures >= maxAuthFailures {
+				log.Printf("agent: authentication failed %d times (%v) — server may have been re-initialized", authFailures, err)
+				log.Printf("agent: stopping. To re-enroll: rm -rf ~/.axon-agent && axon-agent join <server-addr> <token>")
+				return fmt.Errorf("permanent auth error after %d attempts: %w", authFailures, err)
+			}
+		} else {
+			authFailures = 0 // reset on transient errors
+		}
+
 		attempt++
 		delay := backoff(attempt)
 		log.Printf("agent: connection lost (%v), reconnecting in %s (attempt %d)", err, delay, attempt)

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
 	"io"
 	"log"
@@ -147,6 +148,7 @@ func (a *Agent) runOnce(ctx context.Context) error {
 }
 
 // dial creates a gRPC client connection to the configured server.
+// Transport priority: ca_cert (strict TLS) > tls_insecure (TLS skip-verify) > plaintext.
 func (a *Agent) dial(ctx context.Context) (*grpc.ClientConn, error) {
 	opts := []grpc.DialOption{}
 
@@ -157,6 +159,8 @@ func (a *Agent) dial(ctx context.Context) (*grpc.ClientConn, error) {
 			return nil, fmt.Errorf("load CA cert %q: %w", a.cfg.CACert, err)
 		}
 		opts = append(opts, grpc.WithTransportCredentials(creds))
+	case a.cfg.TLSInsecure:
+		opts = append(opts, grpc.WithTransportCredentials(credentials.NewTLS(&tls.Config{InsecureSkipVerify: true}))) //nolint:gosec
 	default:
 		opts = append(opts, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	}

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -156,10 +156,9 @@ func (e *testEnv) agentConfig(t *testing.T) config.AgentConfig {
 		t.Fatalf("sign token: %v", err)
 	}
 	return config.AgentConfig{
-		ServerAddr:  "passthrough://bufnet",
-		Token:       tok,
-		NodeName:    "test-agent",
-		TLSInsecure: true,
+		ServerAddr: "passthrough://bufnet",
+		Token:      tok,
+		NodeName:   "test-agent",
 	}
 }
 

--- a/test/integration/testharness/harness.go
+++ b/test/integration/testharness/harness.go
@@ -124,10 +124,9 @@ func NewHarness(t *testing.T, options ...HarnessOption) *Harness {
 	}
 
 	agentCfg := config.AgentConfig{
-		ServerAddr:  "passthrough://bufnet",
-		Token:       agentToken,
-		NodeName:    opts.agentNodeName,
-		TLSInsecure: true,
+		ServerAddr: "passthrough://bufnet",
+		Token:      agentToken,
+		NodeName:   opts.agentNodeName,
 	}
 
 	agt := agent.NewAgent(agentCfg, "")
@@ -281,7 +280,6 @@ func (h *Harness) ConnectAgent(name string) (*agent.Agent, string) {
 		ServerAddr:  "passthrough://bufnet",
 		Token:       agentToken,
 		NodeName:    name,
-		TLSInsecure: true,
 	}
 
 	agt := agent.NewAgent(agentCfg, "")
@@ -311,7 +309,6 @@ func (h *Harness) ConnectAgentWithToken(name, token string) (*agent.Agent, strin
 		ServerAddr:  "passthrough://bufnet",
 		Token:       token,
 		NodeName:    name,
-		TLSInsecure: true,
 	}
 
 	agt := agent.NewAgent(agentCfg, "")
@@ -343,7 +340,6 @@ func (h *Harness) ConnectAgentWithHandler(name string, handler agent.TaskHandler
 		ServerAddr:  "passthrough://bufnet",
 		Token:       agentToken,
 		NodeName:    name,
-		TLSInsecure: true,
 	}
 
 	agt := agent.NewAgent(agentCfg, "")


### PR DESCRIPTION
## Summary

Two issues from deployment testing: TLS regression and agent infinite retry on auth errors.

## #44 — TLS is config-driven, remove all CLI/agent TLS flags

**Design principle: TLS is a config-only setting. No TLS flags on any command.**

### Changes:
- **Remove** `--tls-insecure` and `--ca-cert` persistent flags from `axon` CLI
- **Remove** `--tls-insecure` and `--ca-cert` flags from `axon-agent join`
- **Transport logic** (shared by CLI + agent): `ca_cert` > `tls_insecure` > plaintext (default)
- **Agent config** `get/set` now supports `tls_insecure` and `ca_cert` keys
- **Login** supports `-u`/`-p` for non-interactive mode
- **Server init** shows conditional TLS setup hints:
  - With `--tls`: includes `axon config set tls_insecure true` steps
  - Without `--tls`: clean plaintext instructions
- **Shared `cliTransport()`** helper for consistent transport selection

### Config commands:
```bash
# CLI
axon config set tls_insecure true
axon config set ca_cert /path/to/ca.crt

# Agent
axon-agent config set tls_insecure true
axon-agent config set ca_cert /path/to/ca.crt
```

## #45 — Agent stops retrying on permanent auth errors

Previously, `axon-agent` retried forever on `invalid token` / `Unauthenticated` errors after server re-init. Now:
- **Transient errors** (connection refused, unavailable) → retry with backoff (unchanged)
- **Permanent auth errors** (invalid token, Unauthenticated, PermissionDenied) → stop after 3 attempts with actionable message:
  ```
  agent: authentication failed 3 times — server may have been re-initialized
  agent: stopping. To re-enroll: rm -rf ~/.axon-agent && axon-agent join <server-addr> <token>
  ```

## Testing
- `go build ./...` ✅
- `go vet ./...` ✅
- All unit tests pass ✅
- All integration tests pass ✅