### PR TITLE
fix(server): Ctrl+C termination + daemon mode + stop command (#49 #50)

### DIFF
--- a/cmd/axon-server/main.go
+++ b/cmd/axon-server/main.go
@@ -5,9 +5,11 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"os/exec"
 	"os/signal"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 	"syscall"
 	"time"
@@ -34,25 +36,70 @@ func rootCmd() *cobra.Command {
 		SilenceUsage:  true,
 		SilenceErrors: true,
 	}
-	root.AddCommand(startCmd(), initCmd(), versionCmd(), statusCmd())
+	root.AddCommand(startCmd(), stopCmd(), initCmd(), versionCmd(), statusCmd())
 	return root
+}
+
+// ── path helpers ───────────────────────────────────────────────────────────
+
+func defaultDataDir() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "~/.axon-server"
+	}
+	return filepath.Join(home, ".axon-server")
+}
+
+func pidFilePath() string {
+	return filepath.Join(defaultDataDir(), "server.pid")
+}
+
+func logFilePath() string {
+	return filepath.Join(defaultDataDir(), "server.log")
+}
+
+func writePID(path string, pid int) error {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		return fmt.Errorf("create dir: %w", err)
+	}
+	return os.WriteFile(path, []byte(strconv.Itoa(pid)+"\n"), 0600)
+}
+
+func readPID(path string) (int, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return 0, err
+	}
+	pid, err := strconv.Atoi(strings.TrimSpace(string(data)))
+	if err != nil {
+		return 0, fmt.Errorf("invalid PID in file: %w", err)
+	}
+	return pid, nil
+}
+
+func isProcessRunning(pid int) bool {
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		return false
+	}
+	return proc.Signal(syscall.Signal(0)) == nil
 }
 
 // ── start ──────────────────────────────────────────────────────────────────
 
 func startCmd() *cobra.Command {
-	var configPath string
+	var (
+		configPath     string
+		flagForeground bool
+	)
 
 	cmd := &cobra.Command{
 		Use:   "start",
 		Short: "Start the Axon server",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if configPath == "" {
-				home, err := os.UserHomeDir()
-				if err != nil {
-					return fmt.Errorf("get home dir: %w", err)
-				}
-				configPath = filepath.Join(home, ".axon-server", "config.yaml")
+				configPath = filepath.Join(defaultDataDir(), "config.yaml")
 			}
 
 			cfg, err := loadServerConfig(configPath)
@@ -60,23 +107,127 @@ func startCmd() *cobra.Command {
 				return fmt.Errorf("load config: %w", err)
 			}
 
-			ctx, cancel := signal.NotifyContext(context.Background(),
-				syscall.SIGINT, syscall.SIGTERM)
-			defer cancel()
-
-			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "axon-server %s listening on %s (pid %d)\n",
-				version, cfg.ListenAddr, os.Getpid())
-
-			srv := server.NewServer(*cfg)
-			if err := srv.Start(ctx); err != nil && !errors.Is(err, context.Canceled) {
-				return fmt.Errorf("server: %w", err)
+			// Prevent double-start.
+			pidPath := pidFilePath()
+			if pid, err := readPID(pidPath); err == nil && isProcessRunning(pid) {
+				return fmt.Errorf("server is already running (PID %d)", pid)
 			}
-			return nil
+
+			if flagForeground {
+				return runServerForeground(cmd, cfg, pidPath)
+			}
+			return runServerDaemon(cmd, configPath)
 		},
 	}
 
 	cmd.Flags().StringVar(&configPath, "config", "", "config file path (default: ~/.axon-server/config.yaml)")
+	cmd.Flags().BoolVar(&flagForeground, "foreground", false, "run in foreground (do not daemonize)")
 	return cmd
+}
+
+// runServerForeground runs the server in the foreground, blocking until signal.
+func runServerForeground(cmd *cobra.Command, cfg *server.ServerConfig, pidPath string) error {
+	if err := writePID(pidPath, os.Getpid()); err != nil {
+		return fmt.Errorf("write PID: %w", err)
+	}
+	defer func() { _ = os.Remove(pidPath) }()
+
+	ctx, cancel := signal.NotifyContext(context.Background(),
+		syscall.SIGINT, syscall.SIGTERM)
+	defer cancel()
+
+	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "axon-server %s listening on %s (pid %d)\n",
+		version, cfg.ListenAddr, os.Getpid())
+
+	srv := server.NewServer(*cfg)
+	if err := srv.Start(ctx); err != nil && !errors.Is(err, context.Canceled) {
+		return fmt.Errorf("server: %w", err)
+	}
+	return nil
+}
+
+// runServerDaemon re-execs self with --foreground, detached from the terminal.
+func runServerDaemon(cmd *cobra.Command, configPath string) error {
+	exe, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("get executable path: %w", err)
+	}
+
+	args := []string{"start", "--foreground"}
+	if configPath != "" {
+		args = append(args, "--config", configPath)
+	}
+
+	logPath := logFilePath()
+	if err := os.MkdirAll(filepath.Dir(logPath), 0700); err != nil {
+		return fmt.Errorf("create log dir: %w", err)
+	}
+	logFile, err := os.OpenFile(logPath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0600)
+	if err != nil {
+		return fmt.Errorf("open log file: %w", err)
+	}
+	defer func() { _ = logFile.Close() }()
+
+	daemonCmd := exec.Command(exe, args...)
+	daemonCmd.Stdout = logFile
+	daemonCmd.Stderr = logFile
+	daemonCmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+	if err := daemonCmd.Start(); err != nil {
+		return fmt.Errorf("start daemon: %w", err)
+	}
+
+	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "axon-server started (pid %d), log: %s\n", daemonCmd.Process.Pid, logPath)
+	return nil
+}
+
+// ── stop ───────────────────────────────────────────────────────────────────
+
+func stopCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "stop",
+		Short: "Stop the running server",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			pidPath := pidFilePath()
+			pid, err := readPID(pidPath)
+			if err != nil {
+				if errors.Is(err, os.ErrNotExist) {
+					return fmt.Errorf("server is not running (no PID file)")
+				}
+				return fmt.Errorf("read PID: %w", err)
+			}
+
+			if !isProcessRunning(pid) {
+				_ = os.Remove(pidPath)
+				return fmt.Errorf("server is not running (stale PID %d)", pid)
+			}
+
+			proc, err := os.FindProcess(pid)
+			if err != nil {
+				return fmt.Errorf("find process %d: %w", pid, err)
+			}
+
+			if err := proc.Signal(syscall.SIGTERM); err != nil {
+				return fmt.Errorf("send SIGTERM to %d: %w", pid, err)
+			}
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Sent SIGTERM to pid %d, waiting...\n", pid)
+
+			deadline := time.Now().Add(10 * time.Second)
+			for time.Now().Before(deadline) {
+				if !isProcessRunning(pid) {
+					_ = os.Remove(pidPath)
+					_, _ = fmt.Fprintln(cmd.OutOrStdout(), "axon-server stopped")
+					return nil
+				}
+				time.Sleep(200 * time.Millisecond)
+			}
+
+			// Process did not exit within 10s — escalate to SIGKILL.
+			_ = proc.Signal(syscall.SIGKILL)
+			_ = os.Remove(pidPath)
+			_, _ = fmt.Fprintln(cmd.OutOrStdout(), "axon-server killed (did not exit within 10s)")
+			return nil
+		},
+	}
 }
 
 // ── version ────────────────────────────────────────────────────────────────

--- a/cmd/axon-server/status.go
+++ b/cmd/axon-server/status.go
@@ -4,44 +4,51 @@ import (
 	"fmt"
 	"net"
 	"os"
-	"path/filepath"
 	"time"
 
 	"github.com/spf13/cobra"
 )
 
 func statusCmd() *cobra.Command {
-	var configPath string
-
 	cmd := &cobra.Command{
 		Use:   "status",
 		Short: "Check if the Axon server is running",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if configPath == "" {
-				home, err := os.UserHomeDir()
-				if err != nil {
-					return fmt.Errorf("get home dir: %w", err)
+			out := cmd.OutOrStdout()
+
+			// Check PID file.
+			pidPath := pidFilePath()
+			pid, pidErr := readPID(pidPath)
+			running := pidErr == nil && isProcessRunning(pid)
+
+			if running {
+				_, _ = fmt.Fprintf(out, "Status:  running\n")
+				_, _ = fmt.Fprintf(out, "PID:     %d\n", pid)
+
+				// Show uptime from PID file mtime.
+				if info, err := os.Stat(pidPath); err == nil {
+					uptime := time.Since(info.ModTime()).Truncate(time.Second)
+					_, _ = fmt.Fprintf(out, "Uptime:  %s\n", uptime)
 				}
-				configPath = filepath.Join(home, ".axon-server", "config.yaml")
+			} else {
+				_, _ = fmt.Fprintf(out, "Status:  stopped\n")
 			}
 
-			cfg, err := loadServerConfig(configPath)
-			if err != nil {
-				return fmt.Errorf("load config: %w", err)
+			// Also try TCP dial to check if port is reachable.
+			configPath := defaultDataDir() + "/config.yaml"
+			if cfg, err := loadServerConfig(configPath); err == nil {
+				conn, err := net.DialTimeout("tcp", cfg.ListenAddr, 2*time.Second)
+				if err == nil {
+					_ = conn.Close()
+					_, _ = fmt.Fprintf(out, "Listen:  %s (reachable)\n", cfg.ListenAddr)
+				} else if running {
+					_, _ = fmt.Fprintf(out, "Listen:  %s (not reachable)\n", cfg.ListenAddr)
+				}
 			}
 
-			addr := cfg.ListenAddr
-			conn, err := net.DialTimeout("tcp", addr, 2*time.Second)
-			if err != nil {
-				_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Server is not running (cannot reach %s)\n", addr)
-				return nil
-			}
-			_ = conn.Close()
-			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Server is running on %s\n", addr)
+			_, _ = fmt.Fprintf(out, "Log:     %s\n", logFilePath())
 			return nil
 		},
 	}
-
-	cmd.Flags().StringVar(&configPath, "config", "", "config file path (default: ~/.axon-server/config.yaml)")
 	return cmd
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -184,9 +184,22 @@ func (s *Server) serve(ctx context.Context, lis net.Listener) error {
 	s.registry.StartMonitor(ctx)
 
 	// Stop the gRPC server when the context is cancelled.
+	// GracefulStop waits for all RPCs to finish, but long-lived bidi streams
+	// (e.g. Control.Connect) may never end. Fall back to Stop after 5s.
 	go func() {
 		<-ctx.Done()
-		s.grpc.GracefulStop()
+		done := make(chan struct{})
+		go func() {
+			s.grpc.GracefulStop()
+			close(done)
+		}()
+		select {
+		case <-done:
+			log.Println("server: graceful shutdown complete")
+		case <-time.After(5 * time.Second):
+			log.Println("server: graceful shutdown timed out, forcing stop")
+			s.grpc.Stop()
+		}
 	}()
 
 	if err := s.grpc.Serve(lis); err != nil {


### PR DESCRIPTION
## Summary

Fix server cannot be terminated with Ctrl+C, and add daemon mode parity with axon-agent.

## #50 — Ctrl+C fails to terminate server

**Root cause**: `GracefulStop()` waits for all RPCs to finish, but `Control.Connect` is a long-lived bidi stream that never ends.

**Fix**: 5-second timeout on graceful shutdown, then force `Stop()`:
```go
select {
case <-done:  // clean shutdown
case <-time.After(5 * time.Second):
    s.grpc.Stop()  // force
}
```

## #49 — Daemon mode and stop command

Now matches axon-agent behavior:

| Command | Behavior |
|---------|----------|
| `axon-server start` | Daemonize, write PID to `~/.axon-server/server.pid`, log to `server.log` |
| `axon-server start --foreground` | Run in foreground (old behavior) |
| `axon-server stop` | SIGTERM → wait 10s → SIGKILL |
| `axon-server status` | Show PID, uptime, port reachability |

Includes double-start prevention via PID file.

## Testing
- All tests pass ✅
- `go build` + `go vet` clean ✅