### PR TITLE
fix(server): write race condition in HandleTask relay (#55)

### DIFF
--- a/internal/server/agent_ops.go
+++ b/internal/server/agent_ops.go
@@ -61,7 +61,8 @@ func (s *AgentOpsServiceImpl) HandleTask(stream grpc.BidiStreamingServer[operati
 		}
 	}
 
-	errCh := make(chan error, 2)
+	upErrCh := make(chan error, 1)
+	downErrCh := make(chan error, 1)
 
 	// Agent → Server (up): read from Agent stream, put on slot.up.
 	// Close slot.up when Agent finishes sending (EOF) so the CLI relay detects completion.
@@ -70,20 +71,20 @@ func (s *AgentOpsServiceImpl) HandleTask(stream grpc.BidiStreamingServer[operati
 		for {
 			msg, err := stream.Recv()
 			if err == io.EOF {
-				errCh <- nil
+				upErrCh <- nil
 				return
 			}
 			if err != nil {
-				errCh <- err
+				upErrCh <- err
 				return
 			}
 			select {
 			case slot.up <- msg:
 			case <-slot.done:
-				errCh <- nil
+				upErrCh <- nil
 				return
 			case <-ctx.Done():
-				errCh <- ctx.Err()
+				upErrCh <- ctx.Err()
 				return
 			}
 		}
@@ -95,26 +96,43 @@ func (s *AgentOpsServiceImpl) HandleTask(stream grpc.BidiStreamingServer[operati
 			select {
 			case msg, ok := <-slot.down:
 				if !ok {
-					// CLI done sending (channel closed).
-					errCh <- nil
+					// CLI done sending (channel closed). This is normal for
+					// write ops — Agent still needs to process and respond.
+					downErrCh <- nil
 					return
 				}
 				if err := stream.Send(msg); err != nil {
-					errCh <- err
+					downErrCh <- err
 					return
 				}
 			case <-slot.done:
-				errCh <- nil
+				downErrCh <- nil
 				return
 			case <-ctx.Done():
-				errCh <- ctx.Err()
+				downErrCh <- ctx.Err()
 				return
 			}
 		}
 	}()
 
-	// Wait for the first goroutine to finish, then cancel the other.
-	err = <-errCh
-	cancel()
-	return err
+	// Wait for both goroutines. The "down" goroutine finishing (CLI done sending)
+	// is normal and must NOT cause early termination — the Agent may still need to
+	// send its response via the "up" goroutine (e.g. WriteResponse after processing).
+	// Only a real error from either side triggers early cancellation.
+	var firstErr error
+	for i := 0; i < 2; i++ {
+		select {
+		case err := <-upErrCh:
+			if err != nil && firstErr == nil {
+				firstErr = err
+				cancel() // cancel the other goroutine
+			}
+		case err := <-downErrCh:
+			if err != nil && firstErr == nil {
+				firstErr = err
+				cancel() // cancel the other goroutine
+			}
+		}
+	}
+	return firstErr
 }


### PR DESCRIPTION
## Problem

`axon write <node> <path>` writes the file successfully but CLI gets an error:
```
Error: write close: rpc error: code = Internal desc = operations: write: agent closed stream without response
```

## Root Cause

Race condition in `HandleTask` between two relay goroutines:

1. **down goroutine** (Server→Agent): relays CLI data. When CLI finishes sending, `slot.down` closes → `errCh ← nil` (first to finish)
2. **up goroutine** (Agent→Server): relays Agent responses. For write, Agent sends `WriteResponse` only **after** all data is received

`HandleTask` waited for the **first** goroutine to finish, then cancelled everything. The down goroutine always won, killing the up goroutine before the Agent's response arrived.

## Fix

Wait for **both** goroutines. Only real errors trigger early cancellation. Normal EOF from the down channel (CLI done sending) is expected and does not terminate the handler.

```
Before: err = <-errCh; cancel(); return err  // first one wins
After:  wait for both; only cancel on real errors
```

## Testing
- All tests pass ✅
- `go build` + `go vet` clean ✅