### PR TITLE
feat(cli): forward subcommand management with auto-daemon (#57)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ vendor/
 # Test coverage
 *.out
 coverage.html
+axon

--- a/cmd/axon/forward.go
+++ b/cmd/axon/forward.go
@@ -6,11 +6,10 @@ import (
 	"io"
 	"net"
 	"os"
-	"os/signal"
 	"strconv"
 	"strings"
 	"sync"
-	"syscall"
+	"text/tabwriter"
 
 	"github.com/google/uuid"
 	"github.com/spf13/cobra"
@@ -22,57 +21,113 @@ func forwardCmd() *cobra.Command {
 	var bindAddr string
 
 	cmd := &cobra.Command{
-		Use:   "forward <node> <local-port>:<remote-port>",
-		Short: "Forward a remote port to localhost",
-		Long:  "Listens on a local port and forwards TCP connections to a remote port on the specified node.",
+		Use:   "forward",
+		Short: "Manage port forwards",
+		Long:  "Manage port forwards to remote nodes. Use subcommands or provide <node> <local:remote> as shorthand for 'create'.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// Backward compat: axon forward <node> <local>:<remote>
+			if len(args) == 2 {
+				return runForwardCreate(cmd.OutOrStdout(), args[0], args[1], bindAddr)
+			}
+			return fmt.Errorf("expected subcommand or <node> <local-port>:<remote-port>")
+		},
+	}
+
+	cmd.Flags().StringVar(&bindAddr, "bind", "127.0.0.1", "bind address")
+	cmd.AddCommand(
+		forwardCreateCmd(),
+		forwardListCmd(),
+		forwardDeleteCmd(),
+		forwardDaemonCmd(),
+	)
+
+	return cmd
+}
+
+func forwardCreateCmd() *cobra.Command {
+	var bindAddr string
+
+	cmd := &cobra.Command{
+		Use:   "create <node> <local-port>:<remote-port>",
+		Short: "Create a port forward (non-blocking, returns forward ID)",
 		Args:  cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			nodeID := args[0]
-
-			localPort, remotePort, err := parsePorts(args[1])
-			if err != nil {
-				return err
-			}
-
-			client, closer, err := dialOperations()
-			if err != nil {
-				return err
-			}
-			defer closer()
-
-			ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
-			defer cancel()
-
-			listenAddr := fmt.Sprintf("%s:%d", bindAddr, localPort)
-			listener, err := net.Listen("tcp", listenAddr)
-			if err != nil {
-				return fmt.Errorf("listen on %s: %w", listenAddr, err)
-			}
-			defer func() { _ = listener.Close() }()
-
-			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Forwarding %s → %s:%d\nReady. Press Ctrl+C to stop.\n", listenAddr, nodeID, remotePort)
-
-			// Close listener on context cancel.
-			go func() {
-				<-ctx.Done()
-				_ = listener.Close()
-			}()
-
-			for {
-				conn, err := listener.Accept()
-				if err != nil {
-					if ctx.Err() != nil {
-						return nil // graceful shutdown
-					}
-					return fmt.Errorf("accept: %w", err)
-				}
-				go handleForwardConn(ctx, client, conn, nodeID, remotePort)
-			}
+			return runForwardCreate(cmd.OutOrStdout(), args[0], args[1], bindAddr)
 		},
 	}
 
 	cmd.Flags().StringVar(&bindAddr, "bind", "127.0.0.1", "bind address")
 	return cmd
+}
+
+func forwardListCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "list",
+		Short: "List active port forwards",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			forwards, err := daemonList()
+			if err != nil {
+				return err
+			}
+			if len(forwards) == 0 {
+				_, _ = fmt.Fprintln(cmd.OutOrStdout(), "No active forwards.")
+				return nil
+			}
+			w := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 0, 2, ' ', 0)
+			_, _ = fmt.Fprintln(w, "ID\tNODE\tLOCAL\tREMOTE\tSTATUS\tCREATED")
+			for _, f := range forwards {
+				_, _ = fmt.Fprintf(w, "%s\t%s\t%d\t%d\t%s\t%s\n",
+					f.ID, f.Node, f.LocalPort, f.RemotePort, f.Status, relativeTime(f.CreatedAt.Unix()))
+			}
+			return w.Flush()
+		},
+	}
+}
+
+func forwardDeleteCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "delete <forward-id>",
+		Short: "Delete a port forward",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := daemonDelete(args[0]); err != nil {
+				return err
+			}
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Forward %s deleted\n", args[0])
+			return nil
+		},
+	}
+}
+
+func forwardDaemonCmd() *cobra.Command {
+	var foreground bool
+
+	cmd := &cobra.Command{
+		Use:    "daemon",
+		Short:  "Start forward daemon (internal use)",
+		Hidden: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runDaemon()
+		},
+	}
+
+	cmd.Flags().BoolVar(&foreground, "foreground", false, "run in foreground")
+	return cmd
+}
+
+func runForwardCreate(out io.Writer, node, portSpec, bindAddr string) error {
+	localPort, remotePort, err := parsePorts(portSpec)
+	if err != nil {
+		return err
+	}
+
+	id, err := daemonCreate(node, int(localPort), int(remotePort), bindAddr)
+	if err != nil {
+		return fmt.Errorf("create forward: %w", err)
+	}
+
+	_, _ = fmt.Fprintf(out, "Forward %s created: %s:%d → %s:%d\n", id, bindAddr, localPort, node, remotePort)
+	return nil
 }
 
 // handleForwardConn handles a single TCP connection by creating a gRPC

--- a/cmd/axon/forward.go
+++ b/cmd/axon/forward.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -67,7 +68,11 @@ func forwardListCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			forwards, err := daemonList()
 			if err != nil {
-				_, _ = fmt.Fprintln(cmd.OutOrStdout(), err.Error())
+				if errors.Is(err, errDaemonNotRunning) {
+					_, _ = fmt.Fprintln(cmd.OutOrStdout(), err.Error())
+				} else {
+					_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Error: %v\n", err)
+				}
 				return nil
 			}
 			if len(forwards) == 0 {

--- a/cmd/axon/forward.go
+++ b/cmd/axon/forward.go
@@ -67,7 +67,8 @@ func forwardListCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			forwards, err := daemonList()
 			if err != nil {
-				return err
+				_, _ = fmt.Fprintln(cmd.OutOrStdout(), err.Error())
+				return nil
 			}
 			if len(forwards) == 0 {
 				_, _ = fmt.Fprintln(cmd.OutOrStdout(), "No active forwards.")
@@ -100,8 +101,6 @@ func forwardDeleteCmd() *cobra.Command {
 }
 
 func forwardDaemonCmd() *cobra.Command {
-	var foreground bool
-
 	cmd := &cobra.Command{
 		Use:    "daemon",
 		Short:  "Start forward daemon (internal use)",
@@ -111,7 +110,9 @@ func forwardDaemonCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().BoolVar(&foreground, "foreground", false, "run in foreground")
+	// --foreground is accepted for the re-exec convention (ensureDaemon passes it)
+	// but has no effect — the daemon always runs in foreground when invoked directly.
+	cmd.Flags().Bool("foreground", false, "run in foreground (accepted but no-op)")
 	return cmd
 }
 

--- a/cmd/axon/forward_client.go
+++ b/cmd/axon/forward_client.go
@@ -130,9 +130,7 @@ func ensureDaemon() error {
 		return fmt.Errorf("start daemon: %w", err)
 	}
 
-	// Write PID file as a convenience (daemon also writes it).
-	pidPath := filepath.Join(dir, "forward.pid")
-	_ = os.WriteFile(pidPath, []byte(fmt.Sprintf("%d\n", cmd.Process.Pid)), 0600)
+	// PID file is written by the daemon itself — no need to duplicate here.
 
 	// Wait up to 5 seconds for the daemon to be ready.
 	deadline := time.Now().Add(5 * time.Second)
@@ -169,12 +167,14 @@ func daemonCreate(node string, localPort, remotePort int, bindAddr string) (stri
 	return resp.ID, nil
 }
 
-// daemonList returns active forwards. Returns nil if the daemon is not running.
+// errDaemonNotRunning is returned when the daemon socket is unreachable.
+var errDaemonNotRunning = fmt.Errorf("forward daemon is not running (start one with 'axon forward create')")
+
+// daemonList returns active forwards. Returns errDaemonNotRunning if the daemon is not reachable.
 func daemonList() ([]forwardInfo, error) {
 	resp, err := sendDaemonRequest(daemonRequest{Action: "list"})
 	if err != nil {
-		// Daemon not running — treat as empty list.
-		return nil, nil
+		return nil, errDaemonNotRunning
 	}
 	if !resp.OK {
 		return nil, fmt.Errorf("%s", resp.Message)

--- a/cmd/axon/forward_client.go
+++ b/cmd/axon/forward_client.go
@@ -68,7 +68,7 @@ func sendDaemonRequest(req daemonRequest) (*daemonResponse, error) {
 	if err != nil {
 		return nil, fmt.Errorf("connect to daemon: %w", err)
 	}
-	defer conn.Close()
+	defer func() { _ = conn.Close() }()
 
 	enc := json.NewEncoder(conn)
 	dec := json.NewDecoder(conn)
@@ -94,7 +94,7 @@ func ensureDaemon() error {
 	// Check if already running.
 	conn, err := net.DialTimeout("unix", sockPath, time.Second)
 	if err == nil {
-		conn.Close()
+		_ = conn.Close()
 		return nil
 	}
 
@@ -113,7 +113,7 @@ func ensureDaemon() error {
 	if err != nil {
 		return fmt.Errorf("open log file: %w", err)
 	}
-	defer logFile.Close()
+	defer func() { _ = logFile.Close() }()
 
 	// Re-exec self as daemon, detached from current session.
 	exe, err := os.Executable()
@@ -140,7 +140,7 @@ func ensureDaemon() error {
 		time.Sleep(100 * time.Millisecond)
 		c, err := net.DialTimeout("unix", sockPath, time.Second)
 		if err == nil {
-			c.Close()
+			_ = c.Close()
 			return nil
 		}
 	}

--- a/cmd/axon/forward_client.go
+++ b/cmd/axon/forward_client.go
@@ -1,0 +1,195 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"syscall"
+	"time"
+)
+
+// daemonRequest is a JSON-encoded request sent over the unix socket.
+type daemonRequest struct {
+	Action     string `json:"action"`
+	Node       string `json:"node,omitempty"`
+	LocalPort  int    `json:"local_port,omitempty"`
+	RemotePort int    `json:"remote_port,omitempty"`
+	BindAddr   string `json:"bind_addr,omitempty"`
+	ID         string `json:"id,omitempty"`
+}
+
+// daemonResponse is a JSON-encoded response received from the daemon.
+type daemonResponse struct {
+	OK       bool          `json:"ok"`
+	ID       string        `json:"id,omitempty"`
+	Message  string        `json:"message,omitempty"`
+	Forwards []forwardInfo `json:"forwards,omitempty"`
+}
+
+// forwardInfo describes an active forward.
+type forwardInfo struct {
+	ID         string    `json:"id"`
+	Node       string    `json:"node"`
+	LocalPort  int       `json:"local_port"`
+	RemotePort int       `json:"remote_port"`
+	BindAddr   string    `json:"bind_addr"`
+	Status     string    `json:"status"`
+	CreatedAt  time.Time `json:"created_at"`
+}
+
+// axonDataDir returns ~/.axon, creating it if necessary.
+func axonDataDir() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("get home dir: %w", err)
+	}
+	return filepath.Join(home, ".axon"), nil
+}
+
+func daemonSockPath() (string, error) {
+	dir, err := axonDataDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, "forward.sock"), nil
+}
+
+// sendDaemonRequest connects to the daemon, sends req, and returns the response.
+func sendDaemonRequest(req daemonRequest) (*daemonResponse, error) {
+	sockPath, err := daemonSockPath()
+	if err != nil {
+		return nil, err
+	}
+
+	conn, err := net.DialTimeout("unix", sockPath, 3*time.Second)
+	if err != nil {
+		return nil, fmt.Errorf("connect to daemon: %w", err)
+	}
+	defer conn.Close()
+
+	enc := json.NewEncoder(conn)
+	dec := json.NewDecoder(conn)
+
+	if err := enc.Encode(req); err != nil {
+		return nil, fmt.Errorf("send request: %w", err)
+	}
+
+	var resp daemonResponse
+	if err := dec.Decode(&resp); err != nil {
+		return nil, fmt.Errorf("read response: %w", err)
+	}
+	return &resp, nil
+}
+
+// ensureDaemon checks whether the daemon is running and auto-starts it if not.
+func ensureDaemon() error {
+	sockPath, err := daemonSockPath()
+	if err != nil {
+		return err
+	}
+
+	// Check if already running.
+	conn, err := net.DialTimeout("unix", sockPath, time.Second)
+	if err == nil {
+		conn.Close()
+		return nil
+	}
+
+	// Prepare data directory.
+	dir, err := axonDataDir()
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		return fmt.Errorf("create data dir: %w", err)
+	}
+
+	// Open log file for daemon stdout/stderr.
+	logPath := filepath.Join(dir, "forward.log")
+	logFile, err := os.OpenFile(logPath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0600)
+	if err != nil {
+		return fmt.Errorf("open log file: %w", err)
+	}
+	defer logFile.Close()
+
+	// Re-exec self as daemon, detached from current session.
+	exe, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("get executable path: %w", err)
+	}
+
+	cmd := exec.Command(exe, "forward", "daemon", "--foreground")
+	cmd.Stdout = logFile
+	cmd.Stderr = logFile
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("start daemon: %w", err)
+	}
+
+	// Write PID file as a convenience (daemon also writes it).
+	pidPath := filepath.Join(dir, "forward.pid")
+	_ = os.WriteFile(pidPath, []byte(fmt.Sprintf("%d\n", cmd.Process.Pid)), 0600)
+
+	// Wait up to 5 seconds for the daemon to be ready.
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		time.Sleep(100 * time.Millisecond)
+		c, err := net.DialTimeout("unix", sockPath, time.Second)
+		if err == nil {
+			c.Close()
+			return nil
+		}
+	}
+	return fmt.Errorf("daemon did not start within 5 seconds")
+}
+
+// daemonCreate auto-starts the daemon if needed, then creates a forward.
+func daemonCreate(node string, localPort, remotePort int, bindAddr string) (string, error) {
+	if err := ensureDaemon(); err != nil {
+		return "", fmt.Errorf("start daemon: %w", err)
+	}
+
+	resp, err := sendDaemonRequest(daemonRequest{
+		Action:     "create",
+		Node:       node,
+		LocalPort:  localPort,
+		RemotePort: remotePort,
+		BindAddr:   bindAddr,
+	})
+	if err != nil {
+		return "", err
+	}
+	if !resp.OK {
+		return "", fmt.Errorf("%s", resp.Message)
+	}
+	return resp.ID, nil
+}
+
+// daemonList returns active forwards. Returns nil if the daemon is not running.
+func daemonList() ([]forwardInfo, error) {
+	resp, err := sendDaemonRequest(daemonRequest{Action: "list"})
+	if err != nil {
+		// Daemon not running — treat as empty list.
+		return nil, nil
+	}
+	if !resp.OK {
+		return nil, fmt.Errorf("%s", resp.Message)
+	}
+	return resp.Forwards, nil
+}
+
+// daemonDelete removes the forward with the given ID.
+func daemonDelete(id string) error {
+	resp, err := sendDaemonRequest(daemonRequest{Action: "delete", ID: id})
+	if err != nil {
+		return fmt.Errorf("daemon not running: %w", err)
+	}
+	if !resp.OK {
+		return fmt.Errorf("%s", resp.Message)
+	}
+	return nil
+}

--- a/cmd/axon/forward_daemon.go
+++ b/cmd/axon/forward_daemon.go
@@ -174,6 +174,7 @@ func (fm *forwardManager) acceptLoop(ctx context.Context, entry *forwardEntry, c
 			fm.mu.Lock()
 			if e, ok := fm.forwards[entry.ID]; ok {
 				e.Status = "failed"
+				_, _ = fmt.Fprintf(os.Stderr, "[forward daemon] forward %s accept failed: %v\n", entry.ID, err)
 			}
 			fm.mu.Unlock()
 			return

--- a/cmd/axon/forward_daemon.go
+++ b/cmd/axon/forward_daemon.go
@@ -265,7 +265,7 @@ func runDaemon() error {
 
 // handleDaemonConn processes a single request-response cycle on the unix socket.
 func handleDaemonConn(conn net.Conn, fm *forwardManager) {
-	defer conn.Close()
+	defer func() { _ = conn.Close() }()
 
 	dec := json.NewDecoder(conn)
 	enc := json.NewEncoder(conn)

--- a/cmd/axon/forward_daemon.go
+++ b/cmd/axon/forward_daemon.go
@@ -1,0 +1,291 @@
+package main
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/json"
+	"fmt"
+	"net"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"sync"
+	"syscall"
+	"time"
+
+	operationspb "github.com/garysng/axon/gen/proto/operations"
+)
+
+const daemonIdleTimeout = 60 * time.Second
+
+// forwardEntry tracks a single active port forward managed by the daemon.
+type forwardEntry struct {
+	ID         string
+	Node       string
+	LocalPort  int
+	RemotePort int
+	BindAddr   string
+	Status     string
+	CreatedAt  time.Time
+	listener   net.Listener
+	cancel     context.CancelFunc
+}
+
+// forwardManager owns all active forwards and the shared gRPC client.
+type forwardManager struct {
+	mu          sync.Mutex
+	forwards    map[string]*forwardEntry
+	client      operationspb.OperationsServiceClient
+	clientClose func()
+	idleTimer   *time.Timer
+	exitCh      chan struct{}
+	exitOnce    sync.Once
+}
+
+func newForwardManager() *forwardManager {
+	fm := &forwardManager{
+		forwards: make(map[string]*forwardEntry),
+		exitCh:   make(chan struct{}),
+	}
+	// Start idle timer — fires if no forwards are created in the first 60s.
+	fm.idleTimer = time.AfterFunc(daemonIdleTimeout, func() {
+		fm.exitOnce.Do(func() { close(fm.exitCh) })
+	})
+	return fm
+}
+
+// resetIdleTimer restarts (empty forwards) or stops (busy) the idle timer.
+// Must be called with mu held.
+func (fm *forwardManager) resetIdleTimer() {
+	if len(fm.forwards) == 0 {
+		fm.idleTimer.Reset(daemonIdleTimeout)
+	} else {
+		fm.idleTimer.Stop()
+	}
+}
+
+// getOrCreateClient returns the shared gRPC client, creating it if needed.
+// Must be called with mu held.
+func (fm *forwardManager) getOrCreateClient() (operationspb.OperationsServiceClient, error) {
+	if fm.client != nil {
+		return fm.client, nil
+	}
+	client, closer, err := dialOperations()
+	if err != nil {
+		return nil, err
+	}
+	fm.client = client
+	fm.clientClose = closer
+	return client, nil
+}
+
+func (fm *forwardManager) handleCreate(req daemonRequest) *daemonResponse {
+	fm.mu.Lock()
+	defer fm.mu.Unlock()
+
+	client, err := fm.getOrCreateClient()
+	if err != nil {
+		return &daemonResponse{OK: false, Message: err.Error()}
+	}
+
+	bindAddr := req.BindAddr
+	if bindAddr == "" {
+		bindAddr = "127.0.0.1"
+	}
+
+	listenAddr := fmt.Sprintf("%s:%d", bindAddr, req.LocalPort)
+	listener, err := net.Listen("tcp", listenAddr)
+	if err != nil {
+		return &daemonResponse{OK: false, Message: fmt.Sprintf("listen on %s: %v", listenAddr, err)}
+	}
+
+	id := randomHexID()
+	ctx, cancel := context.WithCancel(context.Background())
+
+	entry := &forwardEntry{
+		ID:         id,
+		Node:       req.Node,
+		LocalPort:  req.LocalPort,
+		RemotePort: req.RemotePort,
+		BindAddr:   bindAddr,
+		Status:     "active",
+		CreatedAt:  time.Now(),
+		listener:   listener,
+		cancel:     cancel,
+	}
+	fm.forwards[id] = entry
+	fm.resetIdleTimer()
+
+	go fm.acceptLoop(ctx, entry, client)
+
+	return &daemonResponse{OK: true, ID: id}
+}
+
+func (fm *forwardManager) handleList() *daemonResponse {
+	fm.mu.Lock()
+	defer fm.mu.Unlock()
+
+	infos := make([]forwardInfo, 0, len(fm.forwards))
+	for _, e := range fm.forwards {
+		infos = append(infos, forwardInfo{
+			ID:         e.ID,
+			Node:       e.Node,
+			LocalPort:  e.LocalPort,
+			RemotePort: e.RemotePort,
+			BindAddr:   e.BindAddr,
+			Status:     e.Status,
+			CreatedAt:  e.CreatedAt,
+		})
+	}
+	return &daemonResponse{OK: true, Forwards: infos}
+}
+
+func (fm *forwardManager) handleDelete(id string) *daemonResponse {
+	fm.mu.Lock()
+	defer fm.mu.Unlock()
+
+	entry, ok := fm.forwards[id]
+	if !ok {
+		return &daemonResponse{OK: false, Message: fmt.Sprintf("forward %s not found", id)}
+	}
+
+	entry.cancel()
+	_ = entry.listener.Close()
+	delete(fm.forwards, id)
+	fm.resetIdleTimer()
+
+	return &daemonResponse{OK: true, Message: "Forward deleted"}
+}
+
+// acceptLoop runs for one forwardEntry, accepting TCP connections and
+// handing each to handleForwardConn in its own goroutine.
+func (fm *forwardManager) acceptLoop(ctx context.Context, entry *forwardEntry, client operationspb.OperationsServiceClient) {
+	go func() {
+		<-ctx.Done()
+		_ = entry.listener.Close()
+	}()
+
+	for {
+		conn, err := entry.listener.Accept()
+		if err != nil {
+			if ctx.Err() != nil {
+				return // cancelled — expected
+			}
+			fm.mu.Lock()
+			if e, ok := fm.forwards[entry.ID]; ok {
+				e.Status = "failed"
+			}
+			fm.mu.Unlock()
+			return
+		}
+		go handleForwardConn(ctx, client, conn, entry.Node, int32(entry.RemotePort))
+	}
+}
+
+func (fm *forwardManager) close() {
+	fm.mu.Lock()
+	defer fm.mu.Unlock()
+
+	fm.idleTimer.Stop()
+	for _, entry := range fm.forwards {
+		entry.cancel()
+		_ = entry.listener.Close()
+	}
+	if fm.clientClose != nil {
+		fm.clientClose()
+	}
+}
+
+// randomHexID returns a random 8-character hex string.
+func randomHexID() string {
+	b := make([]byte, 4)
+	_, _ = rand.Read(b)
+	return fmt.Sprintf("%x", b)
+}
+
+// runDaemon is the entry point for the forward daemon subprocess.
+func runDaemon() error {
+	dir, err := axonDataDir()
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		return fmt.Errorf("create data dir: %w", err)
+	}
+
+	sockPath := filepath.Join(dir, "forward.sock")
+	pidPath := filepath.Join(dir, "forward.pid")
+
+	// Remove stale socket from a previous run.
+	_ = os.Remove(sockPath)
+
+	// Record our PID.
+	if err := os.WriteFile(pidPath, []byte(fmt.Sprintf("%d\n", os.Getpid())), 0600); err != nil {
+		return fmt.Errorf("write pid file: %w", err)
+	}
+
+	ln, err := net.Listen("unix", sockPath)
+	if err != nil {
+		return fmt.Errorf("listen on %s: %w", sockPath, err)
+	}
+
+	defer func() {
+		_ = ln.Close()
+		_ = os.Remove(sockPath)
+		_ = os.Remove(pidPath)
+	}()
+
+	fm := newForwardManager()
+	defer fm.close()
+
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+
+	// Accept unix-socket connections in background.
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			go handleDaemonConn(conn, fm)
+		}
+	}()
+
+	// Block until signalled or idle timeout.
+	select {
+	case sig := <-sigCh:
+		_, _ = fmt.Fprintf(os.Stderr, "[forward daemon] received signal %s, shutting down\n", sig)
+	case <-fm.exitCh:
+		_, _ = fmt.Fprintln(os.Stderr, "[forward daemon] idle timeout, shutting down")
+	}
+
+	return nil
+}
+
+// handleDaemonConn processes a single request-response cycle on the unix socket.
+func handleDaemonConn(conn net.Conn, fm *forwardManager) {
+	defer conn.Close()
+
+	dec := json.NewDecoder(conn)
+	enc := json.NewEncoder(conn)
+
+	var req daemonRequest
+	if err := dec.Decode(&req); err != nil {
+		return
+	}
+
+	var resp *daemonResponse
+	switch req.Action {
+	case "create":
+		resp = fm.handleCreate(req)
+	case "list":
+		resp = fm.handleList()
+	case "delete":
+		resp = fm.handleDelete(req.ID)
+	default:
+		resp = &daemonResponse{OK: false, Message: fmt.Sprintf("unknown action: %s", req.Action)}
+	}
+
+	_ = enc.Encode(resp)
+}

--- a/cmd/axon/forward_daemon.go
+++ b/cmd/axon/forward_daemon.go
@@ -289,5 +289,7 @@ func handleDaemonConn(conn net.Conn, fm *forwardManager) {
 		resp = &daemonResponse{OK: false, Message: fmt.Sprintf("unknown action: %s", req.Action)}
 	}
 
-	_ = enc.Encode(resp)
+	if err := enc.Encode(resp); err != nil {
+		_, _ = fmt.Fprintf(os.Stderr, "[forward daemon] failed to write response: %v\n", err)
+	}
 }

--- a/cmd/axon/forward_daemon.go
+++ b/cmd/axon/forward_daemon.go
@@ -199,7 +199,9 @@ func (fm *forwardManager) close() {
 // randomHexID returns a random 8-character hex string.
 func randomHexID() string {
 	b := make([]byte, 4)
-	_, _ = rand.Read(b)
+	if _, err := rand.Read(b); err != nil {
+		panic(fmt.Sprintf("crypto/rand.Read failed: %v", err))
+	}
 	return fmt.Sprintf("%x", b)
 }
 


### PR DESCRIPTION
## Summary

Refactor `axon forward` from a blocking single-forward command into a managed subcommand group with an auto-daemon.

## Usage

```bash
# Create forwards (non-blocking)
axon forward create mynode 8080:80
# Forward f1a2b3c4 created: localhost:8080 → mynode:80

axon forward create mynode 5432:5432
# Forward d5e6f7a8 created: localhost:5432 → mynode:5432

# List active forwards
axon forward list
# ID        NODE     LOCAL  REMOTE  STATUS   CREATED
# f1a2b3c4  mynode   8080   80      active   2m ago
# d5e6f7a8  mynode   5432   5432    active   5s ago

# Delete a forward
axon forward delete f1a2b3c4
# Forward f1a2b3c4 deleted

# Shorthand (backward compat)
axon forward mynode 8080:80
```

## Architecture

### Auto-daemon
- First `create` auto-starts daemon process (re-exec with `forward daemon --foreground`)
- Daemon listens on `~/.axon/forward.sock` (unix domain socket)
- JSON-over-unix-socket protocol for management commands
- PID file: `~/.axon/forward.pid`, Log: `~/.axon/forward.log`
- Auto-exits after 60s idle when no active forwards remain
- Graceful shutdown on SIGTERM/SIGINT

### Files
- `cmd/axon/forward.go` — subcommand definitions (create, list, delete, daemon)
- `cmd/axon/forward_client.go` — unix socket client + auto-daemon launch
- `cmd/axon/forward_daemon.go` — daemon internals (forward manager, TCP+gRPC relay)

## Testing
- All tests pass ✅
- `go build` + `go vet` clean ✅
- No changes to internal/ or pkg/ — purely CLI-side