### PR TITLE
fix(agent): data plane auth + join no longer auto-starts (#52 #53)

### DIFF
--- a/cmd/axon-agent/join.go
+++ b/cmd/axon-agent/join.go
@@ -149,11 +149,9 @@ For non-TLS servers (default), no extra config is needed.`,
 			_, _ = fmt.Fprintf(out, "   Server:     %s\n", serverAddr)
 			_, _ = fmt.Fprintf(out, "   Config:     %s\n", cfgPath)
 			_, _ = fmt.Fprintln(out)
-			_, _ = fmt.Fprintln(out, "Starting agent... (Ctrl+C to stop)")
-			_, _ = fmt.Fprintln(out)
-
-			// Start the agent control-plane loop in the foreground.
-			return runForeground(cfg, cfgPath)
+			_, _ = fmt.Fprintln(out, "Start the agent:")
+			_, _ = fmt.Fprintln(out, "   axon-agent start")
+			return nil
 		},
 	}
 

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -194,11 +194,28 @@ func (a *Agent) runOnce(ctx context.Context) error {
 	return a.controlLoop(ctx, stream, interval)
 }
 
+// tokenAuth implements credentials.PerRPCCredentials, attaching the agent JWT
+// as "authorization: Bearer <token>" metadata on every RPC.
+type tokenAuth struct {
+	token    string
+	insecure bool // allow sending on non-TLS connections
+}
+
+func (t tokenAuth) GetRequestMetadata(_ context.Context, _ ...string) (map[string]string, error) {
+	return map[string]string{"authorization": "bearer " + t.token}, nil
+}
+
+func (t tokenAuth) RequireTransportSecurity() bool {
+	return !t.insecure
+}
+
 // dial creates a gRPC client connection to the configured server.
 // Transport priority: ca_cert (strict TLS) > tls_insecure (TLS skip-verify) > plaintext.
+// The agent JWT token is attached to all RPCs via PerRPCCredentials.
 func (a *Agent) dial(ctx context.Context) (*grpc.ClientConn, error) {
 	opts := []grpc.DialOption{}
 
+	transportInsecure := false
 	switch {
 	case a.cfg.CACert != "":
 		creds, err := credentials.NewClientTLSFromFile(a.cfg.CACert, "")
@@ -210,6 +227,15 @@ func (a *Agent) dial(ctx context.Context) (*grpc.ClientConn, error) {
 		opts = append(opts, grpc.WithTransportCredentials(credentials.NewTLS(&tls.Config{InsecureSkipVerify: true}))) //nolint:gosec
 	default:
 		opts = append(opts, grpc.WithTransportCredentials(insecure.NewCredentials()))
+		transportInsecure = true
+	}
+
+	// Attach agent JWT to all RPCs (required for data plane operations).
+	if a.cfg.Token != "" {
+		opts = append(opts, grpc.WithPerRPCCredentials(tokenAuth{
+			token:    a.cfg.Token,
+			insecure: transportInsecure,
+		}))
 	}
 
 	if a.dialOverride != nil {

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -78,6 +78,7 @@ case "$COMPONENT" in
     agent)
         echo "Next steps:"
         echo "  axon-agent join <server-addr> <join-token>"
+        echo "  axon-agent start"
         ;;
     cli)
         echo "Next steps:"


### PR DESCRIPTION
## Summary

Fix P0 blocker: all data plane operations (exec, read, write, forward) broken due to missing JWT auth.

## #52 #53 — Agent data plane missing JWT

**Root cause**: `Agent.dial()` created gRPC connections with only transport credentials (TLS/plaintext), no per-RPC auth. The control plane worked because `RegisterRequest` contains the token inline, but data plane RPCs (`HandleTask`) go through the standard gRPC auth interceptor requiring `authorization: Bearer <jwt>` metadata.

**Fix**: Add `grpc.WithPerRPCCredentials()` to `dial()` that injects `authorization: Bearer <token>` into all outgoing RPCs. Handles both TLS and plaintext transports correctly.

## Join no longer auto-starts

`axon-agent join` now only:
1. Enrolls with server
2. Saves config
3. Prints 'axon-agent start' as next step

This aligns with server's `init` + `start` separation.

## Testing
- All tests pass ✅ (unit + integration)
- `go build` + `go vet` clean ✅