### PR TITLE
refactor: rename Go module from garysng/axon to beancrew/axon

### DIFF
--- a/cmd/axon-agent/join.go
+++ b/cmd/axon-agent/join.go
@@ -15,9 +15,9 @@ import (
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
 
-	managementpb "github.com/garysng/axon/gen/proto/management"
-	"github.com/garysng/axon/internal/agent"
-	"github.com/garysng/axon/pkg/config"
+	managementpb "github.com/beancrew/axon/gen/proto/management"
+	"github.com/beancrew/axon/internal/agent"
+	"github.com/beancrew/axon/pkg/config"
 )
 
 func joinCmd() *cobra.Command {

--- a/cmd/axon-agent/main.go
+++ b/cmd/axon-agent/main.go
@@ -17,9 +17,9 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/garysng/axon/internal/agent"
-	"github.com/garysng/axon/pkg/config"
-	"github.com/garysng/axon/pkg/display"
+	"github.com/beancrew/axon/internal/agent"
+	"github.com/beancrew/axon/pkg/config"
+	"github.com/beancrew/axon/pkg/display"
 )
 
 // version is set at build time via -ldflags.

--- a/cmd/axon-agent/main_test.go
+++ b/cmd/axon-agent/main_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/garysng/axon/pkg/display"
+	"github.com/beancrew/axon/pkg/display"
 )
 
 // ── writePID / readPID ──────────────────────────────────────────────────────

--- a/cmd/axon-server/init.go
+++ b/cmd/axon-server/init.go
@@ -13,7 +13,7 @@ import (
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
 
-	"github.com/garysng/axon/pkg/auth"
+	"github.com/beancrew/axon/pkg/auth"
 	_ "modernc.org/sqlite"
 )
 

--- a/cmd/axon-server/main.go
+++ b/cmd/axon-server/main.go
@@ -17,7 +17,7 @@ import (
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
 
-	"github.com/garysng/axon/internal/server"
+	"github.com/beancrew/axon/internal/server"
 )
 
 var version = "dev"

--- a/cmd/axon/client.go
+++ b/cmd/axon/client.go
@@ -5,9 +5,9 @@ import (
 	"crypto/tls"
 	"fmt"
 
-	managementpb "github.com/garysng/axon/gen/proto/management"
-	operationspb "github.com/garysng/axon/gen/proto/operations"
-	"github.com/garysng/axon/pkg/config"
+	managementpb "github.com/beancrew/axon/gen/proto/management"
+	operationspb "github.com/beancrew/axon/gen/proto/operations"
+	"github.com/beancrew/axon/pkg/config"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"

--- a/cmd/axon/exec.go
+++ b/cmd/axon/exec.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	operationspb "github.com/garysng/axon/gen/proto/operations"
+	operationspb "github.com/beancrew/axon/gen/proto/operations"
 )
 
 type exitError struct{ code int }

--- a/cmd/axon/forward.go
+++ b/cmd/axon/forward.go
@@ -15,7 +15,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/spf13/cobra"
 
-	operationspb "github.com/garysng/axon/gen/proto/operations"
+	operationspb "github.com/beancrew/axon/gen/proto/operations"
 )
 
 func forwardCmd() *cobra.Command {

--- a/cmd/axon/forward_daemon.go
+++ b/cmd/axon/forward_daemon.go
@@ -13,7 +13,7 @@ import (
 	"syscall"
 	"time"
 
-	operationspb "github.com/garysng/axon/gen/proto/operations"
+	operationspb "github.com/beancrew/axon/gen/proto/operations"
 )
 
 const daemonIdleTimeout = 60 * time.Second

--- a/cmd/axon/main.go
+++ b/cmd/axon/main.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/garysng/axon/pkg/config"
-	"github.com/garysng/axon/pkg/display"
+	"github.com/beancrew/axon/pkg/config"
+	"github.com/beancrew/axon/pkg/display"
 )
 
 // version is set at build time via -ldflags.

--- a/cmd/axon/main_test.go
+++ b/cmd/axon/main_test.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/garysng/axon/pkg/config"
+	"github.com/beancrew/axon/pkg/config"
 )
 
 func TestVersionCmd(t *testing.T) {

--- a/cmd/axon/node.go
+++ b/cmd/axon/node.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	managementpb "github.com/garysng/axon/gen/proto/management"
+	managementpb "github.com/beancrew/axon/gen/proto/management"
 )
 
 func nodeCmd() *cobra.Command {

--- a/cmd/axon/node_test.go
+++ b/cmd/axon/node_test.go
@@ -4,8 +4,8 @@ import (
 	"testing"
 	"time"
 
-	managementpb "github.com/garysng/axon/gen/proto/management"
-	"github.com/garysng/axon/pkg/display"
+	managementpb "github.com/beancrew/axon/gen/proto/management"
+	"github.com/beancrew/axon/pkg/display"
 )
 
 func TestFilterByStatus(t *testing.T) {

--- a/cmd/axon/read.go
+++ b/cmd/axon/read.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	operationspb "github.com/garysng/axon/gen/proto/operations"
+	operationspb "github.com/beancrew/axon/gen/proto/operations"
 )
 
 func readCmd() *cobra.Command {

--- a/cmd/axon/token.go
+++ b/cmd/axon/token.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	managementpb "github.com/garysng/axon/gen/proto/management"
+	managementpb "github.com/beancrew/axon/gen/proto/management"
 )
 
 func tokenCmd() *cobra.Command {

--- a/cmd/axon/write.go
+++ b/cmd/axon/write.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	operationspb "github.com/garysng/axon/gen/proto/operations"
+	operationspb "github.com/beancrew/axon/gen/proto/operations"
 )
 
 func writeCmd() *cobra.Command {

--- a/gen/proto/control/control.pb.go
+++ b/gen/proto/control/control.pb.go
@@ -761,7 +761,7 @@ const file_control_proto_rawDesc = "" +
 	"TASK_WRITE\x10\x02\x12\x10\n" +
 	"\fTASK_FORWARD\x10\x032X\n" +
 	"\x0eControlService\x12F\n" +
-	"\aConnect\x12\x1a.axon.control.AgentMessage\x1a\x1b.axon.control.ServerMessage(\x010\x01B+Z)github.com/garysng/axon/gen/proto/controlb\x06proto3"
+	"\aConnect\x12\x1a.axon.control.AgentMessage\x1a\x1b.axon.control.ServerMessage(\x010\x01B,Z*github.com/beancrew/axon/gen/proto/controlb\x06proto3"
 
 var (
 	file_control_proto_rawDescOnce sync.Once

--- a/gen/proto/management/management.pb.go
+++ b/gen/proto/management/management.pb.go
@@ -7,7 +7,7 @@
 package management
 
 import (
-	control "github.com/garysng/axon/gen/proto/control"
+	control "github.com/beancrew/axon/gen/proto/control"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	reflect "reflect"
@@ -1907,7 +1907,7 @@ const file_management_proto_rawDesc = "" +
 	"\x0fCreateJoinToken\x12'.axon.management.CreateJoinTokenRequest\x1a(.axon.management.CreateJoinTokenResponse\x12a\n" +
 	"\x0eListJoinTokens\x12&.axon.management.ListJoinTokensRequest\x1a'.axon.management.ListJoinTokensResponse\x12d\n" +
 	"\x0fRevokeJoinToken\x12'.axon.management.RevokeJoinTokenRequest\x1a(.axon.management.RevokeJoinTokenResponse\x12R\n" +
-	"\tJoinAgent\x12!.axon.management.JoinAgentRequest\x1a\".axon.management.JoinAgentResponseB.Z,github.com/garysng/axon/gen/proto/managementb\x06proto3"
+	"\tJoinAgent\x12!.axon.management.JoinAgentRequest\x1a\".axon.management.JoinAgentResponseB/Z-github.com/beancrew/axon/gen/proto/managementb\x06proto3"
 
 var (
 	file_management_proto_rawDescOnce sync.Once

--- a/gen/proto/operations/operations.pb.go
+++ b/gen/proto/operations/operations.pb.go
@@ -1115,7 +1115,7 @@ const file_operations_proto_rawDesc = "" +
 	"\aForward\x12\x1b.axon.operations.TunnelData\x1a\x1b.axon.operations.TunnelData(\x010\x012_\n" +
 	"\x0fAgentOpsService\x12L\n" +
 	"\n" +
-	"HandleTask\x12\x1b.axon.operations.TaskDataUp\x1a\x1d.axon.operations.TaskDataDown(\x010\x01B.Z,github.com/garysng/axon/gen/proto/operationsb\x06proto3"
+	"HandleTask\x12\x1b.axon.operations.TaskDataUp\x1a\x1d.axon.operations.TaskDataDown(\x010\x01B/Z-github.com/beancrew/axon/gen/proto/operationsb\x06proto3"
 
 var (
 	file_operations_proto_rawDescOnce sync.Once

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/garysng/axon
+module github.com/beancrew/axon
 
 go 1.25.0
 

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -18,8 +18,8 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/status"
 
-	controlpb "github.com/garysng/axon/gen/proto/control"
-	"github.com/garysng/axon/pkg/config"
+	controlpb "github.com/beancrew/axon/gen/proto/control"
+	"github.com/beancrew/axon/pkg/config"
 )
 
 // TaskHandler is called when the server dispatches a task to this agent.

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -11,9 +11,9 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/test/bufconn"
 
-	controlpb "github.com/garysng/axon/gen/proto/control"
-	"github.com/garysng/axon/pkg/auth"
-	"github.com/garysng/axon/pkg/config"
+	controlpb "github.com/beancrew/axon/gen/proto/control"
+	"github.com/beancrew/axon/pkg/auth"
+	"github.com/beancrew/axon/pkg/config"
 )
 
 const (

--- a/internal/agent/dispatcher.go
+++ b/internal/agent/dispatcher.go
@@ -7,8 +7,8 @@ import (
 
 	"google.golang.org/grpc"
 
-	controlpb "github.com/garysng/axon/gen/proto/control"
-	operationspb "github.com/garysng/axon/gen/proto/operations"
+	controlpb "github.com/beancrew/axon/gen/proto/control"
+	operationspb "github.com/beancrew/axon/gen/proto/operations"
 )
 
 // Dispatcher opens data plane streams to the server to fulfill dispatched tasks.

--- a/internal/agent/exec.go
+++ b/internal/agent/exec.go
@@ -11,7 +11,7 @@ import (
 	"syscall"
 	"time"
 
-	operationspb "github.com/garysng/axon/gen/proto/operations"
+	operationspb "github.com/beancrew/axon/gen/proto/operations"
 )
 
 const (

--- a/internal/agent/exec_test.go
+++ b/internal/agent/exec_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	operationspb "github.com/garysng/axon/gen/proto/operations"
+	operationspb "github.com/beancrew/axon/gen/proto/operations"
 )
 
 // outputCollector collects ExecOutput messages for assertions.

--- a/internal/agent/fileio.go
+++ b/internal/agent/fileio.go
@@ -8,7 +8,7 @@ import (
 	"os"
 	"path/filepath"
 
-	operationspb "github.com/garysng/axon/gen/proto/operations"
+	operationspb "github.com/beancrew/axon/gen/proto/operations"
 )
 
 const readChunkSize = 32 * 1024 // 32 KB

--- a/internal/agent/fileio_test.go
+++ b/internal/agent/fileio_test.go
@@ -8,7 +8,7 @@ import (
 	"sync"
 	"testing"
 
-	operationspb "github.com/garysng/axon/gen/proto/operations"
+	operationspb "github.com/beancrew/axon/gen/proto/operations"
 )
 
 // readCollector collects ReadOutput messages.

--- a/internal/agent/forward.go
+++ b/internal/agent/forward.go
@@ -7,7 +7,7 @@ import (
 	"net"
 	"sync"
 
-	operationspb "github.com/garysng/axon/gen/proto/operations"
+	operationspb "github.com/beancrew/axon/gen/proto/operations"
 )
 
 const forwardBufSize = 32 * 1024 // 32 KB

--- a/internal/agent/forward_test.go
+++ b/internal/agent/forward_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 	"time"
 
-	operationspb "github.com/garysng/axon/gen/proto/operations"
+	operationspb "github.com/beancrew/axon/gen/proto/operations"
 )
 
 // startEchoServer starts a TCP server that echoes received data back.

--- a/internal/agent/sysinfo.go
+++ b/internal/agent/sysinfo.go
@@ -7,7 +7,7 @@ import (
 	"runtime"
 	"time"
 
-	controlpb "github.com/garysng/axon/gen/proto/control"
+	controlpb "github.com/beancrew/axon/gen/proto/control"
 )
 
 // version is set at build time via -ldflags.

--- a/internal/agent/sysinfo_darwin.go
+++ b/internal/agent/sysinfo_darwin.go
@@ -6,7 +6,7 @@ import (
 	"os/exec"
 	"strings"
 
-	controlpb "github.com/garysng/axon/gen/proto/control"
+	controlpb "github.com/beancrew/axon/gen/proto/control"
 )
 
 func collectOSInfo() *controlpb.OSInfo {

--- a/internal/agent/sysinfo_linux.go
+++ b/internal/agent/sysinfo_linux.go
@@ -7,7 +7,7 @@ import (
 	"os/exec"
 	"strings"
 
-	controlpb "github.com/garysng/axon/gen/proto/control"
+	controlpb "github.com/beancrew/axon/gen/proto/control"
 )
 
 func collectOSInfo() *controlpb.OSInfo {

--- a/internal/agent/sysinfo_windows.go
+++ b/internal/agent/sysinfo_windows.go
@@ -3,7 +3,7 @@
 package agent
 
 import (
-	controlpb "github.com/garysng/axon/gen/proto/control"
+	controlpb "github.com/beancrew/axon/gen/proto/control"
 )
 
 func collectOSInfo() *controlpb.OSInfo {

--- a/internal/server/agent_ops.go
+++ b/internal/server/agent_ops.go
@@ -9,7 +9,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
-	operationspb "github.com/garysng/axon/gen/proto/operations"
+	operationspb "github.com/beancrew/axon/gen/proto/operations"
 )
 
 // AgentOpsServiceImpl implements operationspb.AgentOpsServiceServer.

--- a/internal/server/bridge.go
+++ b/internal/server/bridge.go
@@ -6,8 +6,8 @@ import (
 	"sync"
 	"time"
 
-	controlpb "github.com/garysng/axon/gen/proto/control"
-	operationspb "github.com/garysng/axon/gen/proto/operations"
+	controlpb "github.com/beancrew/axon/gen/proto/control"
+	operationspb "github.com/beancrew/axon/gen/proto/operations"
 )
 
 // taskBridge manages pending CLI requests waiting for agent data plane connections.

--- a/internal/server/bridge_test.go
+++ b/internal/server/bridge_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	controlpb "github.com/garysng/axon/gen/proto/control"
+	controlpb "github.com/beancrew/axon/gen/proto/control"
 )
 
 func TestBridge_CreateAttachRemove(t *testing.T) {

--- a/internal/server/control.go
+++ b/internal/server/control.go
@@ -11,9 +11,9 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
-	controlpb "github.com/garysng/axon/gen/proto/control"
-	"github.com/garysng/axon/internal/server/registry"
-	"github.com/garysng/axon/pkg/auth"
+	controlpb "github.com/beancrew/axon/gen/proto/control"
+	"github.com/beancrew/axon/internal/server/registry"
+	"github.com/beancrew/axon/pkg/auth"
 )
 
 // ControlService implements controlpb.ControlServiceServer.

--- a/internal/server/control_test.go
+++ b/internal/server/control_test.go
@@ -9,9 +9,9 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 
-	controlpb "github.com/garysng/axon/gen/proto/control"
-	"github.com/garysng/axon/internal/server/registry"
-	"github.com/garysng/axon/pkg/auth"
+	controlpb "github.com/beancrew/axon/gen/proto/control"
+	"github.com/beancrew/axon/internal/server/registry"
+	"github.com/beancrew/axon/pkg/auth"
 )
 
 const (

--- a/internal/server/management.go
+++ b/internal/server/management.go
@@ -15,10 +15,10 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
-	controlpb "github.com/garysng/axon/gen/proto/control"
-	managementpb "github.com/garysng/axon/gen/proto/management"
-	"github.com/garysng/axon/internal/server/registry"
-	"github.com/garysng/axon/pkg/auth"
+	controlpb "github.com/beancrew/axon/gen/proto/control"
+	managementpb "github.com/beancrew/axon/gen/proto/management"
+	"github.com/beancrew/axon/internal/server/registry"
+	"github.com/beancrew/axon/pkg/auth"
 )
 
 // ManagementService implements managementpb.ManagementServiceServer.

--- a/internal/server/management_test.go
+++ b/internal/server/management_test.go
@@ -12,10 +12,10 @@ import (
 	"google.golang.org/grpc/metadata"
 	grpcstatus "google.golang.org/grpc/status"
 
-	controlpb "github.com/garysng/axon/gen/proto/control"
-	managementpb "github.com/garysng/axon/gen/proto/management"
-	"github.com/garysng/axon/internal/server/registry"
-	"github.com/garysng/axon/pkg/auth"
+	controlpb "github.com/beancrew/axon/gen/proto/control"
+	managementpb "github.com/beancrew/axon/gen/proto/management"
+	"github.com/beancrew/axon/internal/server/registry"
+	"github.com/beancrew/axon/pkg/auth"
 )
 
 // fullTestEnv spins up a server with all services registered (control,

--- a/internal/server/operations.go
+++ b/internal/server/operations.go
@@ -11,10 +11,10 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
-	controlpb "github.com/garysng/axon/gen/proto/control"
-	operationspb "github.com/garysng/axon/gen/proto/operations"
-	"github.com/garysng/axon/pkg/audit"
-	"github.com/garysng/axon/pkg/auth"
+	controlpb "github.com/beancrew/axon/gen/proto/control"
+	operationspb "github.com/beancrew/axon/gen/proto/operations"
+	"github.com/beancrew/axon/pkg/audit"
+	"github.com/beancrew/axon/pkg/auth"
 )
 
 const agentAttachTimeout = 30 * time.Second

--- a/internal/server/operations_test.go
+++ b/internal/server/operations_test.go
@@ -7,7 +7,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
-	operationspb "github.com/garysng/axon/gen/proto/operations"
+	operationspb "github.com/beancrew/axon/gen/proto/operations"
 )
 
 // TestOperations_Exec_NodeNotFound verifies that Exec returns NotFound for

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -7,8 +7,8 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
-	"github.com/garysng/axon/internal/server/registry"
-	"github.com/garysng/axon/pkg/auth"
+	"github.com/beancrew/axon/internal/server/registry"
+	"github.com/beancrew/axon/pkg/auth"
 )
 
 // Router authenticates, authorizes, and resolves a nodeID to a registry.NodeEntry.

--- a/internal/server/router_test.go
+++ b/internal/server/router_test.go
@@ -8,8 +8,8 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
-	"github.com/garysng/axon/internal/server/registry"
-	"github.com/garysng/axon/pkg/auth"
+	"github.com/beancrew/axon/internal/server/registry"
+	"github.com/beancrew/axon/pkg/auth"
 )
 
 // claimsCtx injects Claims into a context for testing.

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -17,13 +17,13 @@ import (
 
 	_ "modernc.org/sqlite" // SQLite driver
 
-	controlpb "github.com/garysng/axon/gen/proto/control"
-	managementpb "github.com/garysng/axon/gen/proto/management"
-	operationspb "github.com/garysng/axon/gen/proto/operations"
-	"github.com/garysng/axon/internal/server/registry"
-	"github.com/garysng/axon/pkg/audit"
-	"github.com/garysng/axon/pkg/auth"
-	autotls "github.com/garysng/axon/pkg/tls"
+	controlpb "github.com/beancrew/axon/gen/proto/control"
+	managementpb "github.com/beancrew/axon/gen/proto/management"
+	operationspb "github.com/beancrew/axon/gen/proto/operations"
+	"github.com/beancrew/axon/internal/server/registry"
+	"github.com/beancrew/axon/pkg/audit"
+	"github.com/beancrew/axon/pkg/auth"
+	autotls "github.com/beancrew/axon/pkg/tls"
 )
 
 // ServerConfig holds configuration for the gRPC server.

--- a/internal/server/testing.go
+++ b/internal/server/testing.go
@@ -10,12 +10,12 @@ import (
 
 	_ "modernc.org/sqlite" // SQLite driver
 
-	controlpb "github.com/garysng/axon/gen/proto/control"
-	managementpb "github.com/garysng/axon/gen/proto/management"
-	operationspb "github.com/garysng/axon/gen/proto/operations"
-	"github.com/garysng/axon/internal/server/registry"
-	"github.com/garysng/axon/pkg/audit"
-	"github.com/garysng/axon/pkg/auth"
+	controlpb "github.com/beancrew/axon/gen/proto/control"
+	managementpb "github.com/beancrew/axon/gen/proto/management"
+	operationspb "github.com/beancrew/axon/gen/proto/operations"
+	"github.com/beancrew/axon/internal/server/registry"
+	"github.com/beancrew/axon/pkg/audit"
+	"github.com/beancrew/axon/pkg/auth"
 )
 
 // ServeListenerReady starts the server on lis and closes the ready channel

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -5,7 +5,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/garysng/axon/pkg/config"
+	"github.com/beancrew/axon/pkg/config"
 )
 
 // writeTemp writes content to a temp file and returns its path.

--- a/pkg/tls/autotls_test.go
+++ b/pkg/tls/autotls_test.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"testing"
 
-	autotls "github.com/garysng/axon/pkg/tls"
+	autotls "github.com/beancrew/axon/pkg/tls"
 )
 
 // TestGenerateCA verifies that GenerateCA creates valid PEM files containing

--- a/proto/control.proto
+++ b/proto/control.proto
@@ -1,7 +1,7 @@
 syntax = "proto3";
 package axon.control;
 
-option go_package = "github.com/garysng/axon/gen/proto/control";
+option go_package = "github.com/beancrew/axon/gen/proto/control";
 
 service ControlService {
   // Agent establishes a persistent control channel on startup.

--- a/proto/management.proto
+++ b/proto/management.proto
@@ -1,7 +1,7 @@
 syntax = "proto3";
 package axon.management;
 
-option go_package = "github.com/garysng/axon/gen/proto/management";
+option go_package = "github.com/beancrew/axon/gen/proto/management";
 
 import "control.proto";
 

--- a/proto/operations.proto
+++ b/proto/operations.proto
@@ -1,7 +1,7 @@
 syntax = "proto3";
 package axon.operations;
 
-option go_package = "github.com/garysng/axon/gen/proto/operations";
+option go_package = "github.com/beancrew/axon/gen/proto/operations";
 
 service OperationsService {
   // CLI calls these RPCs. Server routes to the target agent.

--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -8,11 +8,11 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
-	controlpb "github.com/garysng/axon/gen/proto/control"
-	managementpb "github.com/garysng/axon/gen/proto/management"
-	operationspb "github.com/garysng/axon/gen/proto/operations"
-	"github.com/garysng/axon/internal/server/registry"
-	"github.com/garysng/axon/test/integration/testharness"
+	controlpb "github.com/beancrew/axon/gen/proto/control"
+	managementpb "github.com/beancrew/axon/gen/proto/management"
+	operationspb "github.com/beancrew/axon/gen/proto/operations"
+	"github.com/beancrew/axon/internal/server/registry"
+	"github.com/beancrew/axon/test/integration/testharness"
 )
 
 // ── Agent lifecycle tests ──────────────────────────────────────────────────

--- a/test/integration/testharness/harness.go
+++ b/test/integration/testharness/harness.go
@@ -13,12 +13,12 @@ import (
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/test/bufconn"
 
-	controlpb "github.com/garysng/axon/gen/proto/control"
-	"github.com/garysng/axon/internal/agent"
-	"github.com/garysng/axon/internal/server"
-	"github.com/garysng/axon/internal/server/registry"
-	"github.com/garysng/axon/pkg/auth"
-	"github.com/garysng/axon/pkg/config"
+	controlpb "github.com/beancrew/axon/gen/proto/control"
+	"github.com/beancrew/axon/internal/agent"
+	"github.com/beancrew/axon/internal/server"
+	"github.com/beancrew/axon/internal/server/registry"
+	"github.com/beancrew/axon/pkg/auth"
+	"github.com/beancrew/axon/pkg/config"
 )
 
 const bufSize = 1024 * 1024


### PR DESCRIPTION
## Summary

Rename the Go module path from `github.com/garysng/axon` to `github.com/beancrew/axon` to align with the beancrew GitHub organization for the upcoming release.

## Changes

- **go.mod**: Updated module path
- **All .go files** (49 files): Updated import paths
- **Proto files** (3 files): Updated `go_package` options
- **Generated proto code**: Regenerated with new package path

## Verification

- `go build ./...` ✅
- `go vet ./...` ✅
- `go test ./...` ✅ (all pass including integration tests)